### PR TITLE
Fixes #22643 - Config strings may not be displayed

### DIFF
--- a/app/helpers/foreman_ansible/ansible_reports_helper.rb
+++ b/app/helpers/foreman_ansible/ansible_reports_helper.rb
@@ -23,7 +23,9 @@ module ForemanAnsible
       invocations << parsed_log.delete('invocation')
       results = parsed_log.delete('results')
       invocations << results
-      invocations = invocations.compact.flatten.map { |ih| remove_keys(ih) }
+      invocations = invocations.compact.flatten.map do |ih|
+        ih.is_a?(Hash) ? remove_keys(ih) : ih
+      end
       pretty_print_hash invocations
     end
 

--- a/test/unit/helpers/ansible_reports_helper_test.rb
+++ b/test/unit/helpers/ansible_reports_helper_test.rb
@@ -1,0 +1,46 @@
+require 'test_plugin_helper'
+
+class AnsibleReportsHelperTest < ActiveSupport::TestCase
+  include ForemanAnsible::AnsibleReportsHelper
+  include ActionView::Helpers::TagHelper
+
+  test 'is able to print a string instead of a hash' do
+    log_value = <<-ANSIBLELOG.strip_heredoc
+  {"_ansible_parsed": true, "_ansible_no_log": false, "changed": false, "results": ["ntp-4.2.8p10-3.fc27.x86_64 providing ntp is already installed"], "rc": 0, "invocation": {"module_args": {"allow_downgrade": false, "name": ["ntp"], "list": null, "disable_gpg_check": false, "conf_file": null, "install_repoquery": true, "state": "installed", "disablerepo": null, "update_cache": false, "enablerepo": null, "exclude": null, "security": false, "validate_certs": true, "installroot": "/", "skip_broken": false}}, "msg": ""}
+ANSIBLELOG
+    message = FactoryBot.build(:message)
+    message.value = log_value
+    log = FactoryBot.build(:log)
+    log.message = message
+    assert_match(
+      /ntp-4.2.8p10-3.fc27.x86_64 providing ntp is already installed/,
+      module_args(log)
+    )
+  end
+
+  test 'pretty print is able to print a hash' do
+    hash = {
+      'allow_downgrade' => false,
+      'name' => ['ntp'],
+      'list' => nil,
+      'disable_gpg_check' => false,
+      'conf_file' => nil,
+      'install_repoquery' => true,
+      'state' => 'installed',
+      'disablerepo' => nil,
+      'update_cache' => false,
+      'enablerepo' => nil,
+      'exclude' => nil,
+      'security' => false,
+      'validate_certs' => true,
+      'installroot' => '/',
+      'skip_broken' => false
+    }
+    assert_equal(
+      hash,
+      remove_keys(
+        hash
+      )
+    )
+  end
+end


### PR DESCRIPTION
For example, this is an example of such a report:

 "module_args": "allow_downgrade": false, "name": [ "ntp" ], "list":
 null, "disable_gpg_check": false, "conf_file": null,
 "install_repoquery": true, "state": "installed", "disablerepo": null,
 "update_cache": false, "enablerepo": null, "exclude": null, "security":
 false, "validate_certs": true, "installroot": "/", "skip_broken": false
 "ntp-4.2.8p10-3.fc27.x86_64 providing ntp is already installed"

Everything is in the "module_args" hash, but the text
"ntp-4.2.8p10-3.fc27.x86_64 providing ntp is already installed" isn't.
The method_args method in the ansible_reports helper does not deal with
this case & the pages fails to render with a 500