### PR TITLE
Fixes #18108 - Verbosity level for Ansible runs

### DIFF
--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -7,7 +7,8 @@ class Setting::Ansible < ::Setting
         self.set('ansible_user', N_('Foreman will try to connect as this user to hosts when running Ansible playbooks.'), 'root', N_('Default user')),
         self.set('ansible_ssh_pass', N_('Foreman will use this password when running Ansible playbooks.'), 'ansible', N_('Default password')),
         self.set('ansible_connection', N_('Foreman will use configured connection type when running Ansible playbooks.'), 'ssh', N_('Default Connection Type')),
-        self.set('ansible_winrm_server_cert_validation', N_('Foreman will enable/disable WinRM server certificate validation when running Ansible playbooks.'), 'validate', N_('Default WinRM Cert Validation'))
+        self.set('ansible_winrm_server_cert_validation', N_('Foreman will enable/disable WinRM server certificate validation when running Ansible playbooks.'), 'validate', N_('Default WinRM Cert Validation')),
+        self.set('ansible_verbosity', N_('Foreman will add the this level of verbosity for additional debugging output when running Ansible playbooks.'), '0', N_('Default verbosity level'))
       ].compact.each { |s| self.create s.update(:category => 'Setting::Ansible') }
     end
 

--- a/lib/foreman_ansible_core/playbook_runner.rb
+++ b/lib/foreman_ansible_core/playbook_runner.rb
@@ -26,6 +26,7 @@ module ForemanAnsibleCore
       command << 'ansible-playbook'
       command.concat(['-i', json_inventory_script])
       command << playbook_file
+      append_verbosity(command)
       command
     end
 
@@ -99,6 +100,18 @@ module ForemanAnsibleCore
       else
         raise "Ansible dir #{ansible_dir} does not exist"
       end
+    end
+
+    def append_verbosity(command)
+      verbosity_level = Setting['ansible_verbosity'].to_i
+      if verbosity_level > 0
+        verbosity = '-'
+        verbosity_level.times do
+          verbosity += 'v'
+        end
+        command << verbosity
+      end
+      command
     end
   end
 end


### PR DESCRIPTION
In issue https://github.com/theforeman/foreman_ansible/issues/68, a setting for the level of verbosity for Ansible is proposed. I think this feature can be very useful as it helps a lot with debugging Ansible from within Foreman.