### PR TITLE
Fix missing logger method name

### DIFF
--- a/lib/foreman_ansible/engine.rb
+++ b/lib/foreman_ansible/engine.rb
@@ -34,7 +34,7 @@ module ForemanAnsible
         ::HostsController.send(
           :include, ForemanAnsible::Concerns::HostsControllerExtensions)
       rescue => e
-        Rails.logger "Foreman Ansible: skipping engine hook (#{e})"
+        Rails.logger.warn "Foreman Ansible: skipping engine hook (#{e})"
       end
     end
   end


### PR DESCRIPTION
Causes `ArgumentError: wrong number of arguments (1 for 0)` otherwise.