### PR TITLE
 Fixes #23047 - PUT instead of POST for import/obsolete API endpoints

### DIFF
--- a/app/controllers/api/v2/ansible_roles_controller.rb
+++ b/app/controllers/api/v2/ansible_roles_controller.rb
@@ -29,13 +29,13 @@ module Api
         process_response @ansible_role.destroy
       end
 
-      api :POST, '/ansible_roles/import', N_('Import Ansible roles')
+      api :PUT, '/ansible_roles/import', N_('Import Ansible roles')
       param :proxy_id, :identifier, N_('Smart Proxy to import from')
       def import
         @imported = @importer.import!
       end
 
-      api :POST, '/ansible_roles/obsolete', N_('Obsolete Ansible roles')
+      api :PUT, '/ansible_roles/obsolete', N_('Obsolete Ansible roles')
       param :proxy_id, :identifier, N_('Smart Proxy to import from')
       def obsolete
         @obsoleted = @importer.obsolete!

--- a/test/functional/api/v2/ansible_roles_controller_test.rb
+++ b/test/functional/api/v2/ansible_roles_controller_test.rb
@@ -22,6 +22,18 @@ module Api
         assert_response :ok
         refute AnsibleRole.exists?(@role.id)
       end
+
+      test 'should import' do
+        put :import,
+            :session => set_session_user
+        assert_response :success
+      end
+
+      test 'should obsolete' do
+        put :obsolete,
+            :session => set_session_user
+        assert_response :success
+      end
     end
   end
 end


### PR DESCRIPTION
It comes with another commit to avoid any merge conflicts for testing this PR.