### PR TITLE
fixes #17558 Add support to import junos facts in Foreman.

### DIFF
--- a/app/services/foreman_ansible/fact_importer.rb
+++ b/app/services/foreman_ansible/fact_importer.rb
@@ -12,7 +12,8 @@ module ForemanAnsible
     def initialize(host, facts = {})
       # Try to assign these facts to the correct host as per the facts say
       # If that host isn't created yet, the host parameter will contain it
-      @host = Host.find_by(:name => facts[:ansible_facts][:ansible_fqdn]) ||
+      @host = Host.find_by(:name => facts[:ansible_facts][:ansible_fqdn] ||
+                                    facts[:ansible_facts][:fqdn]) ||
               host
       @facts = normalize(facts[:ansible_facts])
       @original_facts = FactSparser.unsparse(facts[:ansible_facts])

--- a/app/services/foreman_ansible/fact_parser.rb
+++ b/app/services/foreman_ansible/fact_parser.rb
@@ -28,7 +28,8 @@ module ForemanAnsible
     end
 
     def domain
-      name = detect_fact([:ansible_domain, :facter_domain, :ohai_domain, :domain])
+      name = detect_fact([:ansible_domain, :facter_domain,
+                          :ohai_domain, :domain])
       Domain.where(:name => name).first_or_create unless name.blank?
     end
 
@@ -75,7 +76,7 @@ module ForemanAnsible
 
     def os_major
       facts[:ansible_distribution_major_version] ||
-        facts[:ansible_lsb] && facts[:ansible_lsb]['major_release'] || 
+        facts[:ansible_lsb] && facts[:ansible_lsb]['major_release'] ||
         (facts[:version].split('R')[0] if os_name == 'junos')
     end
 

--- a/app/services/foreman_ansible/fact_parser.rb
+++ b/app/services/foreman_ansible/fact_parser.rb
@@ -23,12 +23,12 @@ module ForemanAnsible
 
     def model
       name = detect_fact([:ansible_product_name, :facter_virtual,
-                          :facter_productname, :facter_model])
+                          :facter_productname, :facter_model, :model])
       Model.where(:name => name.strip).first_or_create unless name.blank?
     end
 
     def domain
-      name = detect_fact([:ansible_domain, :facter_domain, :ohai_domain])
+      name = detect_fact([:ansible_domain, :facter_domain, :ohai_domain, :domain])
       Domain.where(:name => name).first_or_create unless name.blank?
     end
 
@@ -48,7 +48,7 @@ module ForemanAnsible
       if pref.present?
         (facts[:ansible_interfaces] - [pref]).unshift(pref)
       else
-        facts[:ansible_interfaces].sort
+        (facts[:ansible_interfaces].sort unless facts[:ansible_interfaces].nil?) || []
       end
     end
 
@@ -75,7 +75,8 @@ module ForemanAnsible
 
     def os_major
       facts[:ansible_distribution_major_version] ||
-        facts[:ansible_lsb] && facts[:ansible_lsb]['major_release']
+        facts[:ansible_lsb] && facts[:ansible_lsb]['major_release'] || 
+        (facts[:version].split('R')[0] if os_name == 'junos')
     end
 
     def os_release
@@ -84,7 +85,8 @@ module ForemanAnsible
     end
 
     def os_minor
-      _, minor = os_release.split('.')
+      _, minor = (os_release.split('.') unless os_release.nil?) ||
+                 (facts[:version].split('R') if os_name == 'junos')
       minor || ''
     end
 

--- a/app/services/foreman_ansible/structured_fact_importer.rb
+++ b/app/services/foreman_ansible/structured_fact_importer.rb
@@ -9,7 +9,8 @@ module ForemanAnsible
     def initialize(host, facts = {})
       # Try to assign these facts to the correct host as per the facts say
       # If that host isn't created yet, the host parameter will contain it
-      @host = Host.find_by(:name => facts[:ansible_facts][:ansible_fqdn]) ||
+      @host = Host.find_by(:name => facts[:ansible_facts][:ansible_fqdn] ||
+                                    facts[:ansible_facts][:fqdn]) ||
               host
       @facts = normalize(facts[:ansible_facts])
       @counters = {}


### PR DESCRIPTION
Import junos facts into Foreman received from device by running
'junos_facts' or 'junos_get_facts' Ansible module.

As Ansible junos facts does not include ip address related
information it is not shown in Foreman.