### PR TITLE
Fixes #22507 - Pass REX inputs as inventory variables

### DIFF
--- a/app/models/foreman_ansible/ansible_provider.rb
+++ b/app/models/foreman_ansible/ansible_provider.rb
@@ -14,8 +14,9 @@ if defined? ForemanRemoteExecution
 
         def proxy_command_options(template_invocation, host)
           super(template_invocation, host).merge(
-            'ansible_inventory' =>
-              ::ForemanAnsible::InventoryCreator.new([host]).to_hash.to_json
+            'ansible_inventory' => ::ForemanAnsible::InventoryCreator.new(
+              [host], template_invocation
+            ).to_hash.to_json
           )
         end
       end

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -23,5 +23,7 @@ def assert_job_invocation_is_ok(response, targets)
   assert_response :created
 end
 plugin_factories_path = File.join(File.dirname(__FILE__), 'factories')
+rex_factories_path = "#{ForemanRemoteExecution::Engine.root}/test/factories"
+FactoryBot.definition_file_paths << rex_factories_path
 FactoryBot.definition_file_paths << plugin_factories_path
 FactoryBot.reload


### PR DESCRIPTION
To use inputs in JobTemplates, users would have to use ERB <%=
input('myinput') %> so that the input is actually parsed by Foreman.
Since Ansible users (most likely!) don't want to migrate their Ansible
playbooks which contain Ansible variables to ERB.
Ansible variables are substituted by the variables coming from the
inventory. Therefore, it's possible to simply just send the
resolved inputs to Ansible through the inventory, and Ansible will
substitute the 'variables'.