### PR TITLE
Fixes #20389 - Don't report a non numeric major version on debian sid

### DIFF
--- a/app/services/foreman_ansible/fact_parser.rb
+++ b/app/services/foreman_ansible/fact_parser.rb
@@ -79,10 +79,28 @@ module ForemanAnsible
         facts[:ansible_lsb] && facts[:ansible_lsb]['id']
     end
 
+    def debian_os_major_sid
+      case facts[:ansible_distribution_major_version]
+      when /wheezy/i
+        '7'
+      when /jessie/i
+        '8'
+      when /stretch/i
+        '9'
+      when /buster/i
+        '10'
+      end
+    end
+
     def os_major
-      facts[:ansible_distribution_major_version] ||
-        facts[:ansible_lsb] && facts[:ansible_lsb]['major_release'] ||
-        (facts[:version].split('R')[0] if os_name == 'junos')
+      if os_name == 'Debian' &&
+         facts[:ansible_distribution_major_version][%r{\/sid}i]
+        debian_os_major_sid
+      else
+        facts[:ansible_distribution_major_version] ||
+          facts[:ansible_lsb] && facts[:ansible_lsb]['major_release'] ||
+          (facts[:version].split('R')[0] if os_name == 'junos')
+      end
     end
 
     def os_release

--- a/test/unit/services/fact_parser_test.rb
+++ b/test/unit/services/fact_parser_test.rb
@@ -50,4 +50,23 @@ module ForemanAnsible
       sample_mock.expects(:first_or_create)
     end
   end
+
+  class DebianFactParserTest < ActiveSupport::TestCase
+    setup do
+      @facts_parser = ForemanAnsible::FactParser.new(
+        {'_type': 'ansible',
+         '_timestamp': '2015-10-29 20:01:51 +0100',
+         'ansible_facts': {
+                            'ansible_distribution_major_version': 'buster/sid',
+                            'ansible_distribution': 'Debian'
+                          }
+        })
+    end
+
+    test 'Parses debian unstable aka sid correctly' do
+      os = @facts_parser.operatingsystem
+      assert_equal "10", os.major
+      assert_equal "Debian", os.name
+    end
+  end
 end


### PR DESCRIPTION
since this otherwise fails like

    2017-07-23T15:39:32 07623536 [app] [W] Action failed
     | ActiveRecord::RecordInvalid: Validation failed: Major version is too long (maximum is 5 characters), Major version is not a number
     | /usr/share/foreman/vendor/ruby/2.3.0/gems/activerecord-4.2.9/lib/active_record/validations.rb:79:in `raise_record_invalid'
     | /usr/share/foreman/vendor/ruby/2.3.0/gems/activerecord-4.2.9/lib/active_record/validations.rb:43:in `save!'
     | /usr/share/foreman/vendor/ruby/2.3.0/gems/activerecord-4.2.9/lib/active_record/attribute_methods/dirty.rb:29:in `save!'
     | /usr/share/foreman/vendor/ruby/2.3.0/gems/activerecord-4.2.9/lib/active_record/transactions.rb:291:in `block in save!'
     | /usr/share/foreman/vendor/ruby/2.3.0/gems/activerecord-4.2.9/lib/active_record/transactions.rb:351:in `block in with_transaction_returning_status'
     | /usr/share/foreman/vendor/ruby/2.3.0/gems/activerecord-4.2.9/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `block in transaction'
     | /usr/share/foreman/vendor/ruby/2.3.0/gems/activerecord-4.2.9/lib/active_record/connection_adapters/abstract/transaction.rb:184:in `within_new_transaction'
     | /usr/share/foreman/vendor/ruby/2.3.0/gems/activerecord-4.2.9/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `transaction'
     | /usr/share/foreman/vendor/ruby/2.3.0/gems/activerecord-4.2.9/lib/active_record/transactions.rb:220:in `transaction'
     | /usr/share/foreman/vendor/ruby/2.3.0/gems/activerecord-4.2.9/lib/active_record/transactions.rb:348:in `with_transaction_returning_status'
     | /usr/share/foreman/vendor/ruby/2.3.0/gems/activerecord-4.2.9/lib/active_record/transactions.rb:291:in `save!'
     | /usr/share/foreman/vendor/ruby/2.3.0/gems/activerecord-4.2.9/lib/active_record/persistence.rb:51:in `create!'
     | /usr/share/foreman/vendor/ruby/2.3.0/gems/foreman_ansible-1.4.5/app/services/foreman_ansible/fact_parser.rb:14:in `operatingsystem'
    …

Debian adds the numeric versions after the release to the
/etc/os-release:

    http://metadata.ftp-master.debian.org/changelogs/main/b/base-files/base-files_10_changelog

The puppet fact parser uses s.th. similar.