### PR TITLE
Fixes #19240 - fix the inline help icon position

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ locale/*/*.edit.po
 locale/*/*.po.time_stamp
 locale/*/*.pox
 locale/*/LC_MESSAGES
+Gemfile.lock

--- a/app/views/foreman_ansible/ansible_roles/_select_tab_content.html.erb
+++ b/app/views/foreman_ansible/ansible_roles/_select_tab_content.html.erb
@@ -7,10 +7,9 @@
     {
       :disabled => f.object.inherited_ansible_roles.map(&:id),
       :label => _('Available roles'),
-      :help_inline => popover('' ,
-          _('This list of roles will be applied when the host finishes '\
-            'provisioning. Users can also play these roles through the API '\
-            'or by clicking on the Play Roles button on the Host page '))
+      :label_help => _('This list of roles will be applied when the host finishes<br/> '\
+            'provisioning. Users can also play these roles through the API<br/>'\
+            'or by clicking on the Play Roles button on the Host page ').html_safe
     },
     { 'data-inheriteds' => f.object.inherited_ansible_roles.map(&:id).to_json }) %>
 </div>

--- a/lib/foreman_ansible/engine.rb
+++ b/lib/foreman_ansible/engine.rb
@@ -32,7 +32,7 @@ module ForemanAnsible
 
     initializer 'foreman_ansible.register_plugin', :before => :finisher_hook do
       Foreman::Plugin.register :foreman_ansible do
-        requires_foreman '>= 1.12'
+        requires_foreman '>= 1.15'
 
         security_block :foreman_ansible do
           permission :play_roles_on_host,


### PR DESCRIPTION
before
![ansible_before](https://cloud.githubusercontent.com/assets/109773/24897199/47ec7c46-1e98-11e7-8e11-830384dbaeec.png)

after
![ansible_after](https://cloud.githubusercontent.com/assets/109773/24897198/47d8732c-1e98-11e7-8998-f17666ee17d4.png)

Note that this requires Foreman 1.15. I also added Gemfile.lock to .gitignore, I was lazy to open separate issue for that, let me know if you want me to separate it.