### PR TITLE
Fixes #16413 - append to log_file

### DIFF
--- a/app/jobs/foreman_ansible/run_playbook_job.rb
+++ b/app/jobs/foreman_ansible/run_playbook_job.rb
@@ -14,8 +14,8 @@ module ForemanAnsible
 
     def perform(playbook_path, inventory_path)
       @pid = spawn("ansible-playbook -i #{inventory_path} #{playbook_path}",
-                   :out => log_file,
-                   :err => log_file)
+                   :out => [log_file, 'a'],
+                   :err => [log_file, 'a'])
     end
 
     private


### PR DESCRIPTION
By default spawn opens the log_file in write mode, this changes the
behaviour to instead append to the log.