### PR TITLE
Add a check if 'invocation' key is present in and entry

### DIFF
--- a/extras/foreman_callback.py
+++ b/extras/foreman_callback.py
@@ -97,7 +97,10 @@ class CallbackModule(parent_class):
                 # v2 plugins have the task name
                 source, msg = entry
             else:
-                source = json.dumps(entry['invocation'])
+                if 'invocation' in entry:
+                    source = json.dumps(entry['invocation'])
+                else:
+                    source = json.dumps({"encrypted": "true"})                    
                 msg = entry
             if 'failed' in msg:
                 level = 'err'
@@ -153,7 +156,7 @@ class CallbackModule(parent_class):
         self.items[host].append(res)
 
     def runner_on_ok(self, host, res):
-        if res['invocation']['module_name'] == 'setup':
+        if 'invocation' in res and res['invocation']['module_name'] == 'setup':
             self.send_facts(host, res)
         else:
             self.items[host].append(res)


### PR DESCRIPTION
It's quite common that there are tasks with `no_log: True`. For instance tasks that load sensitive date are mostly with `no_log` enabled. When there is no log available `invocation` key is not present in `res` and `entry` objects.

This PR adds a safe check for this key.