### PR TITLE
Fixes #15976 - Add more info about Ansible roles

### DIFF
--- a/app/controllers/ansible_files_controller.rb
+++ b/app/controllers/ansible_files_controller.rb
@@ -1,0 +1,95 @@
+# UI controller for ansible files
+class AnsibleFilesController < ::ApplicationController
+  include Foreman::Controller::AutoCompleteSearch
+
+  before_action :find_resource, :only => [:edit, :update, :destroy]
+  before_action :initialize_file, :only => [:create]
+  before_action :create_importer, :only => [:edit, :update, :create, :destroy]
+
+  def index
+    @ansible_files = resource_base.search_for(params[:search], :order => params[:order]).paginate(:page => params[:page], :per_page => params[:per_page])
+  end
+
+  def edit
+    @importer.import(@ansible_file)
+    rescue_from_import_error
+  end
+
+  def new
+    @ansible_file = AnsibleFile.new(:ansible_role_id => params[:role_id])
+  end
+
+  def create
+    if @ansible_file.valid? && @importer.create_file(@ansible_file)
+      @ansible_file.save
+      process_success :object => @ansible_file
+    else
+      process_error :object => @ansible_file
+    end
+  rescue *import_exceptions => e
+    process_import_error e
+  end
+
+  def update
+    if @ansible_file.valid? && @importer.update_file(@ansible_file)
+      process_success :success_redirect => ansible_files_index_path(@ansible_file)
+    else
+      process_error :object => @ansible_file
+    end
+  rescue *import_exceptions => e
+    process_import_error e
+  end
+
+  def destroy
+    if @importer.delete_file(@ansible_file) && @ansible_file.destroy
+      process_success :object => @ansible_file
+    else
+      process_error :object => @ansible_file
+    end
+    rescue_from_import_error
+  end
+
+  private
+
+  def find_resource
+    super
+    @ansible_file.content = params[:ansible_file][:content] if params[:ansible_file]
+    @ansible_file
+  end
+
+  def initialize_file
+    @ansible_file = AnsibleFile.new(ansible_file_params)
+  end
+
+  def import_exceptions
+    [ProxyAPI::ProxyException, ForemanAnsibleExporter::Error]
+  end
+
+  def create_importer
+    proxy_id = @ansible_file.ansible_role.proxy_id
+    proxy = proxy_id && SmartProxy.find(proxy_id)
+    @importer = ForemanAnsible::FilesImporter.new(proxy)
+  end
+
+  def ansible_files_index_path(file)
+    ansible_files_path(:search => files_index(@ansible_file))
+  end
+
+  def rescue_from_import_error
+  rescue *import_exceptions => e
+    error(e.message)
+    redirect_to ansible_files_index_path(@ansible_file)
+  end
+
+  def process_import_error(exception)
+    process_error :error_msg => exception.message
+  end
+
+  def files_index(file)
+    "dir = #{file.dir} && ansible_role = #{file.ansible_role.name}"
+  end
+
+  def ansible_file_params
+    params.require(:ansible_file).permit(:name, :content, :ansible_role_id, :dir)
+  end
+end

--- a/app/helpers/foreman_ansible/ansible_files_helper.rb
+++ b/app/helpers/foreman_ansible/ansible_files_helper.rb
@@ -1,0 +1,16 @@
+module ForemanAnsible
+  # Helper methods for Ansible files
+  module AnsibleFilesHelper
+    def form_url(file)
+      file.new_record? ? hash_for_ansible_files_path : hash_for_ansible_file_path(:id => file.id)
+    end
+
+    def form_cancel_url(file)
+      file.new_record? ? hash_for_ansible_roles_path : hash_for_ansible_files_path(:search => files_for_role(file.ansible_role, file.dir))
+    end
+
+    def admissible_file_type(file)
+      AnsibleFile.where(:ansible_role_id => file.ansible_role_id).select('distinct dir').map(&:dir)
+    end
+  end
+end

