### PR TITLE
Fixes #22124 - Add report interval setting for Ansible

### DIFF
--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -72,6 +72,12 @@ class Setting
                  'foreman_params["host_parameter"] in the playbooks.'),
               true,
               N_('Top level Ansible variables')
+            ),
+	    set(
+              'ansible_interval',
+              N_('Timeout (in minutes) when hosts should have reported.'),
+              '30',
+              N_('Ansible report timeout')
             )
           ].compact.each do |s|
             create(s.update(:category => 'Setting::Ansible'))

--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -54,6 +54,7 @@ Foreman::Plugin.register :foreman_ansible do
   # For backwards compatiblity with 1.17
   if respond_to?(:register_report_scanner)
     register_report_scanner ForemanAnsible::AnsibleReportScanner
+    register_report_origin 'Ansible', 'ConfigReport'
   end
 end
 # rubocop:enable BlockLength


### PR DESCRIPTION
This adds the setting (`Setting[:ansible_interval]`) specifically for Ansible host reporting to allow a longer period to report back to Foreman until they are considered "out of sync".

Also see https://github.com/theforeman/foreman/pull/5221
