### PR TITLE
Fixes #18114 - Display proxy information in task

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
   Exclude:
     - 'extras/**/*'
     - 'locale/**/*'
+    - 'test/**/*'
 
 # Just so it looks like core Foreman
 Style/HashSyntax:

--- a/app/controllers/api/v2/ansible_roles_controller.rb
+++ b/app/controllers/api/v2/ansible_roles_controller.rb
@@ -10,8 +10,7 @@ module Api
 
       api :GET, '/ansible/ansible_roles/:id', N_('Show role')
       param :id, :identifier, :required => true
-      def show
-      end
+      def show; end
 
       api :GET, '/ansible/ansible_roles', N_('List Ansible roles')
       param_group :search_and_pagination, ::Api::V2::BaseController

--- a/app/controllers/foreman_ansible/api/v2/hostgroups_controller_extensions.rb
+++ b/app/controllers/foreman_ansible/api/v2/hostgroups_controller_extensions.rb
@@ -6,8 +6,12 @@ module ForemanAnsible
         extend ActiveSupport::Concern
         include ForemanTasks::Triggers
 
+        # Included blocks shouldn't be bound by length, as otherwise concerns
+        # cannot extend the method properly.
+        # rubocop:disable BlockLength
         included do
-          api :POST, '/hostgroups/play_roles', N_('Plays Ansible roles on hostgroups')
+          api :POST, '/hostgroups/play_roles',
+              N_('Plays Ansible roles on hostgroups')
           param :id, Array, :required => true
 
           def play_roles
@@ -22,7 +26,8 @@ module ForemanAnsible
             render_message @result
           end
 
-          api :POST, '/hostgroups/play_roles', N_('Plays Ansible roles on hostgroups')
+          api :POST, '/hostgroups/play_roles',
+              N_('Plays Ansible roles on hostgroups')
           param :id, Array, :required => true
 
           def multiple_play_roles
@@ -43,8 +48,6 @@ module ForemanAnsible
         end
 
         private
-
-        # TODO: A better implementation of find_multiple should be available in hostgroups_controller
 
         def find_multiple
           hostgroup_ids = params.fetch(:hostgroup_ids, [])

--- a/app/controllers/foreman_ansible/api/v2/hosts_controller_extensions.rb
+++ b/app/controllers/foreman_ansible/api/v2/hosts_controller_extensions.rb
@@ -24,7 +24,6 @@ module ForemanAnsible
           param :id, Array, :required => true
 
           def multiple_play_roles
-            # TODO: How to prevent that find_resource is triggered by hosts_controller?
             @result = []
 
             @host.each do |item|

--- a/app/controllers/foreman_ansible/concerns/hostgroups_controller_extensions.rb
+++ b/app/controllers/foreman_ansible/concerns/hostgroups_controller_extensions.rb
@@ -7,7 +7,10 @@ module ForemanAnsible
 
       def play_roles
         find_resource
-        task = async_task(::Actions::ForemanAnsible::PlayHostgroupRoles, @hostgroup)
+        task = async_task(
+          ::Actions::ForemanAnsible::PlayHostgroupRoles,
+          @hostgroup
+        )
         redirect_to task
       rescue Foreman::Exception => e
         error e.message

--- a/app/helpers/foreman_ansible/hosts_helper_extensions.rb
+++ b/app/helpers/foreman_ansible/hosts_helper_extensions.rb
@@ -8,16 +8,25 @@ module ForemanAnsible
       alias_method_chain(:multiple_actions, :run_ansible_roles)
     end
 
+    def ansible_roles_present?(host)
+      host.ansible_roles.present? ||
+        host.inherited_ansible_roles.present?
+    end
+
+    def ansible_roles_button(host)
+      link_to(
+        icon_text('play', ' ' + _('Ansible roles'), :kind => 'fa'),
+        play_roles_host_path(:id => host.id),
+        :id => :ansible_roles_button,
+        :class => 'btn btn-default',
+        :'data-no-turbolink' => true
+      )
+    end
+
     def host_title_actions_with_run_ansible_roles(*args)
-      if args.first.ansible_roles.present? ||
-         args.first.inherited_ansible_roles.present?
-        button = link_to(
-          icon_text('play', ' ' + _('Ansible roles'), :kind => 'fa'),
-          play_roles_host_path(:id => args.first.id),
-          :id => :ansible_roles_button,
-          :class => 'btn btn-default',
-          :'data-no-turbolink' => true
-        )
+      host = args.first
+      if ansible_roles_present?(host)
+        button = ansible_roles_button(host)
         title_actions(button_group(button))
       end
       host_title_actions_without_run_ansible_roles(*args)