--- a/app/helpers/foreman_ansible/ansible_roles_helper.rb
+++ b/app/helpers/foreman_ansible/ansible_roles_helper.rb
@@ -19,5 +19,18 @@ module ForemanAnsible
     def import_time(role)
       _('%s ago') % time_ago_in_words(role.updated_at)
     end
+
+    def files_for_role(role, dirname)
+      "ansible_role = #{role} && dir = #{dirname}"
+    end
+
+    def link_to_ansible_files(role, dirname)
+      link_to_if_authorized(role.file_count(dirname), hash_for_ansible_files_path(:search => files_for_role(role, dirname)))
+    end
+
+    def link_to_import_source(role)
+      return link_to_if_authorized(role.ansible_proxy.name, hash_for_smart_proxy_path(:id => role.proxy_id)) if role.ansible_proxy
+      _("Foreman host")
+    end
   end
 end

--- a/app/lib/proxy_api/ansible.rb
+++ b/app/lib/proxy_api/ansible.rb
@@ -24,5 +24,29 @@ module ProxyAPI
     rescue *PROXY_ERRORS => e
       raise ProxyException.new(url, e, N_('Unable to get roles from Ansible'))
     end
+
+    def file(role_name, dir, file_name)
+      parse(get "/file/#{role_name}/#{dir}/#{file_name}")
+    rescue => e
+      raise ProxyException.new(url, e, N_('Unable to get file.'))
+    end
+
+    def update_file(role_name, dir, file_name, content)
+      parse(post content, "/file/#{role_name}/#{dir}/#{file_name}")
+    rescue => e
+      raise ProxyException.new(url, e, N_('Unable to update file'))
+    end
+
+    def delete_file(role_name, dir, file_name)
+      parse(delete "/file/#{role_name}/#{dir}/#{file_name}")
+    rescue => e
+      raise ProxyException.new(url, e, N_('Unable to delete file'))
+    end
+
+    def create_file(role_name, dir, file_name, content)
+      parse(put content, "/file/#{role_name}/#{dir}/#{file_name}")
+    rescue => e
+      raise ProxyException.new(url, e, N_('Unable to delete file'))
+    end
   end
 end

--- a/app/models/ansible_file.rb
+++ b/app/models/ansible_file.rb
@@ -1,0 +1,21 @@
+# represents a basic file in Ansible Role
+class AnsibleFile < ActiveRecord::Base
+  DIRS = %w(defaults tasks vars meta templates handlers files)
+  validates :name, :presence => true, :uniqueness => { :scope => [:dir, :ansible_role] }
+  validates :dir, :presence => true, :inclusion => { :in => DIRS }
+
+  scoped_search :on => :name, :complete_value => true
+  scoped_search :on => :dir, :complete_value => true
+  scoped_search :in => :ansible_role, :on => :name, :complete_value => true, :rename => :ansible_role
+
+  belongs_to :ansible_role
+  attr_accessor :content
+
+  def yml?
+    name_ext == 'yml' || name_ext == 'yaml'
+  end
+
+  def name_ext
+    name.split('.').last
+  end
+end

--- a/app/models/ansible_role.rb
+++ b/app/models/ansible_role.rb
@@ -9,6 +9,12 @@ class AnsibleRole < ActiveRecord::Base
   has_many :hostgroup_ansible_roles
   has_many :hostgroups, :through => :hostgroup_ansible_roles,
                         :dependent => :destroy
+  has_many :ansible_files, :dependent => :destroy
+  belongs_to :ansible_proxy, :foreign_key => :proxy_id, :class_name => 'SmartProxy'
 
   scoped_search :on => :name, :complete_value => true
+
+  def file_count(dirname)
+    AnsibleFile.where(:dir => dirname, :ansible_role_id => id).count
+  end
 end

--- a/app/models/concerns/foreman_ansible/smart_proxy_extensions.rb
+++ b/app/models/concerns/foreman_ansible/smart_proxy_extensions.rb
@@ -1,0 +1,8 @@
+module ForemanAnsible
+  module SmartProxyExtensions
+    extend ActiveSupport::Concern
+    included do
+      has_many :ansible_roles
+    end
+  end
+end

