### PR TITLE
Fixes #16147 - set index names explicitly

### DIFF
--- a/db/migrate/20160802153302_create_join_table_hostgroup_ansible_roles.rb
+++ b/db/migrate/20160802153302_create_join_table_hostgroup_ansible_roles.rb
@@ -1,10 +1,10 @@
 # Defines the relation between Hostgroup and AnsibleRole
+# rubocop:disable Metrics/LineLength
 class CreateJoinTableHostgroupAnsibleRoles < ActiveRecord::Migration
   def change
-    create_join_table :hostgroup, :ansible_roles,
-                      :table_name => 'hostgroup_ansible_roles' do |t|
-      t.index [:hostgroup_id, :ansible_role_id]
-      t.index [:ansible_role_id, :hostgroup_id]
+    create_join_table :hostgroup, :ansible_roles, :table_name => 'hostgroup_ansible_roles' do |t|
+      t.index [:hostgroup_id, :ansible_role_id], :name => 'index_ansible_roles_hostgroup_on_hostgroup_id_and_role_id'
+      t.index [:ansible_role_id, :hostgroup_id], :name => 'index_ansible_roles_hostgroup_on_role_id_and_hostgroup_id'
     end
   end
 end


### PR DESCRIPTION
To avoid limit on label size in Postgres

As part of the change, increasing the limit on lines size to 120,
80 it just too little.