### PR TITLE
Fixes #23114 - Add setting to disable out of sync

### DIFF
--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -79,6 +79,12 @@ class Setting
               N_('Timeout (in minutes) when hosts should have reported.'),
               '30',
               N_('Ansible report timeout')
+            ),
+            set(
+              'ansible_out_of_sync_disabled',
+              N_("Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval") % 'Ansible',
+              false,
+              N_('%s out of sync disabled') % 'Ansible'
             )
           ].compact.each do |s|
             create(s.update(:category => 'Setting::Ansible'))


### PR DESCRIPTION
This PR requires https://github.com/theforeman/foreman/pull/5401 to allow disabling out of sync for Ansible host reports.