--- a/app/models/foreman_ansible/ansible_file.rb
+++ b/app/models/foreman_ansible/ansible_file.rb
@@ -1,0 +1,21 @@
+class AnsibleFile < ActiveRecord::Base
+  DIRS = %w(defaults tasks vars meta templates handlers files)
+  validates :name, :presence => true, :uniqueness => { :scope => [:dir, :ansible_role] }
+  validates :dir, :presence => true, :inclusion => { :in => DIRS }
+
+  scoped_search :on => :name, :complete_value => true
+  scoped_search :on => :dir, :complete_value => true
+  scoped_search :in => :ansible_role, :on => :name, :complete_value => true, :rename => :ansible_role
+
+  belongs_to :ansible_role
+
+  attr_accessor :content
+
+  def yml?
+    name_ext == 'yml' || name_ext == 'yaml'
+  end
+
+  def name_ext
+    name.split('.').last
+  end
+end

--- a/app/services/foreman_ansible/ansible_importer.rb
+++ b/app/services/foreman_ansible/ansible_importer.rb
@@ -1,0 +1,16 @@
+module ForemanAnsible
+  # Base importer class
+  class AnsibleImporter
+    attr_reader :ansible_proxy, :source
+
+    def initialize(proxy = nil)
+      @ansible_proxy = proxy
+      @source = proxy.present? ? proxy_api : ForemanAnsibleExporter::FilesExporter.new('/etc/ansible/roles')
+    end
+
+    def proxy_api
+      raise ::Foreman::Exception.new(N_("Proxy must have Ansible feature")) unless ansible_proxy.has_feature? 'Ansible'
+      ::ProxyAPI::Ansible.new(:url => ansible_proxy.url)
+    end
+  end
+end

--- a/app/services/foreman_ansible/api_roles_importer.rb
+++ b/app/services/foreman_ansible/api_roles_importer.rb
@@ -2,13 +2,13 @@ module ForemanAnsible
   # imports Ansible roles through API
   class ApiRolesImporter < RolesImporter
     def import!
-      new_roles = import_role_names[:new]
+      new_roles = import_roles[:new]
       new_roles.map(&:save)
       new_roles
     end
 
     def obsolete!
-      obsolete_roles = import_role_names[:obsolete]
+      obsolete_roles = import_roles[:obsolete]
       obsolete_roles.map(&:destroy)
       obsolete_roles
     end

--- a/app/services/foreman_ansible/files_importer.rb
+++ b/app/services/foreman_ansible/files_importer.rb
@@ -1,0 +1,28 @@
+module ForemanAnsible
+  # imports content of Ansible roles
+  class FilesImporter < AnsibleImporter
+    attr_reader :roles_path, :source
+
+    def import(ansible_file)
+      file_content = source.file(*file_to_args(ansible_file))
+      ansible_file.content = file_content['content']
+      ansible_file
+    end
+
+    def update_file(ansible_file)
+      source.update_file(*file_to_args(ansible_file), ansible_file.content)
+    end
+
+    def delete_file(ansible_file)
+      source.delete_file(*file_to_args(ansible_file))
+    end
+
+    def create_file(ansible_file)
+      source.create_file(*file_to_args(ansible_file), ansible_file.content)
+    end
+
+    def file_to_args(ansible_file)
+      [ansible_file.ansible_role.name, ansible_file.dir, ansible_file.name]
+    end
+  end
+end

--- a/app/services/foreman_ansible/ui_roles_importer.rb
+++ b/app/services/foreman_ansible/ui_roles_importer.rb
@@ -2,7 +2,7 @@ module ForemanAnsible
   # imports ansible roles through UI
   class UiRolesImporter < RolesImporter
     def import!
-      import_role_names
+      import_roles
     end
 
     def finish_import(changes)
@@ -13,8 +13,16 @@ module ForemanAnsible
 
     def create_new_roles(changes)
       changes.values.each do |new_role|
-        ::AnsibleRole.create(JSON.parse(new_role))
+        role_hash = JSON.parse new_role
+        new_files = create_new_files role_hash.delete('ansible_files')
+        role = AnsibleRole.new(role_hash)
+        role.ansible_files = new_files
+        role.save
       end
