### PR TITLE
Fixes #18311 - Read /etc/ansible/ansible.cfg roles_path

### DIFF
--- a/app/services/foreman_ansible/roles_importer.rb
+++ b/app/services/foreman_ansible/roles_importer.rb
@@ -1,5 +1,5 @@
 module ForemanAnsible
-  # imports roles from smart proxy
+  # Imports roles from smart proxy
   class RolesImporter
     attr_reader :ansible_proxy
 
@@ -39,9 +39,7 @@ module ForemanAnsible
     end
 
     def local_roles
-      Dir.glob('/etc/ansible/roles/*').map do |path|
-        path.split('/').last
-      end
+      ::ForemanAnsibleCore::RolesReader.list_roles
     end
 
     def remote_roles

--- a/lib/foreman_ansible_core.rb
+++ b/lib/foreman_ansible_core.rb
@@ -6,6 +6,7 @@ module ForemanAnsibleCore
   extend ForemanTasksCore::SettingsLoader
   register_settings(:ansible, :ansible_dir => '/etc/ansible',
                               :working_dir => nil)
+  require 'foreman_ansible_core/exception'
 
   if ForemanTasksCore.dynflow_present?
     require 'foreman_tasks_core/runner'
@@ -13,5 +14,6 @@ module ForemanAnsibleCore
     require 'foreman_ansible_core/actions'
   end
 
+  require 'foreman_ansible_core/roles_reader'
   require 'foreman_ansible_core/version'
 end

--- a/lib/foreman_ansible_core/exception.rb
+++ b/lib/foreman_ansible_core/exception.rb
@@ -1,0 +1,35 @@
+module ForemanAnsibleCore
+  # Taken from Foreman core, this class creates an error code for any exception
+  class Exception < ::StandardError
+    def initialize(message, *params)
+      @message = message
+      @params = params
+    end
+
+    def self.calculate_error_code(classname, message)
+      return 'ERF00-0000' if classname.nil? || message.nil?
+      basename = classname.split(':').last
+      class_hash = Zlib.crc32(basename) % 100
+      msg_hash = Zlib.crc32(message) % 10_000
+      format 'ERF%02d-%04d', class_hash, msg_hash
+    end
+
+    def code
+      @code ||= Exception.calculate_error_code(self.class.name, @message)
+      @code
+    end
+
+    def message
+      # make sure it works without gettext too
+      translated_msg = @message % @params
+      "#{code} [#{self.class.name}]: #{translated_msg}"
+    end
+
+    def to_s
+      message
+    end
+  end
+
+  class ReadConfigFileException < ForemanAnsibleCore::Exception
+  end
+end

--- a/lib/foreman_ansible_core/playbook_runner.rb
+++ b/lib/foreman_ansible_core/playbook_runner.rb
@@ -16,7 +16,7 @@ module ForemanAnsibleCore
     def start
       write_inventory
       write_playbook
-      logger.debug('Initializing Ansible Runner')
+      logger.debug('[foreman_ansible] - Initializing Ansible Runner')
       Dir.chdir(@ansible_dir) do
         initialize_command(*command)
       end
@@ -31,7 +31,7 @@ module ForemanAnsibleCore
       end
       command.concat(['-T', @options[:timeout]]) unless @options[:timeout].nil?
       command << playbook_file
-      logger.debug("Running command #{command}")
+      logger.debug("[foreman_ansible] - Running command #{command}")
       command
     end
 
@@ -109,7 +109,8 @@ module ForemanAnsibleCore
 
     def setup_verbosity
       verbosity_level = @options[:verbosity_level].to_i
-      logger.debug("Setting Ansible verbosity level to #{verbosity_level}")
+      logger.debug('[foreman_ansible] - Setting Ansible verbosity level to'\
+                   "#{verbosity_level}")
       verbosity = '-'
       verbosity_level.times do
         verbosity += 'v'