--- a/app/lib/actions/foreman_ansible/helpers/host_common.rb
+++ b/app/lib/actions/foreman_ansible/helpers/host_common.rb
@@ -1,0 +1,37 @@
+module Actions
+  module ForemanAnsible
+    module Helpers
+      # Shared task methods between hostgroup and host roles actions
+      module HostCommon
+        def finalize
+          return unless delegated_output[:exit_status].to_s != '0'
+          error! _('Playbook execution failed')
+        end
+
+        def rescue_strategy
+          ::Dynflow::Action::Rescue::Fail
+        end
+
+        def humanized_name
+          _('Play Ansible roles')
+        end
+
+        def humanized_output
+          continuous_output.humanize
+        end
+
+        def continuous_output_providers
+          super << self
+        end
+
+        def fill_continuous_output(continuous_output)
+          delegated_output.fetch('result', []).each do |raw_output|
+            continuous_output.add_raw_output(raw_output)
+          end
+        rescue => e
+          continuous_output.add_exception(_('Error loading data from proxy'), e)
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/foreman_ansible/helpers/play_roles_description.rb
+++ b/app/lib/actions/foreman_ansible/helpers/play_roles_description.rb
@@ -1,0 +1,18 @@
+module Actions
+  module ForemanAnsible
+    module Helpers
+      # Returns the name of the proxy running the specified action, or Foreman
+      # if it's the one running the action instead.
+      module PlayRolesDescription
+        def running_proxy_name
+          proxy = input.fetch(:host, {})[:proxy_used]
+          if [:not_defined, 'Foreman'].include? proxy
+            _('Foreman')
+          else
+            proxy
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/foreman_ansible/play_host_roles.rb
+++ b/app/lib/actions/foreman_ansible/play_host_roles.rb
@@ -5,51 +5,36 @@ module Actions
     class PlayHostRoles < Actions::EntryAction
       include ::Actions::Helpers::WithContinuousOutput
       include ::Actions::Helpers::WithDelegatedAction
+      include Helpers::PlayRolesDescription
+      include Helpers::HostCommon
 
       def plan(host, proxy_selector = ::ForemanAnsible::ProxySelector.new)
-        input[:host] = { :id => host.id, :name => host.fqdn }
-        proxy = proxy_selector.determine_proxy(host)
+        proxy = find_host_and_proxy(host, proxy_selector)
         inventory_creator = ::ForemanAnsible::InventoryCreator.new([host])
         role_names = host.all_ansible_roles.map(&:name)
         playbook_creator = ::ForemanAnsible::PlaybookCreator.new(role_names)
