### PR TITLE
Fixes #22626 - hide stdout and stderr

### DIFF
--- a/app/helpers/foreman_ansible/ansible_reports_helper.rb
+++ b/app/helpers/foreman_ansible/ansible_reports_helper.rb
@@ -8,6 +8,7 @@ module ForemanAnsible
     ].freeze
     ANSIBLE_HIDDEN_KEYS = %w[
       invocation module_args results
+      stdout stderr
     ].freeze
 
     def module_name(log)


### PR DESCRIPTION
note that we still display stdout_lines and stderr_lines which are properly formatted, since they are arrays, stdout and stderr are just long strings that makes the page extremely wide