### PR TITLE
Fixes #21005 - Better wording for roles import button

### DIFF
--- a/app/helpers/foreman_ansible/ansible_roles_helper.rb
+++ b/app/helpers/foreman_ansible/ansible_roles_helper.rb
@@ -3,17 +3,24 @@ module ForemanAnsible
   module AnsibleRolesHelper
     def ansible_proxy_links(hash, classes = nil)
       links = SmartProxy.with_features('Ansible').map do |proxy|
-        display_link_if_authorized(_('Import from %s') % proxy.name,
+        display_link_if_authorized(_('From %s') % proxy.name,
                                    hash.merge(:proxy => proxy),
                                    :class => classes)
       end.flatten
-      links.unshift display_link_if_authorized(_('Import from Foreman host'),
+      host_text = if links.any?
+                    _('From Foreman host')
+                  else
+                    _('Import from Foreman host')
+                  end
+      links.unshift display_link_if_authorized(host_text,
                                                hash,
                                                :class => classes)
     end
 
     def ansible_proxy_import(hash)
-      select_action_button(_('Import'), {}, ansible_proxy_links(hash))
+      select_action_button(_('Import'),
+                           { :primary => true, :class => 'roles-import' },
+                           ansible_proxy_links(hash))
     end
 
     def import_time(role)


### PR DESCRIPTION
Changes the wording of the roles import button to the following wording when multiple sources for roles are available:

![gnome-shell-screenshot-wunr7y](https://user-images.githubusercontent.com/7757/31214564-035315b4-a9ac-11e7-8663-e353d28e76d2.png)

When only one is available it stays as is:

![gnome-shell-screenshot-tdsm7y](https://user-images.githubusercontent.com/7757/31214572-0e29ba42-a9ac-11e7-8040-dbf0bc98e13b.png)
 
_A change of `select_action_button` in core to allow those to be primary (blue) buttons is needed before this is ready_