-        plan_delegated_action(proxy, ::ForemanAnsibleCore::Actions::RunPlaybook,
+        plan_delegated_action(proxy,
+                              ::ForemanAnsibleCore::Actions::RunPlaybook,
                               :inventory => inventory_creator.to_hash.to_json,
                               :playbook => playbook_creator.roles_playbook)
         plan_self
       end
 
-      def finalize
-        if delegated_output[:exit_status].to_s != '0'
-          error! _('Playbook execution failed')
-        end
-      end
-
-      def rescue_strategy
-        ::Dynflow::Action::Rescue::Fail
-      end
-
       def humanized_input
-        _('on host %{name}') % { :name => input.fetch(:host, {})[:name] }
+        _('on host %{name} through %{proxy}') % {
+          :name => input.fetch(:host, {})[:name],
+          :proxy => running_proxy_name
+        }
       end
 
-      def humanized_name
-        _('Play Ansible roles')
-      end
+      private
 
-      def humanized_output
-        continuous_output.humanize
-      end
-
-      def continuous_output_providers
-        super << self
-      end
-
-      def fill_continuous_output(continuous_output)
-        delegated_output.fetch('result', []).each do |raw_output|
-          continuous_output.add_raw_output(raw_output)
-        end
-      rescue => e
-        continuous_output.add_exception(_('Error loading data from proxy'), e)
+      def find_host_and_proxy(host, proxy_selector)
+        proxy = proxy_selector.determine_proxy(host)
+        input[:host] = { :id => host.id,
+                         :name => host.fqdn,
+                         :proxy_used => proxy.try(:name) || :not_defined }
+        proxy
       end
     end
   end

--- a/app/lib/actions/foreman_ansible/play_hostgroup_roles.rb
+++ b/app/lib/actions/foreman_ansible/play_hostgroup_roles.rb
@@ -5,60 +5,51 @@ module Actions
     class PlayHostgroupRoles < Actions::EntryAction
       include ::Actions::Helpers::WithContinuousOutput
       include ::Actions::Helpers::WithDelegatedAction
+      include Helpers::PlayRolesDescription
+      include Helpers::HostCommon
 
       def plan(hostgroup, proxy_selector = ::ForemanAnsible::ProxySelector.new)
-        if hostgroup.hosts.empty?
-          raise ::Foreman::Exception.new(N_('host group is empty'))
-        end
-        input[:hostgroup] = { :id => hostgroup.id, :name => hostgroup.name }
-        proxy = proxy_selector.determine_proxy(hostgroup.hosts[0])
-        inventory_creator = ::ForemanAnsible::InventoryCreator.new(hostgroup.hosts)
+        proxy = find_hostgroup_and_proxy(hostgroup, proxy_selector)
+        inventory_creator = ::ForemanAnsible::
+          InventoryCreator.new(hostgroup.hosts)
+        playbook_creator = ::ForemanAnsible::
+          PlaybookCreator.new(hostgroup_ansible_roles(hostgroup))
+        plan_delegated_action(proxy,
+                              ::ForemanAnsibleCore::Actions::RunPlaybook,
+                              :inventory => inventory_creator.to_hash.to_json,
+                              :playbook => playbook_creator.roles_playbook)
+        plan_self
+      end
+
+      def humanized_input
+        _('on host group %{name} through proxy %{proxy}') % {
+          :name => input.fetch(:hostgroup, {})[:name],
+          :proxy => running_proxy_name
+        }
+      end
+
+      private
+
+      def hostgroup_ansible_roles(hostgroup)
         role_names = []
         hostgroup.hostgroup_ansible_roles.each do |ansible_role|
           role_names.append(ansible_role.ansible_role_name)
         end
-        playbook_creator = ::ForemanAnsible::PlaybookCreator.new(role_names)
-        plan_delegated_action(
-          proxy,
-          ::ForemanAnsibleCore::Actions::RunPlaybook,
-          :inventory => inventory_creator.to_hash.to_json,
-          :playbook => playbook_creator.roles_playbook
-        )
-        plan_self
+        role_names
       end
 
-      def finalize
-        return unless delegated_output[:exit_status].to_s != '0'
-        error! _('Playbook execution failed')
+      def hostgroup_contains_hosts(hostgroup)
+        return unless hostgroup.hosts.empty?
+        raise ::Foreman::Exception.new(N_('host group is empty'))
       end
 
-      def rescue_strategy
-        ::Dynflow::Action::Rescue::Fail
-      end
-
-      def humanized_input
-        _('on host group %{name}') %
-          { :name => input.fetch(:hostgroup, {})[:name] }
-      end
-
-      def humanized_name
-        _('Play Ansible roles')
-      end
-
-      def humanized_output
-        continuous_output.humanize
-      end
-
-      def continuous_output_providers
-        super << self
-      end
-
-      def fill_continuous_output(continuous_output)
-        delegated_output.fetch('result', []).each do |raw_output|
-          continuous_output.add_raw_output(raw_output)
-        end
-      rescue => e
-        continuous_output.add_exception(_('Error loading data from proxy'), e)
+      def find_hostgroup_and_proxy(hostgroup, proxy_selector)
+        hostgroup_contains_hosts(hostgroup)
+        proxy = proxy_selector.determine_proxy(hostgroup.hosts[0])
+        input[:hostgroup] = { :id => hostgroup.id,
+                              :name => hostgroup.name,
+                              :proxy_used => proxy.try(:name) || :not_defined }
+        proxy
       end
     end
   end

--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -1,21 +1,76 @@
-class Setting::Ansible < ::Setting
-  def self.load_defaults
-    return unless super
-    self.transaction do
-      [
-        self.set('ansible_port', N_('Foreman will use this port to ssh into hosts for running playbooks'), 22, N_('Default port')),
-        self.set('ansible_user', N_('Foreman will try to connect as this user to hosts when running Ansible playbooks.'), 'root', N_('Default user')),
-        self.set('ansible_ssh_pass', N_('Foreman will use this password when running Ansible playbooks.'), 'ansible', N_('Default password')),
-        self.set('ansible_connection', N_('Foreman will use configured connection type when running Ansible playbooks.'), 'ssh', N_('Default Connection Type')),
-        self.set('ansible_winrm_server_cert_validation', N_('Foreman will enable/disable WinRM server certificate validation when running Ansible playbooks.'), 'validate', N_('Default WinRM Cert Validation')),
-        self.set('ansible_verbosity', N_('Foreman will add the this level of verbosity for additional debugging output when running Ansible playbooks.'), '0', N_('Default verbosity level'))
-      ].compact.each { |s| self.create s.update(:category => 'Setting::Ansible') }
+class Setting
+  # Provide settings related with Ansible
+  class Ansible < ::Setting
+    class << self
+      # It would be more disadvantages than advantages to split up
+      # load_defaults into multiple methods, this way it's already very
+      # manageable.
+      # rubocop:disable AbcSize
+      # rubocop:disable MethodLength
+      # rubocop:disable BlockLength
+      def load_defaults
+        return unless super
+        transaction do
+          [
+            set(
+              'ansible_port',
+              N_('Use this port to connect to hosts '\
+                 'and run Ansible. You can override this on hosts'\
+                ' by adding a parameter "ansible_port"'),
+              22,
+              N_('Port')
+            ),
+            set(
+              'ansible_user',
+              N_('Foreman will try to connect to hosts as this user by default'\
+                 ' when running Ansible playbooks. You can override this '\
+                 ' on hosts by adding a parameter "ansible_user"'),
+              'root',
+              N_('User')
+            ),
+            set(
+              'ansible_ssh_pass',
+              N_('Use this password by default when running Ansible '\
+                 'playbooks. You can override this on hosts '\
+                 'by adding a parameter "ansible_ssh_pass"'),
+              'ansible',
+              N_('Password')
+            ),
+            set(
+              'ansible_connection',
+              N_('Use this connection type by default when running '\
+                 'Ansible playbooks. You can override this on hosts by '\
+                 'adding a parameter "ansible_connection"'),
+              'ssh',
+              N_('Connection type')
+            ),
+            set(
+              'ansible_winrm_server_cert_validation',
+              N_('Enable/disable WinRM server certificate '\
+                 'validation when running Ansible playbooks. You can override '\
+                 'this on hosts by adding a parameter '\
+                 '"ansible_winrm_server_cert_validation"'),
+              'validate',
+              N_('WinRM cert Validation')
+            ),
+            set(
+              'ansible_verbosity',
+              N_('Foreman will add the this level of verbosity for '\
+                 'additional debugging output when running Ansible playbooks.'),
+              '0',
+              N_('Default verbosity level')
+            )
+          ].compact.each do |s|
+            create(s.update(:category => 'Setting::Ansible'))
+          end
+        end
+
+        true
+      end
+
+      def humanized_category
+        N_('Ansible')
+      end
     end
-
-    true
-  end
-
-  def self.humanized_category
-    N_('Ansible')
   end
 end

--- a/app/services/foreman_ansible/fact_parser.rb
+++ b/app/services/foreman_ansible/fact_parser.rb
@@ -49,7 +49,7 @@ module ForemanAnsible
       if pref.present?
         (facts[:ansible_interfaces] - [pref]).unshift(pref)
       else
-        (facts[:ansible_interfaces].sort unless facts[:ansible_interfaces].nil?) || []
+        ansible_interfaces
       end
     end
 
@@ -63,6 +63,11 @@ module ForemanAnsible
     def ipmi_interface; end
 
     private
+
+    def ansible_interfaces
+      return [] unless facts[:ansible_interfaces].present?
+      facts[:ansible_interfaces].sort
+    end
 
     def ip_from_interface(interface)
       return unless facts[:"ansible_#{interface}"]['ipv4'].present?

--- a/app/services/foreman_ansible/proxy_selector.rb
+++ b/app/services/foreman_ansible/proxy_selector.rb
@@ -8,6 +8,14 @@ module ForemanAnsible
       proxies
     end
 
+    def determine_proxy(*args)
+      result = super
+      return result unless result == :not_available
+      # Always run roles in some way, even if there are no proxies, Foreman
+      # should take that role in that case.
+      :not_defined
+    end
+
     private
 
     def proxy_scope(host)


### PR DESCRIPTION
This commit adds info about which proxy is running the Ansible task, and
also fixes some of the cops that were broken during the commit to play
roles in hostgroups