### PR TITLE
Fixes #18951 - Assigning Ansible roles over the API

### DIFF
--- a/app/controllers/foreman_ansible/api/v2/concerns/api_common.rb
+++ b/app/controllers/foreman_ansible/api/v2/concerns/api_common.rb
@@ -1,0 +1,32 @@
+module ForemanAnsible
+  module Api
+    module V2
+      module Concerns
+        # Shared task methods between api controllers
+        module ApiCommon
+          extend ActiveSupport::Concern
+
+          def find_ansible_roles
+            role_ids = params.fetch(:roles, [])
+            # rails transforms empty arrays to nil but we want to be able
+            # to remove all role assignments as well with an empty array
+            role_ids = [] if role_ids.nil?
+
+            @roles = []
+            role_ids.uniq.each do |role_id|
+              begin
+                @roles.append(find_ansible_role(role_id))
+              rescue ActiveRecord::RecordNotFound => e
+                return not_found(e.message)
+              end
+            end
+          end
+
+          def find_ansible_role(id)
+            @ansible_role = AnsibleRole.find(id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/foreman_ansible/api/v2/hosts_controller_extensions.rb
+++ b/app/controllers/foreman_ansible/api/v2/hosts_controller_extensions.rb
@@ -6,7 +6,12 @@ module ForemanAnsible
         extend ActiveSupport::Concern
         include ForemanTasks::Triggers
 
+        # Included blocks shouldn't be bound by length, as otherwise concerns
+        # cannot extend the method properly.
+        # rubocop:disable BlockLength
         included do
+          before_action :find_ansible_roles, :only => [:ansible_roles]
+
           api :POST, '/hosts/:id/play_roles', N_('Plays Ansible roles on hosts')
           param :id, String, :required => true
 
@@ -36,13 +41,65 @@ module ForemanAnsible
 
             render_message @result
           end
+
+          api :GET, '/hosts/:id/list_ansible_roles',
+              N_('Lists assigned Ansible roles')
+          param :id, :identifier, :required => true
+
+          def list_ansible_roles
+            @result = {
+              :all_ansible_roles => @host.all_ansible_roles,
+              :ansible_roles => @host.ansible_roles,
+              :inherited_ansible_roles => @host.inherited_ansible_roles
+            }
+
+            render_message @result
+          end
+
+          api :POST, '/hosts/:id/ansible_roles',
+              N_('Assigns Ansible roles to a host')
+          param :id, :identifier, :required => true
+          param :roles, Array, :required => true
+
+          def ansible_roles
+            # we do not want to store inherited roles twice
+            @host.ansible_roles = @roles - @host.inherited_ansible_roles
+
+            @result = {
+              :roles => @roles,
+              :host => @host
+            }
+
+            render_message @result
+          end
         end
 
         private
 
+        def find_ansible_roles
+          role_ids = params.fetch(:roles, [])
+          # rails transforms empty arrays to nil but we want to be able
+          # to remove all role assignments as well with an empty array
+          role_ids = [] if role_ids.nil?
+
+          @roles = []
+          role_ids.uniq.each do |role_id|
+            begin
+              @roles.append(find_ansible_role(role_id))
+            rescue ActiveRecord::RecordNotFound => e
+              return not_found(e.message)
+            end
+          end
+        end
+
+        def find_ansible_role(id)
+          @ansible_role = AnsibleRole.find(id)
+        end
+
         def action_permission
           case params[:action]
-          when 'play_roles', 'multiple_play_roles'
+          when 'play_roles', 'multiple_play_roles', 'ansible_roles',
+               'list_ansible_roles'
             :view
           else
             super

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,8 @@ Rails.application.routes.draw do
           resources :hosts, :only => [] do
             member do
               post :play_roles
+              get :list_ansible_roles
+              post :ansible_roles
             end
             collection do
               post :multiple_play_roles
@@ -43,6 +45,8 @@ Rails.application.routes.draw do
           resources :hostgroups, :only => [] do
             member do
               post :play_roles
+              get :list_ansible_roles
+              post :ansible_roles
             end
             collection do
               post :multiple_play_roles

--- a/lib/foreman_ansible/engine.rb
+++ b/lib/foreman_ansible/engine.rb
@@ -36,14 +36,19 @@ module ForemanAnsible
 
         security_block :foreman_ansible do
           permission :play_roles_on_host,
-                     { :hosts => [:play_roles, :multiple_play_roles],
+                     { :hosts => [:play_roles, :multiple_play_roles,
+                                  :ansible_roles],
                        :'api/v2/hosts' => [:play_roles,
-                                           :multiple_play_roles] },
+                                           :multiple_play_roles,
+                                           :ansible_roles,
+                                           :list_ansible_roles] },
                      :resource_type => 'Host'
           permission :play_roles_on_hostgroup,
                      { :hostgroups => [:play_roles],
                        :'api/v2/hostgroups' => [:play_roles,
-                                                :multiple_play_roles] },
+                                                :multiple_play_roles,
+                                                :ansible_roles,
+                                                :list_ansible_roles] },
                      :resource_type => 'Hostgroup'
           permission :view_ansible_roles,
                      { :ansible_roles => [:index],

--- a/test/functional/api/v2/hosts_controller_test.rb
+++ b/test/functional/api/v2/hosts_controller_test.rb
@@ -6,8 +6,12 @@ module Api
       include ::Dynflow::Testing
 
       setup do
-        @host1 = FactoryGirl.create(:host)
+        @host1 = FactoryGirl.create(:host, :with_hostgroup)
         @host2 = FactoryGirl.create(:host)
+        @role1 = FactoryGirl.create(:ansible_role)
+        @role2 = FactoryGirl.create(:ansible_role)
+        @host1.ansible_roles           = [@role1]
+        @host1.hostgroup.ansible_roles = [@role2]
       end
 
       after do
@@ -41,6 +45,38 @@ module Api
         response = JSON.parse(@response.body)
 
         assert response['message'].length == 2, 'should trigger two tasks'
+        assert_response :success
+      end
+
+      test 'should list assigned roles on host' do
+        get :list_ansible_roles, :id => @host1.id
+        response = JSON.parse(@response.body)
+
+        assert_equal response['message']['ansible_roles'][0]['id'],
+                     @role1.id
+                     'assigned role not in role list'
+        assert_equal response['message']['inherited_ansible_roles'][0]['id'],
+                     @role2.id
+                     'inherited role not in role list'
+        assert response['message']['all_ansible_roles'].length == 2,
+               'not all assigned ansible roles listed'
+        assert_response :success
+      end
+
+      test 'unassign and assign a role to a host' do
+        post :ansible_roles, :id => @host1.id, :roles => []
+        response = JSON.parse(@response.body)
+
+        assert response['message']['roles'].empty?,
+               'host role could not be unassigned'
+        assert_response :success
+
+        post :ansible_roles, :id => @host1.id, :roles => [@role1.id]
+        response = JSON.parse(@response.body)
+
+        assert_equal response['message']['roles'][0]['id'],
+                     @role1.id
+                     'host role could not be assigned'
         assert_response :success
       end
     end


### PR DESCRIPTION
At the moment, it is only possible to assign Ansible roles from the
Foreman UI. Due to this reason, Foreman cannot be used as a pure backend
service and it cannot be configured externally. In this feature, new
endpoints are added to the API, which allow setting roles as well as
listing assigned roles.