### PR TITLE
Fixes #22634 - Reuse remote execution settings

### DIFF
--- a/app/models/foreman_ansible/ansible_provider.rb
+++ b/app/models/foreman_ansible/ansible_provider.rb
@@ -4,12 +4,16 @@ if defined? ForemanRemoteExecution
     # Read the source of other RemoteExecution providers for more.
     class AnsibleProvider < RemoteExecutionProvider
       class << self
-        def humanized_name
-          'Ansible'
+        def ssh_password(host)
+          host_setting(host, :remote_execution_ssh_password)
         end
 
-        def host_setting(host, setting)
-          host.params[setting.to_s] || Setting[setting]
+        def ssh_key_passphrase(host)
+          host_setting(host, :remote_execution_ssh_key_passphrase)
+        end
+
+        def humanized_name
+          'Ansible'
         end
 
         def proxy_command_options(template_invocation, host)

--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -1,6 +1,5 @@
 class Setting
   # Provide settings related with Ansible
-  # rubocop:disable ClassLength
   class Ansible < ::Setting
     class << self
       # It would be more disadvantages than advantages to split up
@@ -13,39 +12,6 @@ class Setting
         return unless super
         transaction do
           [
-            set(
-              'ansible_port',
-              N_('Use this port to connect to hosts '\
-                 'and run Ansible. You can override this on hosts '\
-                 'by adding a parameter "ansible_port"'),
-              22,
-              N_('Port')
-            ),
-            set(
-              'ansible_user',
-              N_('Foreman will try to connect to hosts as this user by '\
-                 'default when running Ansible playbooks. You can '\
-                 'override this on hosts by adding a parameter '\
-                 '"ansible_user"'),
-              'root',
-              N_('User')
-            ),
-            set(
-              'ansible_become',
-              N_('Foreman will use the sudo command to run roles on hosts '\
-                 'You can override this on hosts by adding a parameter '\
-                 '"ansible_become"'),
-              true,
-              N_('Become')
-            ),
-            set(
-              'ansible_ssh_pass',
-              N_('Use this password by default when running Ansible '\
-                 'playbooks. You can override this on hosts '\
-                 'by adding a parameter "ansible_ssh_pass"'),
-              'ansible',
-              N_('Password')
-            ),
             set(
               'ansible_ssh_private_key_file',
               N_('Use this to supply a path to an SSH Private Key '\
@@ -122,5 +88,4 @@ class Setting
       end
     end
   end
-  # rubocop:enable ClassLength
 end


### PR DESCRIPTION
effective_user, remote_execution_ssh_passphrase,
remote_execution_ssh_user, remote_execution_ssh_port should substitute
the role that 'ansible_become', 'ansible_ssh_pass', 'ansible_user',
'ansible_port' had in previous versions. The variables should still be
overridable at the host params level, for example:
host_params['ansible_user'] overrides the 'remote_execution_ssh_user'
setting.

cc @ares @adamruzicka