### PR TITLE
Allow to configure foreman connection parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,19 @@ Deploy `extras/foreman_callback.py` as a callback on your Ansible installation. 
 callback_plugins = ~/.ansible/plugins/callback_plugins/
 bin_ansible_callbacks = True
 ```
+And copy `extras/foreman_callback.py` from this repo to `~/.ansible/plugins/callback_plugins/`.
 
-And copy `extras/foreman_callback.py` from this repo to `~/.ansible/plugins/callback_plugins/`. That's it!
+You can configure it via the following environment variables:
+
+* FOREMAN_URL: the URL of your Foreman installatoin (default "http://localhost:3000")
+* FOREMAN_SSL_CERT: The public key when using SSL client certificates (default "/etc/foreman/client_cert.pem")
+* FOREMAN_SSL_KEY: The private key when using SSL client certificates (default  "/etc/foreman/client_key.pem")
+* FOREMAN_SSL_VERIFY: wether to verify SSL certificates. Use *False*
+  to disable certificate checks. You can also set it to CA bundle (default is "True").
+
+See the [python-requests documentation][] on the details of certificate setup.
+
+That's it!
 
 Now, every time you run a playbook or  `ansible -m setup $HOSTNAME`, Ansible will automatically submit facts and a small report for $HOSTNAME to Foreman. See 'Extra information' below if you find any error.
 
@@ -62,3 +73,6 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+[1]: http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification

--- a/extras/foreman_callback.py
+++ b/extras/foreman_callback.py
@@ -46,6 +46,7 @@ class CallbackModule(parent_class):
     Sends Ansible facts (if ansible -m setup ran) and reports
     """
     def __init__(self):
+        super(CallbackModule, self).__init__()
         self.items = defaultdict(list)
         self.start_time = int(time.time())
 
@@ -56,7 +57,6 @@ class CallbackModule(parent_class):
         if 'ansible_facts' in data:
             self.send_facts(host, data)
         self.send_report(host, data)
-
 
     def send_facts(self, host, data):
         """


### PR DESCRIPTION
following the examples of upstream ansible plugins.
    
    If we detect disabled SSL supress the urllib3 warning and print a more
    specific warning message via ansible instead. We dont' disable the
    urllib3 warning globally so should we ever fail to detect disabled SSL
    it stays in place.
