### PR TITLE
Fixes #17397 - Use StructuredFactImporter on 1.13+

### DIFF
--- a/app/services/foreman_ansible/fact_importer.rb
+++ b/app/services/foreman_ansible/fact_importer.rb
@@ -2,6 +2,8 @@ module ForemanAnsible
   # Override methods from Foreman app/services/fact_importer so that Ansible
   # facts are recognized in Foreman as ForemanAnsible facts. It supports
   # nested facts.
+  #
+  # Only relevant for 1.12 and lower versions
   class FactImporter < ::FactImporter
     def fact_name_class
       ForemanAnsible::FactName

--- a/app/services/foreman_ansible/structured_fact_importer.rb
+++ b/app/services/foreman_ansible/structured_fact_importer.rb
@@ -1,0 +1,15 @@
+module ForemanAnsible
+  # On 1.13+ , use the parser for structured facts (like Facter 2) that comes
+  # from core
+  class StructuredFactImporter < ::StructuredFactImporter
+    def fact_name_class
+      ForemanAnsible::FactName
+    end
+
+    def initialize(host, facts = {})
+      @host = host
+      @facts = normalize(facts[:ansible_facts])
+      @counters = {}
+    end
+  end
+end

--- a/lib/foreman_ansible/engine.rb
+++ b/lib/foreman_ansible/engine.rb
@@ -57,7 +57,8 @@ module ForemanAnsible
              :parent => :configure_menu
 
         apipie_documented_controllers [
-          "#{ForemanAnsible::Engine.root}/app/controllers/api/v2/*.rb"]
+          "#{ForemanAnsible::Engine.root}/app/controllers/api/v2/*.rb"
+        ]
       end
     end
 
@@ -83,8 +84,17 @@ module ForemanAnsible
 
     config.to_prepare do
       begin
-        ::FactImporter.register_fact_importer(:ansible,
-                                              ForemanAnsible::FactImporter)
+        foreman_version = ::Foreman::Version.new
+        if Rails.env.test? ||
+           foreman_version.major.to_i == 1 && foreman_version.minor.to_i < 13
+          ::FactImporter.register_fact_importer(:ansible,
+                                                ForemanAnsible::FactImporter)
+        else
+          ::FactImporter.register_fact_importer(
+            :ansible,
+            ForemanAnsible::StructuredFactImporter
+          )
+        end
         ::FactParser.register_fact_parser(:ansible, ForemanAnsible::FactParser)
         ::Host::Managed.send(:include, ForemanAnsible::HostManagedExtensions)
         ::Hostgroup.send(:include, ForemanAnsible::HostgroupExtensions)


### PR DESCRIPTION
foreman-ansible provided its own parser for parsing structured facts.
However this is not needed on 1.13+ versions, as the Facter 2+ parser in
core is able to parse Ansible facts just fine, even better in some
cases.