### PR TITLE
Fixes #22784 - Documentation button for roles

### DIFF
--- a/app/helpers/foreman_ansible/ansible_plugin_helper.rb
+++ b/app/helpers/foreman_ansible/ansible_plugin_helper.rb
@@ -2,7 +2,9 @@ module ForemanAnsible
   # General helper for foreman_ansible
   module AnsiblePluginHelper
     def ansible_doc_url
-      'http://theforeman.org/plugins/foreman_ansible/1.x/index.html'
+      major_version = ::ForemanAnsible::VERSION.split('.')[0]
+      'https://theforeman.org/plugins/foreman_ansible/'\
+        "#{major_version}.x/index.html"
     end
   end
 end

--- a/app/views/ansible_roles/index.html.erb
+++ b/app/views/ansible_roles/index.html.erb
@@ -1,6 +1,7 @@
 <% title _("Ansible Roles") %>
 
-<% title_actions ansible_proxy_import(hash_for_import_ansible_roles_path) %>
+<% title_actions ansible_proxy_import(hash_for_import_ansible_roles_path),
+  documentation_button('#4.1ImportingRoles', :root_url => ansible_doc_url) %>
 
 <table class="<%= table_css_classes 'table-fixed' %>">
   <thead>


### PR DESCRIPTION
Similar to other pages in Foreman, the roles table should show some
documentation button pointing to the Ansible manual. This link points
exactly to the section showing how to import a role.