+    end
+
+    def create_new_files(files_attrs)
+      files_attrs.map { |attrs| AnsibleFile.create attrs }
     end
 
     def delete_old_roles(changes)

--- a/app/views/ansible_files/_form.html.erb
+++ b/app/views/ansible_files/_form.html.erb
@@ -1,0 +1,29 @@
+<%= form_for @ansible_file, :url => form_url(@ansible_file), :html => { :multipart => true, :onsubmit => 'submit_code();' } do |f| %>
+  <%= base_errors_for @ansible_file %>
+  <div class="tab-content">
+      <div class='form-group'>
+        <div class="col-md-12">
+          <label class="control-label"  for="file"><%= _("File editor") %></label>
+          <% if @ansible_file.new_record? %>
+            <%= text_f f, :name %>
+            <%= f.hidden_field :ansible_role_id %>
+            <%= select_f f, :dir, admissible_file_type(@ansible_file), :to_s, :to_s, { :include_blank => true }, :label => _('Directory') %>
+          <% end %>
+
+          <div class="editor-container">
+            <%= render :partial => 'editor/toolbar', :locals => { :show_preview => false } %>
+
+            <%= textarea_f f, :content, :class => "editor_source", :label =>:none, :size => "max",
+                            :'data-file-name' => @ansible_file.name %>
+          </div>
+        </div>
+      </div>
+
+      <%= file_field_f f, :content, :class => "editor_file_source",:size => "col-md-10", :id => 'ansible_file_content',
+                       :help_block  => _("Selecting a file will override the editor and load the file instead") %>
+
+      <%= submit_or_cancel f, false, :cancel_path => form_cancel_url(@ansible_file) %>
+  </div>
+  <input type="hidden" id="old" value="<%= @ansible_file.content %>" />
+  <input type="hidden" id="new" value="<%= @ansible_file.content %>" />
+<% end %>

--- a/app/views/ansible_files/edit.html.erb
+++ b/app/views/ansible_files/edit.html.erb
@@ -1,0 +1,3 @@
+<% title _("Edit Ansible File") %>
+
+<%= render :partial => 'form' %>

--- a/app/views/ansible_files/index.html.erb
+++ b/app/views/ansible_files/index.html.erb
@@ -1,0 +1,28 @@
+<% title _("Ansible Files") %>
+
+<% title_actions  link_to(_("Back to Ansible Roles"), ansible_roles_path, :class => "btn btn-default") %>
+
+<table class="<%= table_css_classes 'table-fixed' %>">
+  <thead>
+    <tr>
+      <th class="col-md-3"><%= sort :name, :as => s_("File|Name") %></th>
+      <th class="col-md-1"><%= _("Actions") %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% for file in @ansible_files %>
+      <tr>
+        <td class="ellipsis"><%= link_to_if_authorized(file.name, hash_for_edit_ansible_file_path(:id => file.id)) %></td>
+        <td>
+          <%
+            links = [display_delete_if_authorized(hash_for_ansible_file_path(:id => file).merge(:auth_object => file, :authorizer => authorizer),
+                      :data => { :confirm => _("Delete %s?") % "#{file.dir}/#{file.name}" }, :action => :delete)]
+          %>
+          <%= action_buttons(*links) %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= will_paginate_with_info @ansible_files %>

--- a/app/views/ansible_files/new.html.erb
+++ b/app/views/ansible_files/new.html.erb
@@ -1,0 +1,3 @@
+<% title _("New File") %>
+
+<%= render :partial => 'form' %>

--- a/app/views/ansible_roles/import.html.erb
+++ b/app/views/ansible_roles/import.html.erb
@@ -29,7 +29,8 @@
         <% roles.each do |role| %>
           <tr>
             <td>
