### PR TITLE
Fixes #17536 - Return user-friendly message when working_dir not set

### DIFF
--- a/lib/foreman_ansible/engine.rb
+++ b/lib/foreman_ansible/engine.rb
@@ -46,9 +46,9 @@ module ForemanAnsible
                      :resource_type => 'AnsibleRole'
         end
 
-        role "Ansible Roles Manager",
-          [:play_roles, :view_ansible_roles, :destroy_ansible_roles,
-           :import_ansible_roles]
+        role 'Ansible Roles Manager',
+             [:play_roles, :view_ansible_roles, :destroy_ansible_roles,
+              :import_ansible_roles]
 
         role_assignment_params = { :ansible_role_ids => [],
                                    :ansible_roles => [] }

--- a/lib/foreman_ansible_core/playbook_runner.rb
+++ b/lib/foreman_ansible_core/playbook_runner.rb
@@ -78,16 +78,16 @@ module ForemanAnsibleCore
     end
 
     def initialize_working_dir(working_dir)
-      if working_dir.present?
-        @working_dir = File.expand_path(working_dir)
-      else
+      if working_dir.nil?
         @working_dir = Dir.mktmpdir
         @tmp_working_dir = true
+      else
+        @working_dir = File.expand_path(working_dir)
       end
     end
 
     def initialize_ansible_dir(ansible_dir)
-      if File.exist?(ansible_dir)
+      if !ansible_dir.nil? && File.exist?(ansible_dir)
         @ansible_dir = ansible_dir
       else
         raise "Ansible dir #{ansible_dir} does not exist"


### PR DESCRIPTION
Currently if the user is lacking the 'ansible_working_dir' key in their
proxy settings, the task output will not be very helpful when the user
tries to debug what happened. It'll just say `no method error .present?
called on nil' or similar. Instead, the AnsibleCore playbook runner
needs to be aware of this situation and provide a friendlier error
message.