### PR TITLE
Fixes #20884 - Allow importing roles from multiple paths

### DIFF
--- a/lib/foreman_ansible_core/exception.rb
+++ b/lib/foreman_ansible_core/exception.rb
@@ -30,6 +30,6 @@ module ForemanAnsibleCore
     end
   end
 
-  class ReadConfigFileException < ForemanAnsibleCore::Exception
-  end
+  class ReadConfigFileException < ForemanAnsibleCore::Exception; end
+  class ReadRolesException < ForemanAnsibleCore::Exception; end
 end

--- a/lib/foreman_ansible_core/roles_reader.rb
+++ b/lib/foreman_ansible_core/roles_reader.rb
@@ -3,31 +3,18 @@ module ForemanAnsibleCore
   class RolesReader
     class << self
       DEFAULT_CONFIG_FILE = '/etc/ansible/ansible.cfg'.freeze
+      DEFAULT_ROLES_PATH = '/etc/ansible/roles'.freeze
 
       def list_roles
-        logger.info('[foreman_ansible] - Reading roles from '\
-                    '/etc/ansible/ansible.cfg roles_path')
-        Dir.glob("#{roles_path}/*").map do |path|
-          path.split('/').last
-        end
-      rescue Errno::ENOENT, Errno::EACCES => e
-        logger.debug("[foreman_ansible] - #{e.backtrace}")
-        exception_message = '[foreman_ansible] - Could not read Ansible config'\
-          " file #{DEFAULT_CONFIG_FILE} - #{e.message}"
-        raise ReadConfigFileException.new(exception_message)
+        roles_path.split(':').map { |path| read_roles(path) }.flatten
       end
 
-      def roles_path(ansible_config_file = DEFAULT_CONFIG_FILE)
-        default_path = '/etc/ansible/roles'
-        roles_line = File.readlines(ansible_config_file).select do |line|
-          line =~ /roles_path/
-        end
+      def roles_path(roles_line = roles_path_from_config)
         # Default to /etc/ansible/roles if none found
-        return default_path if roles_line.empty?
+        return DEFAULT_ROLES_PATH if roles_line.empty?
         roles_path_key = roles_line.first.split('=').first.strip
         # In case of commented roles_path key "#roles_path", return default
-        return default_path unless roles_path_key == 'roles_path'
-        # In case roles_path is there, and is not commented, return the value
+        return DEFAULT_ROLES_PATH unless roles_path_key == 'roles_path'
         roles_line.first.split('=').last.strip
       end
 
@@ -39,6 +26,35 @@ module ForemanAnsibleCore
         else
           ::Proxy::LogBuffer::Decorator.instance
         end
+      end
+
+      private
+
+      def read_roles(roles_path)
+        rescue_and_raise_file_exception ReadRolesException,
+                                        roles_path, 'roles' do
+          Dir.glob("#{roles_path}/*").map do |path|
+            path.split('/').last
+          end
+        end
+      end
+
+      def roles_path_from_config
+        rescue_and_raise_file_exception ReadConfigFileException,
+                                        DEFAULT_CONFIG_FILE, 'config file' do
+          File.readlines(DEFAULT_CONFIG_FILE).select do |line|
+            line =~ /roles_path/
+          end
+        end
+      end
+
+      def rescue_and_raise_file_exception(exception, path, type)
+        yield
+      rescue Errno::ENOENT, Errno::EACCES => e
+        logger.debug(e.backtrace)
+        exception_message = "Could not read Ansible #{type} "\
+                            "#{path} - #{e.message}"
+        raise exception.new(exception_message)
       end
     end
   end

--- a/test/unit/lib/foreman_ansible_core/roles_reader_test.rb
+++ b/test/unit/lib/foreman_ansible_core/roles_reader_test.rb
@@ -10,50 +10,84 @@ class RolesReaderTest < ActiveSupport::TestCase
     test 'detects commented roles_path' do
       expect_content_config ['#roles_path = thisiscommented!']
       assert_equal(ROLES_PATH,
-                   ForemanAnsibleCore::RolesReader.roles_path(CONFIG_PATH))
+                   ForemanAnsibleCore::RolesReader.roles_path)
     end
 
     test 'returns default path if no roles_path defined' do
       expect_content_config ['norolepath!']
       assert_equal(ROLES_PATH,
-                   ForemanAnsibleCore::RolesReader.roles_path(CONFIG_PATH))
+                   ForemanAnsibleCore::RolesReader.roles_path)
     end
 
     test 'returns roles_path if one is defined' do
       expect_content_config ['roles_path = /mycustom/ansibleroles/path']
       assert_equal('/mycustom/ansibleroles/path',
-                   ForemanAnsibleCore::RolesReader.roles_path(CONFIG_PATH))
+                   ForemanAnsibleCore::RolesReader.roles_path)
     end
   end
 
   describe '#list_roles' do
