### PR TITLE
fixes #17701 - Ansible Button on Host page emits two ansible tasks

### DIFF
--- a/app/helpers/foreman_ansible/hosts_helper_extensions.rb
+++ b/app/helpers/foreman_ansible/hosts_helper_extensions.rb
@@ -13,7 +13,8 @@ module ForemanAnsible
         icon_text('play', ' ' + _('Ansible roles'), :kind => 'fa'),
         play_roles_host_path(:id => args.first.id),
         :id => :ansible_roles_button,
-        :class => 'btn btn-default'
+        :class => 'btn btn-default',
+        :method => :post
       )
       title_actions(button_group(button)) if args.first.ansible_roles.present?
       host_title_actions_without_run_ansible_roles(*args)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
     constraints(:id => %r{[^\/]+}) do
       resources :hosts, :only => [] do
         member do
-          get :play_roles
+          post :play_roles
         end
         collection do
           get :multiple_play_roles


### PR DESCRIPTION
Steps to reproduce:
1. Apply role on a single host "myhost"
2. got to host page: https://katello/hosts/myhost.mydomain
3. Click "|> Ansible roles"
4. Goto Tasks view (https://katello/foreman_tasks/tasks)
5. Notice that two task are emitted (Name: Play Ansible roles on host /myhost.mydomain)

I used a chrome browser

This issue gave has particular headache since the visible ansible run was failing with all kind of weird issues caused by the second (hidden) ansible run.

