### PR TITLE
Fixes #22774 -  ssh_private_key_path setting does not show up

### DIFF
--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -10,6 +10,7 @@ class Setting
       # rubocop:disable BlockLength
       def load_defaults
         return unless super
+        Setting::BLANK_ATTRS.push('ansible_ssh_private_key_file')
         transaction do
           [
             set(
@@ -77,7 +78,6 @@ class Setting
             create(s.update(:category => 'Setting::Ansible'))
           end
         end
-        Setting::BLANK_ATTRS.push('ansible_ssh_private_key_file')
         true
       end
       # rubocop:enable AbcSize


### PR DESCRIPTION
The setting to set the SSH key path does not show up by default. This
makes foreman_ansible set an option the inventory
'ansible_ssh_private_key_path: nil' which makes the path always default
to `/usr/share/foreman-proxy/.ssh/id_rsa`. This is problematic because
the key setup by REX by default will be at
`/usr/share/foreman-proxy/.ssh/id_rsa_foreman_proxy`, and besides, the
user has no way of configuring this.

This fix should make it into 1.4.7 and the next 2.0 version of Ansible.