-    setup do
-      # Return a path without actually reading the config file to make tests
-      # pass even on hosts without Ansible installed
-      ForemanAnsibleCore::RolesReader.stubs(:roles_path).
-        returns('/etc/ansible/roles')
+    test 'reads roles from paths' do
+      expect_content_config ["roles_path = #{ROLES_PATH}"]
+      ForemanAnsibleCore::RolesReader.expects(:read_roles)
+                                     .with(ROLES_PATH)
+      ForemanAnsibleCore::RolesReader.list_roles
     end
 
-    test 'handles "No such file or dir" with exception' do
-      Dir.expects(:glob).with("#{ROLES_PATH}/*").raises(Errno::ENOENT)
-      ex = assert_raises(ForemanAnsibleCore::ReadConfigFileException) do
-        ForemanAnsibleCore::RolesReader.list_roles
+    test 'reads roles from paths' do
+      roles_paths = ['/mycustom/roles/path', '/another/path']
+      roles_paths.each do |path|
+        ForemanAnsibleCore::RolesReader.expects(:read_roles)
+                                       .with(path)
       end
-      assert_match(/Could not read Ansible config file/, ex.message)
+      expect_content_config ["roles_path = #{roles_paths.join(':')}"]
+      ForemanAnsibleCore::RolesReader.list_roles
     end
 
-    test 'raises error if the roles path is not readable' do
-      Dir.expects(:glob).with("#{ROLES_PATH}/*").raises(Errno::EACCES)
-      ex = assert_raises(ForemanAnsibleCore::ReadConfigFileException) do
-        ForemanAnsibleCore::RolesReader.list_roles
+    context 'with unreadable roles path' do
+      setup do
+        expect_content_config ["roles_path = #{ROLES_PATH}"]
       end
-      assert_match(/Could not read Ansible config file/, ex.message)
+
+      test 'handles "No such file or dir" with exception' do
+        Dir.expects(:glob).with("#{ROLES_PATH}/*").raises(Errno::ENOENT)
+        ex = assert_raises(ForemanAnsibleCore::ReadRolesException) do
+          ForemanAnsibleCore::RolesReader.list_roles
+        end
+        assert_match(/Could not read Ansible roles/, ex.message)
+      end
+
+      test 'raises error if the roles path is not readable' do
+        Dir.expects(:glob).with("#{ROLES_PATH}/*").raises(Errno::EACCES)
+        ex = assert_raises(ForemanAnsibleCore::ReadRolesException) do
+          ForemanAnsibleCore::RolesReader.list_roles
+        end
+        assert_match(/Could not read Ansible roles/, ex.message)
+      end
+    end
+
+    context 'with unreadable config' do
+      test 'handles "No such file or dir" with exception' do
+        File.expects(:readlines).with(CONFIG_PATH).raises(Errno::ENOENT)
+        ex = assert_raises(ForemanAnsibleCore::ReadConfigFileException) do
+          ForemanAnsibleCore::RolesReader.list_roles
+        end
+        assert_match(/Could not read Ansible config file/, ex.message)
+      end
+
+      test 'raises error if the roles path is not readable' do
+        File.expects(:readlines).with(CONFIG_PATH).raises(Errno::EACCES)
+        ex = assert_raises(ForemanAnsibleCore::ReadConfigFileException) do
+          ForemanAnsibleCore::RolesReader.list_roles
+        end
+        assert_match(/Could not read Ansible config file/, ex.message)
+      end
     end
   end
 
   private
 
   def expect_content_config(ansible_cfg_content)
-    File.expects(:readlines).with(CONFIG_PATH).returns(ansible_cfg_content)
+    ForemanAnsibleCore::RolesReader.expects(:roles_path_from_config).returns(ansible_cfg_content)
   end
 end


### PR DESCRIPTION
This allows importing from multiple paths, when 'roles_path' has multiple colon separated paths. 