-              <%= check_box_tag "changed[#{kind}][#{role}]", role.to_json, false, :class => "role_select_boxes role_select_boxes_#{kind} role_select_boxes_role_#{role}" %>
+              <% role_json = role.new_record? ? role.to_json(:include => :ansible_files) : role.to_json %>
+              <%= check_box_tag "changed[#{kind}][#{role}]", role_json, false, :class => "role_select_boxes role_select_boxes_#{kind} role_select_boxes_role_#{role}" %>
             </td>
             <td>
               <%= link_to_function("#{role}", "toggleCheckboxesBySelector('.role_select_boxes_role_#{role}')", :title => _("Check/Uncheck all %s changes") % role) %>

--- a/app/views/ansible_roles/index.html.erb
+++ b/app/views/ansible_roles/index.html.erb
@@ -5,9 +5,17 @@
 <table class="<%= table_css_classes 'table-fixed' %>">
   <thead>
     <tr>
-      <th class="col-md-3"><%= sort :name, :as => s_("Role|Name") %></th>
-      <th class="col-md-3"><%= _("Imported at") %></th>
-      <th class="col-md-1"><%= _("Actions") %></th>
+       <th class="col-md-3"><%= sort :name, :as => s_("Role|Name") %></th>
+       <th class="col-md-2"><%= _("Imported at") %></th>
+       <th class="col-md-2"><%= _("Imported from") %></th>
+       <th class="col-md-1"><%= _("Tasks") %></th>
+       <th class="col-md-1"><%= _("Templates") %></th>
+       <th class="col-md-1"><%= _("Vars") %></th>
+       <th class="col-md-1"><%= _("Handlers") %></th>
+       <th class="col-md-1"><%= _("Defaults") %></th>
+       <th class="col-md-1"><%= _("Meta") %></th>
+       <th class="col-md-1"><%= _("Files") %></th>
+       <th class="col-md-1"><%= _("Actions") %></th>
     </tr>
   </thead>
   <tbody>
@@ -15,10 +23,19 @@
       <tr>
         <td class="ellipsis"><%= role.name %></td>
         <td class="ellipsis"><%= import_time role %></td>
+        <td class="ellipsis"><%= link_to_import_source role %></td>
+        <td><%= link_to_ansible_files role, "tasks" %></td>
+        <td><%= link_to_ansible_files role, "templates" %></td>
+        <td><%= link_to_ansible_files role, "vars" %></td>
+        <td><%= link_to_ansible_files role, "handlers" %></td>
+        <td><%= link_to_ansible_files role, "defaults" %></td>
+        <td><%= link_to_ansible_files role, "meta" %></td>
+        <td><%= link_to_ansible_files role, "files" %></td>
         <td>
           <%
             links = [display_delete_if_authorized(hash_for_ansible_role_path(:id => role).merge(:auth_object => role, :authorizer => authorizer),
-                      :data => { :confirm => _("Delete %s?") % role.name }, :action => :delete)]
+                      :data => { :confirm => _("Delete %s?") % role.name }, :action => :delete),
+                    link_to_if_authorized(_("New file"), hash_for_new_ansible_file_path(:role_id => role.id))]
           %>
           <%= action_buttons(*links) %>
         </td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,12 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :ansible_files, :only => [:index, :edit, :update, :destroy, :new, :create] do
+      collection do
+        get 'auto_complete_search'
+      end
+    end
+
     namespace :api do
       scope '(:apiv)',
             :module      => :v2,

--- a/db/migrate/20160801100217_create_role_files.rb
+++ b/db/migrate/20160801100217_create_role_files.rb
@@ -1,0 +1,16 @@
+class CreateRoleFiles < ActiveRecord::Migration
+  def up
+    create_table :ansible_files do |t|
+      t.string :name, :null => false, :limit => 255
+      t.string :dir, :null => false, :limit => 255
+      t.integer :ansible_role_id
+      t.datetime :created_at
+      t.datetime :updated_at
+    end
+    add_index :ansible_files, [:ansible_role_id, :name, :dir], :unique => true
+  end
+
+  def down
+    drop_table :ansible_files
+  end
+end

