### PR TITLE
Encode json payload to UTF-8 in send_facts()

### DIFF
--- a/extras/foreman_callback.py
+++ b/extras/foreman_callback.py
@@ -99,7 +99,7 @@ class CallbackModule(parent_class):
         facts_json = FACTS_FORMAT % dict(host=host, data=data)
 
         requests.post(url=FOREMAN_URL + '/api/v2/hosts/facts',
-                      data=facts_json,
+                      data=facts_json.encode('utf-8'),
                       headers=FOREMAN_HEADERS,
                       cert=FOREMAN_SSL_CERT,
                       verify=self.ssl_verify)


### PR DESCRIPTION
I've encountered the following error when using the Ansible callback plugin to upload facts:

`[WARNING]: Failure when attempting to use callback plugin (</home/foobar/.ansible/plugins/callback_plugins/foreman_callback.CallbackModule object at 0x7f32cd4c96d0>): buf must be a byte string`

The environment variables are configured as follows:
```
FOREMAN_URL=https://foreman.example.com
FOREMAN_SSL_CERT=foreman_client.crt
FOREMAN_SSL_KEY=foreman_client.key
FOREMAN_SSL_VERIFY=False
```
Encoding the JSON payload to UTF-8 fixed the issue and I was able to upload facts to Foreman. Maybe this has to be fixed on line 161 as well.

The PR definitely needs to be reviewed because I didn't had time to thoroughly test it.