### PR TITLE
Fixes #22126 - Always show 'Play Roles' button for Hostgroups

### DIFF
--- a/app/models/concerns/foreman_ansible/has_many_ansible_roles.rb
+++ b/app/models/concerns/foreman_ansible/has_many_ansible_roles.rb
@@ -6,7 +6,9 @@ module ForemanAnsible
 
     included do
       def all_ansible_roles
-        (ansible_roles + inherited_ansible_roles).uniq
+        result = (ansible_roles + inherited_ansible_roles).uniq
+        result += host_ansible_roles if is_a? Hostgroup
+        result
       end
     end
   end

--- a/app/models/concerns/foreman_ansible/hostgroup_extensions.rb
+++ b/app/models/concerns/foreman_ansible/hostgroup_extensions.rb
@@ -14,6 +14,10 @@ module ForemanAnsible
           roles + hostgroup.ansible_roles
         end.uniq
       end
+
+      def host_ansible_roles
+        hosts.all.includes(:ansible_roles).flat_map(&:ansible_roles)
+      end
     end
   end
 end

--- a/app/views/foreman_ansible/ansible_roles/_hostgroup_ansible_roles_button.erb
+++ b/app/views/foreman_ansible/ansible_roles/_hostgroup_ansible_roles_button.erb
@@ -1,14 +1,13 @@
 <%=
-if hostgroup.all_ansible_roles.empty?
+  play_roles = if hostgroup.all_ansible_roles.empty?
+    "<a title='No Roles assigned' href=\"#\">#{_('Play Roles')}</a>".html_safe
+  else
+    display_link_if_authorized(_('Play Roles'),   hash_for_play_roles_hostgroup_path(:id => hostgroup),   :'data-no-turbolink' => true)
+  end
+
   action_buttons(
               display_link_if_authorized(_('Nest'),    hash_for_nest_hostgroup_path(:id => hostgroup)),
               display_link_if_authorized(_('Clone'),   hash_for_clone_hostgroup_path(:id => hostgroup)),
+              play_roles,
               display_delete_if_authorized(hash_for_hostgroup_path(:id => hostgroup).merge(:auth_object => hostgroup, :authorizer => authorizer), :data => { :confirm => warning_message(hostgroup) }))
-else
-  action_buttons(
-              display_link_if_authorized(_('Nest'),    hash_for_nest_hostgroup_path(:id => hostgroup)),
-              display_link_if_authorized(_('Clone'),   hash_for_clone_hostgroup_path(:id => hostgroup)),
-              display_link_if_authorized(_('Play Roles'),   hash_for_play_roles_hostgroup_path(:id => hostgroup),   :'data-no-turbolink' => true),
-              display_delete_if_authorized(hash_for_hostgroup_path(:id => hostgroup).merge(:auth_object => hostgroup, :authorizer => authorizer), :data => { :confirm => warning_message(hostgroup) }))
-end
 %>


### PR DESCRIPTION
This will always show the "Play Roles" button as an action for hostgroups listed.
If no roles are assigned a tooltip is now giving that hint:
![gnome-shell-screenshot-fpwedz](https://user-images.githubusercontent.com/7757/35100524-73c14552-fc5c-11e7-8ab6-c08e12bd6661.png)

If a role is assigned to either the hostgroup itself or any of the hosts assigned, there will be no tooltip and the link can be used to run the roles. 

Currently only roles assigned directly to the hostgroup are used for the run, this behavior needs to be changed, but is likely a bigger change. 