### PR TITLE
Fixes #22896 - Fall back to REX private key

### DIFF
--- a/app/services/foreman_ansible/inventory_creator.rb
+++ b/app/services/foreman_ansible/inventory_creator.rb
@@ -94,6 +94,7 @@ module ForemanAnsible
         'ansible_become' => @template_invocation.effective_user,
         'ansible_user' => host_setting(host, 'remote_execution_ssh_user'),
         'ansible_ssh_pass' => rex_ssh_password(host),
+        'ansible_ssh_private_key_file' => ansible_or_rex_ssh_private_key(host),
         'ansible_port' => host_setting(host, 'remote_execution_ssh_port')
       }
       # Backward compatibility for Ansible 1.x
@@ -113,6 +114,15 @@ module ForemanAnsible
     def rex_ssh_password(host)
       @template_invocation.job_invocation.password ||
         host_setting(host, 'remote_execution_ssh_password')
+    end
+
+    def ansible_or_rex_ssh_private_key(host)
+      ansible_private_file = host_setting(host, 'ansible_ssh_private_key_file')
+      if !ansible_private_file.empty?
+        ansible_private_file
+      else
+        ForemanRemoteExecutionCore.settings[:ssh_identity_key_file]
+      end
     end
 
     private

--- a/test/unit/services/inventory_creator_test.rb
+++ b/test/unit/services/inventory_creator_test.rb
@@ -62,6 +62,8 @@ module ForemanAnsible
                    connection_params['ansible_user']
       refute_equal Setting['remote_execution_ssh_port'],
                    connection_params['ansible_port']
+      assert_equal ForemanRemoteExecutionCore.settings[:ssh_identity_key_file],
+                   connection_params['ansible_ssh_private_key_file']
       assert_equal extra_options['ansible_port'],
                    connection_params['ansible_port']
       assert_equal Setting['remote_execution_ssh_password'],
@@ -75,6 +77,22 @@ module ForemanAnsible
                                                        @template_invocation)
       assert_equal(@template_invocation.job_invocation.password,
                    inventory.rex_ssh_password(@host))
+    end
+
+    test 'ssh private key is passed when available' do
+      host = FactoryBot.build(:host)
+      path_to_key = '/path/to/private/key'
+      inventory = ForemanAnsible::InventoryCreator.new(host,
+                                                       @template_invocation)
+      host.params.expects(:[]).with('ansible_ssh_private_key_file')
+          .returns(path_to_key)
+      host.params.expects(:[]).with('remote_execution_ssh_user')
+          .returns('root')
+      host.params.expects(:[]).with('remote_execution_ssh_port')
+          .returns('2222')
+      connection_params = inventory.connection_params(host)
+      assert_equal path_to_key,
+                   connection_params['ansible_ssh_private_key_file']
     end
 
     test 'template invocation inputs are sent as Ansible variables' do


### PR DESCRIPTION
With this Ansible Jobs will fall back on REXs private key value.