### PR TITLE
Refs #23205 - Fix renaming migration for empty and/or unseeded DBs

### DIFF
--- a/db/migrate/20180410125416_rename_ansible_job_categories.rb
+++ b/db/migrate/20180410125416_rename_ansible_job_categories.rb
@@ -1,5 +1,9 @@
 class RenameAnsibleJobCategories < ActiveRecord::Migration[5.1]
   def up
+    unless User.unscoped.find_by_login(User::ANONYMOUS_ADMIN)
+      puts "No ANONYMOUS_ADMIN found. Skipping renaming Ansbible jobs"
+      return
+    end
     User.as_anonymous_admin do
       updated_templates = ['Power Action - Ansible Default',
                            'Puppet Run Once - Ansible Default']
@@ -9,9 +13,10 @@ class RenameAnsibleJobCategories < ActiveRecord::Migration[5.1]
         job_template.save!
       end
 
-      service_template = JobTemplate.where(:name => 'Service Action - Ansible Default').first
-      service_template.job_category = 'Ansible Services'
-      service_template.save!
+      if service_template = JobTemplate.where(:name => 'Service Action - Ansible Default').first
+        service_template.job_category = 'Ansible Services'
+        service_template.save!
+      end
     end
   end
 end


### PR DESCRIPTION
This will prevent the migration from failing when the database is unseeded and there are no job templates that need to be updated.