### PR TITLE
fixes #20407 - adds two new options

### DIFF
--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -34,7 +34,7 @@ class Setting
               N_('Foreman will use the sudo command to run roles on hosts '\
                  'You can override this on hosts by adding a parameter '\
                  '"ansible_become"'),
-              'true',
+              true,
               N_('Become')
             ),
             set(

--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -42,7 +42,7 @@ class Setting
               N_('Use this password by default when running Ansible '\
                  'playbooks. You can override this on hosts '\
                  'by adding a parameter "ansible_ssh_pass"'),
-                 'ansible',
+              'ansible',
               N_('Password')
             ),
             set(

--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -99,7 +99,7 @@ class Setting
             create(s.update(:category => 'Setting::Ansible'))
           end
         end
-
+        Setting::BLANK_ATTRS.push('ansible_ssh_private_key_file')
         true
       end
 

--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -12,71 +12,86 @@ class Setting
         return unless super
         transaction do
           [
-            set(
-              'ansible_port',
-              N_('Use this port to connect to hosts '\
+              set(
+                  'ansible_port',
+                  N_('Use this port to connect to hosts '\
                  'and run Ansible. You can override this on hosts'\
                 ' by adding a parameter "ansible_port"'),
-              22,
-              N_('Port')
-            ),
-            set(
-              'ansible_user',
-              N_('Foreman will try to connect to hosts as this user by default'\
+                  22,
+                  N_('Port')
+              ),
+              set(
+                  'ansible_user',
+                  N_('Foreman will try to connect to hosts as this user by default'\
                  ' when running Ansible playbooks. You can override this '\
                  ' on hosts by adding a parameter "ansible_user"'),
-              'root',
-              N_('User')
-            ),
-            set(
-              'ansible_ssh_pass',
-              N_('Use this password by default when running Ansible '\
+                  'root',
+                  N_('User')
+              ),
+              set(
+                  'ansible_become',
+                  N_('Foreman will use the sudo command to run roles on hosts'\
+                   ' You can override this on hosts by adding a parameter "ansible_become"'),
+                  'True',
+                  N_('Become')
+              ),
+              set(
+                  'ansible_ssh_pass',
+                  N_('Use this password by default when running Ansible '\
                  'playbooks. You can override this on hosts '\
                  'by adding a parameter "ansible_ssh_pass"'),
-              'ansible',
-              N_('Password')
-            ),
-            set(
-              'ansible_connection',
-              N_('Use this connection type by default when running '\
+                  'ansible',
+                  N_('Password')
+              ),
+              set(
+                  'ansible_ssh_private_key_file',
+                  N_('Use this to supply a path to an SSH Private Key'\
+                     ' that Ansible will use in lieu of a password'\
+                     ' Override with "ansible_ssh_private_key_file" host parameter'),
+                  '/tmp/private_key_file',
+                  N_('Private Key Path')
+              ),
+              set(
+                  'ansible_connection',
+                  N_('Use this connection type by default when running '\
                  'Ansible playbooks. You can override this on hosts by '\
                  'adding a parameter "ansible_connection"'),
-              'ssh',
-              N_('Connection type')
-            ),
-            set(
-              'ansible_winrm_server_cert_validation',
-              N_('Enable/disable WinRM server certificate '\
+                  'ssh',
+                  N_('Connection type')
+              ),
+              set(
+                  'ansible_winrm_server_cert_validation',
+                  N_('Enable/disable WinRM server certificate '\
                  'validation when running Ansible playbooks. You can override '\
                  'this on hosts by adding a parameter '\
                  '"ansible_winrm_server_cert_validation"'),
-              'validate',
-              N_('WinRM cert Validation')
-            ),
-            set(
-              'ansible_verbosity',
-              N_('Foreman will add the this level of verbosity for '\
+                  'validate',
+                  N_('WinRM cert Validation')
+              ),
+              set(
+                  'ansible_verbosity',
+                  N_('Foreman will add the this level of verbosity for '\
                  'additional debugging output when running Ansible playbooks.'),
-              '',
-              N_('Default verbosity level'),
-              nil,
-              :collection => lambda do
-                { '' => N_('Disabled'),
-                  '1' => N_('Level 1 (-v)'),
-                  '2' => N_('Level 2 (-vv)'),
-                  '3' => N_('Level 3 (-vvv)'),
-                  '4' => N_('Level 4 (-vvvv)') }
-              end
-            ),
-            set(
-              'ansible_post_provision_timeout',
-              N_('Timeout (in seconds) to set when Foreman will trigger a '\
+                  '',
+                  N_('Default verbosity level'),
+                  nil,
+                  :collection => lambda do
+                    {'' => N_('Disabled'),
+                     '1' => N_('Level 1 (-v)'),
+                     '2' => N_('Level 2 (-vv)'),
+                     '3' => N_('Level 3 (-vvv)'),
+                     '4' => N_('Level 4 (-vvvv)')}
+                  end
+              ),
+              set(
+                  'ansible_post_provision_timeout',
+                  N_('Timeout (in seconds) to set when Foreman will trigger a '\
                  'play Ansible roles task after a host is fully provisioned. '\
                  'Set this to the maximum time you expect a host to take until'\
                  ' it is ready after a reboot.'),
-              '360',
-              N_('Post-provision timeout')
-            )
+                  '360',
+                  N_('Post-provision timeout')
+              )
           ].compact.each do |s|
             create(s.update(:category => 'Setting::Ansible'))
           end

--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -34,7 +34,7 @@ class Setting
               N_('Foreman will use the sudo command to run roles on hosts '\
                  'You can override this on hosts by adding a parameter '\
                  '"ansible_become"'),
-              'True',
+              'true',
               N_('Become')
             ),
             set(
@@ -49,9 +49,9 @@ class Setting
               'ansible_ssh_private_key_file',
               N_('Use this to supply a path to an SSH Private Key '\
                  'that Ansible will use in lieu of a password '\
-                 'Override with "ansible_ssh_private_key_file"'\
+                 'Override with "ansible_ssh_private_key_file" '\
                  'host parameter'),
-              '/tmp/private_key_file',
+              '',
               N_('Private Key Path')
             ),
             set(

--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -80,10 +80,10 @@ class Setting
               nil,
               :collection => lambda do
                 { '' => N_('Disabled'),
-                 '1' => N_('Level 1 (-v)'),
-                 '2' => N_('Level 2 (-vv)'),
-                 '3' => N_('Level 3 (-vvv)'),
-                 '4' => N_('Level 4 (-vvvv)') }
+                  '1' => N_('Level 1 (-v)'),
+                  '2' => N_('Level 2 (-vv)'),
+                  '3' => N_('Level 3 (-vvv)'),
+                  '4' => N_('Level 4 (-vvvv)') }
               end
             ),
             set(

--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -12,86 +12,89 @@ class Setting
         return unless super
         transaction do
           [
-              set(
-                  'ansible_port',
-                  N_('Use this port to connect to hosts '\
-                 'and run Ansible. You can override this on hosts'\
-                ' by adding a parameter "ansible_port"'),
-                  22,
-                  N_('Port')
-              ),
-              set(
-                  'ansible_user',
-                  N_('Foreman will try to connect to hosts as this user by default'\
-                 ' when running Ansible playbooks. You can override this '\
-                 ' on hosts by adding a parameter "ansible_user"'),
-                  'root',
-                  N_('User')
-              ),
-              set(
-                  'ansible_become',
-                  N_('Foreman will use the sudo command to run roles on hosts'\
-                   ' You can override this on hosts by adding a parameter "ansible_become"'),
-                  'True',
-                  N_('Become')
-              ),
-              set(
-                  'ansible_ssh_pass',
-                  N_('Use this password by default when running Ansible '\
+            set(
+              'ansible_port',
+              N_('Use this port to connect to hosts '\
+                 'and run Ansible. You can override this on hosts '\
+                 'by adding a parameter "ansible_port"'),
+              22,
+              N_('Port')
+            ),
+            set(
+              'ansible_user',
+              N_('Foreman will try to connect to hosts as this user by '\
+                 'default when running Ansible playbooks. You can '\
+                 'override this on hosts by adding a parameter '\
+                 '"ansible_user"'),
+              'root',
+              N_('User')
+            ),
+            set(
+              'ansible_become',
+              N_('Foreman will use the sudo command to run roles on hosts '\
+                 'You can override this on hosts by adding a parameter '\
+                 '"ansible_become"'),
+              'True',
+              N_('Become')
+            ),
+            set(
+              'ansible_ssh_pass',
+              N_('Use this password by default when running Ansible '\
                  'playbooks. You can override this on hosts '\
                  'by adding a parameter "ansible_ssh_pass"'),
-                  'ansible',
-                  N_('Password')
-              ),
-              set(
-                  'ansible_ssh_private_key_file',
-                  N_('Use this to supply a path to an SSH Private Key'\
-                     ' that Ansible will use in lieu of a password'\
-                     ' Override with "ansible_ssh_private_key_file" host parameter'),
-                  '/tmp/private_key_file',
-                  N_('Private Key Path')
-              ),
-              set(
-                  'ansible_connection',
-                  N_('Use this connection type by default when running '\
+                 'ansible',
+              N_('Password')
+            ),
+            set(
+              'ansible_ssh_private_key_file',
+              N_('Use this to supply a path to an SSH Private Key '\
+                 'that Ansible will use in lieu of a password '\
+                 'Override with "ansible_ssh_private_key_file"'\
+                 'host parameter'),
+              '/tmp/private_key_file',
+              N_('Private Key Path')
+            ),
+            set(
+              'ansible_connection',
+              N_('Use this connection type by default when running '\
                  'Ansible playbooks. You can override this on hosts by '\
                  'adding a parameter "ansible_connection"'),
-                  'ssh',
-                  N_('Connection type')
-              ),
-              set(
-                  'ansible_winrm_server_cert_validation',
-                  N_('Enable/disable WinRM server certificate '\
+              'ssh',
+              N_('Connection type')
+            ),
+            set(
+              'ansible_winrm_server_cert_validation',
+              N_('Enable/disable WinRM server certificate '\
                  'validation when running Ansible playbooks. You can override '\
                  'this on hosts by adding a parameter '\
                  '"ansible_winrm_server_cert_validation"'),
-                  'validate',
-                  N_('WinRM cert Validation')
-              ),
-              set(
-                  'ansible_verbosity',
-                  N_('Foreman will add the this level of verbosity for '\
+              'validate',
+              N_('WinRM cert Validation')
+            ),
+            set(
+              'ansible_verbosity',
+              N_('Foreman will add the this level of verbosity for '\
                  'additional debugging output when running Ansible playbooks.'),
-                  '',
-                  N_('Default verbosity level'),
-                  nil,
-                  :collection => lambda do
-                    {'' => N_('Disabled'),
-                     '1' => N_('Level 1 (-v)'),
-                     '2' => N_('Level 2 (-vv)'),
-                     '3' => N_('Level 3 (-vvv)'),
-                     '4' => N_('Level 4 (-vvvv)')}
-                  end
-              ),
-              set(
-                  'ansible_post_provision_timeout',
-                  N_('Timeout (in seconds) to set when Foreman will trigger a '\
+              '',
+              N_('Default verbosity level'),
+              nil,
+              :collection => lambda do
+                { '' => N_('Disabled'),
+                 '1' => N_('Level 1 (-v)'),
+                 '2' => N_('Level 2 (-vv)'),
+                 '3' => N_('Level 3 (-vvv)'),
+                 '4' => N_('Level 4 (-vvvv)') }
+              end
+            ),
+            set(
+              'ansible_post_provision_timeout',
+              N_('Timeout (in seconds) to set when Foreman will trigger a '\
                  'play Ansible roles task after a host is fully provisioned. '\
                  'Set this to the maximum time you expect a host to take until'\
                  ' it is ready after a reboot.'),
-                  '360',
-                  N_('Post-provision timeout')
-              )
+              '360',
+              N_('Post-provision timeout')
+            )
           ].compact.each do |s|
             create(s.update(:category => 'Setting::Ansible'))
           end

--- a/app/services/foreman_ansible/inventory_creator.rb
+++ b/app/services/foreman_ansible/inventory_creator.rb
@@ -45,7 +45,7 @@ module ForemanAnsible
       # Check if private_key is defined, if it is use that. Otherwise
       # use ssh_pass
       if !host.host_params['ansible_ssh_private_key_file'].empty? ||
-          !Setting[:private_key].empty?
+          Setting[:ansible_ssh_private_key_file].empty?
         params['ansible_ssh_private_key_file'] = host_private_key_file(host)
       else
         params['ansible_ssh_pass'] = host_ssh_pass(host)

--- a/app/services/foreman_ansible/inventory_creator.rb
+++ b/app/services/foreman_ansible/inventory_creator.rb
@@ -40,15 +40,9 @@ module ForemanAnsible
         'ansible_user' => host_user(host),
         'ansible_become' => host_become(host),
         'ansible_connection' => connection_type(host),
+        'ansible_ssh_pass' => host_ssh_pass(host),
         'ansible_winrm_server_cert_validation' => winrm_cert_validation(host)
       }
-      # Check if private_key is defined, if it is use that. Otherwise
-      # use ssh_pass
-      if !host_private_key_file.empty?
-        params['ansible_ssh_private_key_file'] = host_private_key_file(host)
-      else
-        params['ansible_ssh_pass'] = host_ssh_pass(host)
-      end
       # Backward compatibility for Ansible 1.x
       params['ansible_ssh_port'] = params['ansible_port']
       params['ansible_ssh_user'] = params['ansible_user']
@@ -84,17 +78,8 @@ module ForemanAnsible
       host.host_params['ansible_user'] || Setting[:ansible_user]
     end
 
-    def host_become(host)
-      host.host_params['ansible_become'] || Setting[:ansible_become]
-    end
-
     def host_ssh_pass(host)
       host.host_params['ansible_ssh_pass'] || Setting[:ansible_ssh_pass]
-    end
-
-    def host_private_key_file(host)
-      host.host_params['ansible_ssh_private_key_file'] ||
-        Setting[:ansible_ssh_private_key_file]
     end
 
     private

--- a/app/services/foreman_ansible/inventory_creator.rb
+++ b/app/services/foreman_ansible/inventory_creator.rb
@@ -58,7 +58,7 @@ module ForemanAnsible
 
     def winrm_cert_validation(host)
       host.host_params['ansible_winrm_server_cert_validation'] ||
-          Setting['ansible_winrm_server_cert_validation']
+        Setting['ansible_winrm_server_cert_validation']
     end
 
     def connection_type(host)
@@ -94,7 +94,8 @@ module ForemanAnsible
     end
 
     def host_private_key_file(host)
-      host.host_params['ansible_ssh_private_key_file'] || Setting[:ansible_ssh_private_key_file]
+      host.host_params['ansible_ssh_private_key_file'] ||
+        Setting[:ansible_ssh_private_key_file]
     end
 
     private

--- a/app/services/foreman_ansible/inventory_creator.rb
+++ b/app/services/foreman_ansible/inventory_creator.rb
@@ -38,10 +38,17 @@ module ForemanAnsible
       params = {
         'ansible_port' => host_port(host),
         'ansible_user' => host_user(host),
-        'ansible_ssh_pass' => host_ssh_pass(host),
+        'ansible_become' => host_become(host),
         'ansible_connection' => connection_type(host),
         'ansible_winrm_server_cert_validation' => winrm_cert_validation(host)
       }
+      # Check if private_key is defined, if it is use that. Otherwise
+      # use ssh_pass
+      if not host.host_params['ansible_ssh_private_key_file'].empty? or not Setting[:private_key].empty?
+        params['ansible_ssh_private_key_file'] = host_private_key_file(host)
+      else
+        params['ansible_ssh_pass'] = host_ssh_pass(host)
+      end
       # Backward compatibility for Ansible 1.x
       params['ansible_ssh_port'] = params['ansible_port']
       params['ansible_ssh_user'] = params['ansible_user']
@@ -77,8 +84,16 @@ module ForemanAnsible
       host.host_params['ansible_user'] || Setting[:ansible_user]
     end
 
+    def host_become(host)
+      host.host_params['ansible_become'] || Setting[:ansible_become]
+    end
+
     def host_ssh_pass(host)
       host.host_params['ansible_ssh_pass'] || Setting[:ansible_ssh_pass]
+    end
+
+    def host_private_key_file(host)
+      host.host_params['ansible_ssh_private_key_file'] || Setting[:ansible_ssh_private_key_file]
     end
 
     private

--- a/app/services/foreman_ansible/inventory_creator.rb
+++ b/app/services/foreman_ansible/inventory_creator.rb
@@ -44,8 +44,7 @@ module ForemanAnsible
       }
       # Check if private_key is defined, if it is use that. Otherwise
       # use ssh_pass
-      if !host.host_params['ansible_ssh_private_key_file'].empty? ||
-          Setting[:ansible_ssh_private_key_file].empty?
+      if !host_private_key_file.empty?
         params['ansible_ssh_private_key_file'] = host_private_key_file(host)
       else
         params['ansible_ssh_pass'] = host_ssh_pass(host)

--- a/app/services/foreman_ansible/inventory_creator.rb
+++ b/app/services/foreman_ansible/inventory_creator.rb
@@ -44,7 +44,8 @@ module ForemanAnsible
       }
       # Check if private_key is defined, if it is use that. Otherwise
       # use ssh_pass
-      if not host.host_params['ansible_ssh_private_key_file'].empty? or not Setting[:private_key].empty?
+      if not host.host_params['ansible_ssh_private_key_file'].empty? or
+          not Setting[:private_key].empty?
         params['ansible_ssh_private_key_file'] = host_private_key_file(host)
       else
         params['ansible_ssh_pass'] = host_ssh_pass(host)
@@ -56,8 +57,7 @@ module ForemanAnsible
     end
 
     def winrm_cert_validation(host)
-      host.host_params['ansible_winrm_server_cert_validation'] ||
-        Setting['ansible_winrm_server_cert_validation']
+      host.host_params['ansible_winrm_server_cert_validation'] || Setting['ansible_winrm_server_cert_validation']
     end
 
     def connection_type(host)

--- a/app/services/foreman_ansible/inventory_creator.rb
+++ b/app/services/foreman_ansible/inventory_creator.rb
@@ -44,7 +44,7 @@ module ForemanAnsible
       }
       # Check if private_key is defined, if it is use that. Otherwise
       # use ssh_pass
-      if not host.host_params['ansible_ssh_private_key_file'].empty? or not Setting[:private_key].empty?
+      if ! host.host_params['ansible_ssh_private_key_file'].empty? || ! Setting[:private_key].empty?
         params['ansible_ssh_private_key_file'] = host_private_key_file(host)
       else
         params['ansible_ssh_pass'] = host_ssh_pass(host)

--- a/app/services/foreman_ansible/inventory_creator.rb
+++ b/app/services/foreman_ansible/inventory_creator.rb
@@ -44,7 +44,8 @@ module ForemanAnsible
       }
       # Check if private_key is defined, if it is use that. Otherwise
       # use ssh_pass
-      if ! host.host_params['ansible_ssh_private_key_file'].empty? || ! Setting[:private_key].empty?
+      if !host.host_params['ansible_ssh_private_key_file'].empty? ||
+          !Setting[:private_key].empty?
         params['ansible_ssh_private_key_file'] = host_private_key_file(host)
       else
         params['ansible_ssh_pass'] = host_ssh_pass(host)
@@ -56,7 +57,8 @@ module ForemanAnsible
     end
 
     def winrm_cert_validation(host)
-      host.host_params['ansible_winrm_server_cert_validation'] || Setting['ansible_winrm_server_cert_validation']
+      host.host_params['ansible_winrm_server_cert_validation'] ||
+          Setting['ansible_winrm_server_cert_validation']
     end
 
     def connection_type(host)

--- a/app/services/foreman_ansible/inventory_creator.rb
+++ b/app/services/foreman_ansible/inventory_creator.rb
@@ -44,8 +44,7 @@ module ForemanAnsible
       }
       # Check if private_key is defined, if it is use that. Otherwise
       # use ssh_pass
-      if not host.host_params['ansible_ssh_private_key_file'].empty? or
-          not Setting[:private_key].empty?
+      if not host.host_params['ansible_ssh_private_key_file'].empty? or not Setting[:private_key].empty?
         params['ansible_ssh_private_key_file'] = host_private_key_file(host)
       else
         params['ansible_ssh_pass'] = host_ssh_pass(host)


### PR DESCRIPTION
Fixes #20407 - adds two new options.
Adds ability to configure ansible_become & ansible_ssh_private_key_file options to foreman_ansible plugin. IDE also edited whitespace in ansible.rb file.