### PR TITLE
Fixes #17702 - Make ansible run cancelable

### DIFF
--- a/lib/foreman_ansible_core/playbook_runner.rb
+++ b/lib/foreman_ansible_core/playbook_runner.rb
@@ -29,6 +29,13 @@ module ForemanAnsibleCore
       command
     end
 
+    def kill
+      publish_data('== TASK ABORTED BY USER ==', 'stdout')
+      publish_exit_status(1)
+      ::Process.kill('SIGTERM', @command_pid)
+      close
+    end
+
     def close
       super
       FileUtils.remove_entry(@working_dir) if @tmp_working_dir


### PR DESCRIPTION
Make ansible task cancelable by killing the ansible process. 