--- a/lib/foreman_ansible_core/roles_reader.rb
+++ b/lib/foreman_ansible_core/roles_reader.rb
@@ -1,0 +1,45 @@
+module ForemanAnsibleCore
+  # Implements the logic needed to read the roles and associated information
+  class RolesReader
+    class << self
+      DEFAULT_CONFIG_FILE = '/etc/ansible/ansible.cfg'.freeze
+
+      def list_roles
+        logger.info('[foreman_ansible] - Reading roles from '\
+                    '/etc/ansible/ansible.cfg roles_path')
+        Dir.glob("#{roles_path}/*").map do |path|
+          path.split('/').last
+        end
+      rescue Errno::ENOENT, Errno::EACCES => e
+        logger.debug("[foreman_ansible] - #{e.backtrace}")
+        exception_message = '[foreman_ansible] - Could not read Ansible config'\
+          " file #{DEFAULT_CONFIG_FILE} - #{e.message}"
+        raise ReadConfigFileException.new(exception_message)
+      end
+
+      def roles_path(ansible_config_file = DEFAULT_CONFIG_FILE)
+        default_path = '/etc/ansible/roles'
+        roles_line = File.readlines(ansible_config_file).select do |line|
+          line =~ /roles_path/
+        end
+        # Default to /etc/ansible/roles if none found
+        return default_path if roles_line.empty?
+        roles_path_key = roles_line.first.split('=').first.strip
+        # In case of commented roles_path key "#roles_path", return default
+        return default_path unless roles_path_key == 'roles_path'
+        # In case roles_path is there, and is not commented, return the value
+        roles_line.first.split('=').last.strip
+      end
+
+      def logger
+        # Return a different logger depending on where ForemanAnsibleCore is
+        # running from
+        if defined?(::Foreman::Logging)
+          ::Foreman::Logging.logger('foreman_ansible')
+        else
+          ::Proxy::LogBuffer::Decorator.instance
+        end
+      end
+    end
+  end
+end

--- a/test/functional/api/v2/hostgroups_controller_test.rb
+++ b/test/functional/api/v2/hostgroups_controller_test.rb
@@ -1,4 +1,5 @@
 require 'test_plugin_helper'
+require 'dynflow/testing'
 
 module Api
   module V2

--- a/test/unit/lib/foreman_ansible_core/roles_reader_test.rb
+++ b/test/unit/lib/foreman_ansible_core/roles_reader_test.rb
@@ -1,0 +1,57 @@
+require 'test_plugin_helper'
+
+class RolesReaderTest < ActiveSupport::TestCase
+  CONFIG_PATH = '/etc/ansible/ansible.cfg'.freeze
+  ROLES_PATH = '/etc/ansible/roles'.freeze
+
+  describe '#roles_path' do
+    test 'detects commented roles_path' do
+      expect_content_config ['#roles_path = thisiscommented!']
+      assert_equal(ROLES_PATH,
+                   ForemanAnsibleCore::RolesReader.roles_path(CONFIG_PATH))
+    end
+
+    test 'returns default path if no roles_path defined' do
+      expect_content_config ['norolepath!']
+      assert_equal(ROLES_PATH,
+                   ForemanAnsibleCore::RolesReader.roles_path(CONFIG_PATH))
+    end
+
+    test 'returns roles_path if one is defined' do
+      expect_content_config ['roles_path = /mycustom/ansibleroles/path']
+      assert_equal('/mycustom/ansibleroles/path',
+                   ForemanAnsibleCore::RolesReader.roles_path(CONFIG_PATH))
+    end
+  end
+
+  describe '#list_roles' do
+    setup do
+      # Return a path without actually reading the config file to make tests
+      # pass even on hosts without Ansible installed
+      ForemanAnsibleCore::RolesReader.stubs(:roles_path).
+        returns('/etc/ansible/roles')
+    end
+
+    test 'handles "No such file or dir" with exception' do
+      Dir.expects(:glob).with("#{ROLES_PATH}/*").raises(Errno::ENOENT)
+      ex = assert_raises(ForemanAnsibleCore::ReadConfigFileException) do
+        ForemanAnsibleCore::RolesReader.list_roles
+      end
+      assert_match(/Could not read Ansible config file/, ex.message)
+    end
+
+    test 'raises error if the roles path is not readable' do
+      Dir.expects(:glob).with("#{ROLES_PATH}/*").raises(Errno::EACCES)
+      ex = assert_raises(ForemanAnsibleCore::ReadConfigFileException) do
+        ForemanAnsibleCore::RolesReader.list_roles
+      end
+      assert_match(/Could not read Ansible config file/, ex.message)
+    end
+  end
+
+  private
+
+  def expect_content_config(ansible_cfg_content)
+    File.expects(:readlines).with(CONFIG_PATH).returns(ansible_cfg_content)
+  end
+end


### PR DESCRIPTION
Currently it's reading the hardcoded /etc/ansible/roles directory
instead of the /etc/ansible/ansible.cfg roles_path, which makes it
confusing for users who have custom roles_paths.

The implementation for reading roles_path should go in
ForemanAnsibleCore so that the proxy and Foreman can reuse the same
gem for reading roles