--- a/db/migrate/20160803101413_add_proxy_to_ansible_role.rb
+++ b/db/migrate/20160803101413_add_proxy_to_ansible_role.rb
@@ -1,0 +1,9 @@
+class AddProxyToAnsibleRole < ActiveRecord::Migration
+  def up
+    add_column :ansible_roles, :proxy_id, :integer
+  end
+
+  def down
+    remove_column :ansible_roles, :proxy_id
+  end
+end

--- a/lib/foreman_ansible/engine.rb
+++ b/lib/foreman_ansible/engine.rb
@@ -2,6 +2,7 @@ require 'deface'
 require 'fast_gettext'
 require 'gettext_i18n_rails'
 require 'foreman_ansible_core'
+require 'foreman_ansible_exporter'
 
 module ForemanAnsible
   # This engine connects ForemanAnsible with Foreman core
@@ -80,6 +81,7 @@ module ForemanAnsible
         ::Host::Managed.send(:include, ForemanAnsible::HostManagedExtensions)
         ::Hostgroup.send(:include, ForemanAnsible::HostgroupExtensions)
         ::HostsHelper.send(:include, ForemanAnsible::HostsHelperExtensions)
+        ::SmartProxy.send(:include, ForemanAnsible::SmartProxyExtensions)
         ::HostsController.send(
           :include, ForemanAnsible::Concerns::HostsControllerExtensions
         )

--- a/lib/foreman_ansible/update_roles.rb
+++ b/lib/foreman_ansible/update_roles.rb
@@ -1,0 +1,41 @@
+module ForemanAnsible
+  class UpdateRoles
+    attr_reader :proxy, :source
+
+    def initialize(proxy_id)
+      @proxy = ::SmartProxy.find proxy_id if proxy_id
+    end
+
+    def has_available_proxy?
+      return true unless proxy
+      return false unless proxy.has_feature? 'Ansible'
+      return false unless proxy_reachable?
+      true
+    end
+
+    def run
+      roles_importer = RolesImporter.new
+      imported = source.roles
+      imported.each do |role_name, folders|
+        role = ::AnsibleRole.find_by :name => role_name
+        next unless role
+        roles_importer.process_files(role, folders)
+        role.ansible_proxy = proxy
+        role.save
+      end
+    end
+
+    private
+
+    def source
+      @source ||= proxy ? ::ProxyAPI::Ansible.new(proxy.url) : ForemanAnsibleExporter::RolesExporter.new('/etc/ansible/roles')
+    end
+
+    def proxy_reachable?
+      api = ::ProxyAPI::Features.new proxy.url
+      api.features
+    rescue ProxyException
+      false
+    end
+  end
+end

--- a/lib/tasks/foreman_ansible_tasks.rake
+++ b/lib/tasks/foreman_ansible_tasks.rake
@@ -25,6 +25,15 @@ namespace :foreman_ansible do
 
     Rake::Task['rubocop_foreman_ansible'].invoke
   end
+
+  task :update_roles, [:proxy] => [:environment] do |task, args|
+    require 'foreman_ansible/update_roles'
+    puts 'Updating Ansible Roles, from #{args[:proxy] ? args[:proxy] : Foreman host} please wait...'
+    migration = ForemanAnsible::UpdateRoles.new(args[:proxy])
+    abort('Foreman and proxy with Ansible feature should be up for this migration') unless migration.has_available_proxy?
+    migration.run
+    puts 'Migration successfully finished.'
+  end
 end
 
 Rake::Task[:test].enhance ['test:foreman_ansible']


### PR DESCRIPTION
This extracts the common code for retrieving roles into a separate gem (foreman_ansible_exporter)
that can be used by both Foreman and Smart Proxy. It also exposes more details about the imported roles.

foreman_ansible_exporter will be listed as a dependency in gemspec once released, for now I just run from [source](https://github.com/xprazak2/foreman_ansible_exporter) and drop `gemspec :path => path/to/foreman_ansible_exporter` into my Gemfile.local.rb in core's bundler.d.

I realize this may not be entirely the way we want to go for a couple of reasons, but anyway. Let me know what you think. If we decide this is a way to go, I will gladly add tests and corresponding changes to `smart_proxy_ansible`