### PR TITLE
Fixes #17700 - Allow to configure connection type and winrm cert validation via host variables

### DIFF
--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -5,7 +5,9 @@ class Setting::Ansible < ::Setting
       [
         self.set('ansible_port', N_('Foreman will use this port to ssh into hosts for running playbooks'), 22, N_('Default port')),
         self.set('ansible_user', N_('Foreman will try to connect as this user to hosts when running Ansible playbooks.'), 'root', N_('Default user')),
-        self.set('ansible_ssh_pass', N_('Foreman will use this password when running Ansible playbooks.'), 'ansible', N_('Default password'))
+        self.set('ansible_ssh_pass', N_('Foreman will use this password when running Ansible playbooks.'), 'ansible', N_('Default password')),
+        self.set('ansible_connection', N_('Foreman will use configured connection type when running Ansible playbooks.'), 'ssh', N_('Default Connection Type')),
+        self.set('ansible_winrm_server_cert_validation', N_('Foreman will enable/disable WinRM server certificate validation when running Ansible playbooks.'), 'validate', N_('Default WinRM Cert Validation'))
       ].compact.each { |s| self.create s.update(:category => 'Setting::Ansible') }
     end
 

--- a/app/services/foreman_ansible/inventory_creator.rb
+++ b/app/services/foreman_ansible/inventory_creator.rb
@@ -38,13 +38,23 @@ module ForemanAnsible
       params = {
         'ansible_port' => host_port(host),
         'ansible_user' => host_user(host),
-        'ansible_ssh_pass' => host_ssh_pass(host)
+        'ansible_ssh_pass' => host_ssh_pass(host),
+        'ansible_connection' => connection_type(host),
+        'ansible_winrm_server_cert_validation' => winrm_cert_validation(host)
       }
-
-      #Backward compatibility for Ansible 1.x
+      # Backward compatibility for Ansible 1.x
       params['ansible_ssh_port'] = params['ansible_port']
       params['ansible_ssh_user'] = params['ansible_user']
       params
+    end
+
+    def winrm_cert_validation(host)
+      host.host_params['ansible_winrm_server_cert_validation'] ||
+        Setting['ansible_winrm_server_cert_validation']
+    end
+
+    def connection_type(host)
+      host.host_params['ansible_connection'] || Setting['ansible_connection']
     end
 
     def host_roles(host)
@@ -68,7 +78,7 @@ module ForemanAnsible
     end
 
     def host_ssh_pass(host)
-      host.host_params['ansible_ssh_port'] || Setting[:ansible_ssh_pass]
+      host.host_params['ansible_ssh_pass'] || Setting[:ansible_ssh_pass]
     end
 
     private


### PR DESCRIPTION
Allow to configure connection type and winrm cert validation via host variables

