### PR TITLE
Fixes #21008 - Improve button to run ansible roles

### DIFF
--- a/app/helpers/foreman_ansible/hosts_helper_extensions.rb
+++ b/app/helpers/foreman_ansible/hosts_helper_extensions.rb
@@ -15,7 +15,7 @@ module ForemanAnsible
 
     def ansible_roles_button(host)
       link_to(
-        icon_text('play', ' ' + _('Ansible roles'), :kind => 'fa'),
+        _('Run Ansible roles'),
         play_roles_host_path(:id => host.id),
         :id => :ansible_roles_button,
         :class => 'btn btn-default',


### PR DESCRIPTION
The button to run roles is now without an icon, but proper wording instead:
![gnome-shell-screenshot-k1oz6y](https://user-images.githubusercontent.com/7757/30900331-f3ae9e10-a363-11e7-8e76-3e81770c74ec.png)
