### PR TITLE
Fixes #17150 - Allow setting some ansible connection parameters

### DIFF
--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -1,0 +1,18 @@
+class Setting::Ansible < ::Setting
+  def self.load_defaults
+    return unless super
+    self.transaction do
+      [
+        self.set('ansible_port', N_('Foreman will use this port to ssh into hosts for running playbooks'), 22, N_('Default port')),
+        self.set('ansible_user', N_('Foreman will try to connect as this user to hosts when running Ansible playbooks.'), 'root', N_('Default user')),
+        self.set('ansible_ssh_pass', N_('Foreman will use this password when running Ansible playbooks.'), 'ansible', N_('Default password'))
+      ].compact.each { |s| self.create s.update(:category => 'Setting::Ansible') }
+    end
+
+    true
+  end
+
+  def self.humanized_category
+    N_('Ansible')
+  end
+end

--- a/lib/foreman_ansible/engine.rb
+++ b/lib/foreman_ansible/engine.rb
@@ -16,6 +16,12 @@ module ForemanAnsible
     config.autoload_paths += Dir["#{config.root}/app/views"]
     config.autoload_paths += Dir["#{config.root}/app/lib"]
 
+    initializer 'foreman_ansible.load_default_settings',
+                :before => :load_config_initializers do
+      require_dependency(File.join(ForemanAnsible::Engine.root,
+                                   'app/models/setting/ansible.rb'))
+    end
+
     initializer 'foreman_ansible.register_gettext',
                 :after => :load_config_initializers do
       locale_dir = File.join(File.expand_path('../../..', __FILE__), 'locale')


### PR DESCRIPTION
This currently allows setting the ansible_user, ansible_port and
ansible_ssh_pass for all hosts. There is a default setting which can
also be overriden by using host or hostgroup parameters with the same
name.