### PR TITLE
Fixes #18278 - Validate verbosity levels

### DIFF
--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -57,8 +57,16 @@ class Setting
               'ansible_verbosity',
               N_('Foreman will add the this level of verbosity for '\
                  'additional debugging output when running Ansible playbooks.'),
-              '0',
-              N_('Default verbosity level')
+              '',
+              N_('Default verbosity level'),
+              nil,
+              :collection => lambda do
+                { '' => N_('Disabled'),
+                  '1' => N_('Level 1 (-v)'),
+                  '2' => N_('Level 2 (-vv)'),
+                  '3' => N_('Level 3 (-vvv)'),
+                  '4' => N_('Level 4 (-vvvv)') }
+              end
             ),
             set(
               'ansible_post_provision_timeout',

--- a/lib/foreman_ansible_core/playbook_runner.rb
+++ b/lib/foreman_ansible_core/playbook_runner.rb
@@ -110,11 +110,9 @@ module ForemanAnsibleCore
     def setup_verbosity
       verbosity_level = @options[:verbosity_level].to_i
       logger.debug("Setting Ansible verbosity level to #{verbosity_level}")
-      if verbosity_level > 0
-        verbosity = '-'
-        verbosity_level.times do
-          verbosity += 'v'
-        end
+      verbosity = '-'
+      verbosity_level.times do
+        verbosity += 'v'
       end
       verbosity
     end


### PR DESCRIPTION
Verbosity levels were defaulting to the wrong one (0, which caused an
error). Now it offers a sensible list of possible verbosities with the
description of what they are.