### PR TITLE
Refs #22125 - Use react-json-tree for report json rendering

### DIFF
--- a/.bablerc
+++ b/.bablerc
@@ -1,0 +1,9 @@
+{
+  "presets": ["env", "react"],
+  "plugins": [
+    "transform-class-properties",
+    "transform-object-rest-spread",
+    "transform-object-assign",
+    "lodash"
+  ]
+}

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+# Ignore all files except webpack directory
+**/*.js
+!webpack/**/*.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,49 @@
+{
+  "root": true,
+  "extends": "airbnb-base",
+  "plugins": [
+    "react"
+  ],
+  "env": {
+    "browser": true,
+    "es6": true,
+    "node": true,
+    "jasmine": true,
+    "jest": true
+  },
+  "globals": {
+    "document": false,
+    "escape": false,
+    "navigator": false,
+    "unescape": false,
+    "window": false,
+    "$": true,
+    "_": true,
+    "__": true
+  },
+  "parser": "babel-eslint",
+  "rules": {
+    "react/jsx-uses-vars": "error",
+    "react/jsx-uses-react": "error",
+    "no-unused-vars": [
+      "error",
+      {
+        "vars": "all",
+        "args": "none"
+      }
+    ],
+    "no-underscore-dangle": "off",
+    "no-use-before-define": "off",
+    "import/prefer-default-export": "off",
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        // Allow importing devDependencies like @storybook
+        "devDependencies": true
+      }
+    ],
+    // Import rules off for now due to HoundCI issue
+    "import/no-unresolved": "off",
+    "import/extensions": "off"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ locale/*/*.po.time_stamp
 locale/*/*.pox
 locale/*/LC_MESSAGES
 Gemfile.lock
+node_modules

--- a/app/assets/stylesheets/foreman_ansible/foreman-ansible.css
+++ b/app/assets/stylesheets/foreman_ansible/foreman-ansible.css
@@ -1,0 +1,3 @@
+.report-json-viewer * {
+  background: transparent !important;
+}

--- a/app/views/foreman_ansible/config_reports/_ansible.html.erb
+++ b/app/views/foreman_ansible/config_reports/_ansible.html.erb
@@ -1,3 +1,6 @@
+<%= webpacked_plugins_js_for :foreman_ansible %>
+<%= stylesheet 'foreman_ansible/foreman-ansible' %>
+
 <table id='report_log' class="<%= table_css_classes %>">
   <thead>
     <tr>
@@ -11,8 +14,8 @@
     <% logs.each do |log| %>
       <tr>
         <td><span <%= report_tag log.level %>><%= h log.level %></span></td>
-        <td><%= h module_name(log) %></td>
-        <td><%= h module_args(log) %></td>
+        <td><%= ansible_module_name(log) %></td>
+        <td><%= ansible_module_args(log) %></td>
         <td><%= ansible_module_message(log) %></td>
       </tr>
     <% end %>

--- a/lib/foreman_ansible/engine.rb
+++ b/lib/foreman_ansible/engine.rb
@@ -56,7 +56,8 @@ module ForemanAnsible
     initializer 'foreman_ansible.configure_assets', :group => :assets do
       SETTINGS[:foreman_ansible] = {
         :assets => {
-          :precompile => ['foreman_ansible/Ansible.png']
+          :precompile => ['foreman_ansible/Ansible.png',
+                          'foreman_ansible/foreman-ansible.css']
         }
       }
     end

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "foreman_ansible",
+  "version": "1.0.0",
+  "description": "[![Code Climate](https://codeclimate.com/github/theforeman/foreman_ansible/badges/gpa.svg)](https://codeclimate.com/github/theforeman/foreman_ansible) [![Gem Version](https://badge.fury.io/rb/foreman_ansible.svg)](https://badge.fury.io/rb/foreman_ansible) [![GPL License](https://img.shields.io/github/license/theforeman/foreman_ansible.svg)](https://github.com/theforeman/foreman_ansible/blob/master/LICENSE)",
+  "main": "index.js",
+  "directories": {
+    "test": "test"
+  },
+  "dependencies": {
+    "react-json-tree": "^0.11.0"
+  },
+  "devDependencies": {
+    "babel-eslint": "^8.2.1",
+    "babel-preset-env": "^1.6.0",
+    "babel-preset-react": "^6.24.1",
+    "babel-plugin-lodash": "^3.3.2",
+    "babel-plugin-transform-object-assign": "^6.22.0",
+    "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "eslint": "^4.18.1",
+    "eslint-config-airbnb": "^16.0.0",
+    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-jest": "^21.2.0",
+    "eslint-plugin-jsx-a11y": "^6.0.2",
+    "eslint-plugin-react": "^7.4.0"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bastilian/foreman_ansible.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/bastilian/foreman_ansible/issues"
+  },
+  "homepage": "https://github.com/bastilian/foreman_ansible#readme"
+}

--- a/test/unit/helpers/ansible_reports_helper_test.rb
+++ b/test/unit/helpers/ansible_reports_helper_test.rb
@@ -14,7 +14,7 @@ ANSIBLELOG
     log.message = message
     assert_match(
       /ntp-4.2.8p10-3.fc27.x86_64 providing ntp is already installed/,
-      module_args(log)
+      module_invocations(parsed_message_json(log)).to_s
     )
   end
 

--- a/webpack/components/ReportJsonViewer.js
+++ b/webpack/components/ReportJsonViewer.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import JSONTree from 'react-json-tree';
+
+const theme = {
+  scheme: 'foreman',
+  backgroundColor: 'rgba(0, 0, 0, 255)',
+  base00: 'rgba(0, 0, 0, 0)',
+};
+
+class ReportJsonViewer extends React.Component {
+  render() {
+    return <div className="report-json-viewer">
+      <JSONTree data={this.props.data} hideRoot theme={theme} />
+    </div>;
+  }
+}
+export default ReportJsonViewer;

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -1,0 +1,4 @@
+import componentRegistry from 'foremanReact/components/componentRegistry';
+import ReportJsonViewer from './components/ReportJsonViewer';
+
+componentRegistry.register({ name: 'ReportJsonViewer', type: ReportJsonViewer });


### PR DESCRIPTION
This implements a React component, which is based on [react-jsontree](https://www.npmjs.com/package/react-json-tree), to display JSON of ansible reports nicely in a tree that can be expanded and collapsed at will:

The styling still needs some tweaks to integrate better into Foreman, but it's already better than what is at the moment:

![gnome-shell-screenshot-m5ajez](https://user-images.githubusercontent.com/7757/36543483-3062362e-17e4-11e8-8e99-c41f3f0de25b.png)
