### PR TITLE
Refs #23205 - fix the migration on existing setups

### DIFF
--- a/db/migrate/20180410125416_rename_ansible_job_categories.rb
+++ b/db/migrate/20180410125416_rename_ansible_job_categories.rb
@@ -7,21 +7,23 @@ class RenameAnsibleJobCategories < ActiveRecord::Migration[5.1]
     User.as_anonymous_admin do
       updated_templates = ['Power Action - Ansible Default',
                            'Puppet Run Once - Ansible Default']
-      job_templates = JobTemplate.without_auditing.where(
-        :name => updated_templates
-      ).all
-      job_templates.each do |job_template|
-        next if job_template.job_category =~ /^Ansible/
-        job_template.job_category = "Ansible #{job_template.job_category}"
-        job_template.save_without_auditing
-      end
-
-      service_template = JobTemplate.where(
-        :name => 'Service Action - Ansible Default'
-      ).first
-      if service_template.present?
-        service_template.job_category = 'Ansible Services'
-        service_template.save_without_auditing
+      JobTemplate.without_auditing do
+        job_templates = JobTemplate.where(
+          :name => updated_templates
+        ).all
+        job_templates.each do |job_template|
+          next if job_template.job_category =~ /^Ansible/
+          job_template.job_category = "Ansible #{job_template.job_category}"
+          job_template.save_without_auditing
+        end
+  
+        service_template = JobTemplate.where(
+          :name => 'Service Action - Ansible Default'
+        ).first
+        if service_template.present?
+          service_template.job_category = 'Ansible Services'
+          service_template.save_without_auditing
+        end
       end
     end
   end


### PR DESCRIPTION
The migration fails because `without_auditing` is not a named scope but actually required a block in which auditing is ignored.