### PR TITLE
Use proper api host name to allow TLS mutual auth

### DIFF
--- a/app/services/foreman_ansible/insights_plan_runner.rb
+++ b/app/services/foreman_ansible/insights_plan_runner.rb
@@ -27,10 +27,8 @@ module ForemanAnsible
     # Fetches the playbook from the Red Hat Insights API
     def playbook
       resource = RestClient::Resource.new(
-        'https://api.access.redhat.com/r/insights/'\
-        "v3/maintenance/#{@plan_id}/playbook",
-        get_ssl_options_for_org(@organization, nil).
-        merge(:verify_ssl => OpenSSL::SSL::VERIFY_NONE)
+        "#{insights_api_host}/r/insights/v3/maintenance/#{@plan_id}/playbook",
+        get_ssl_options_for_org(@organization, nil)
       )
       response = resource.get
       YAML.safe_load(response.body)


### PR DESCRIPTION
Removed hard coded (and incorrect)  Insights API hostname.
API requests must be made against "cert-api.access.redhat.com" and not "api.access.redhat.com".
The former is configured to accept RHSM manifest certificates for authentication, which is the expected production authentication method, with mutual tls verification enabled.
Reading the value of the API  from a config file also allows this plugin to share configuration with the Insights plugin.

The change depends on this change in Insights plugin : https://github.com/redhataccess/foreman-plugin/commit/4a69522e1d29a60bb49aa844826b46e4176e7880