### PR TITLE
Pass string to webpacked_assets

### DIFF
--- a/app/views/foreman_ansible/config_reports/_ansible.html.erb
+++ b/app/views/foreman_ansible/config_reports/_ansible.html.erb
@@ -1,4 +1,4 @@
-<%= webpacked_plugins_js_for :foreman_ansible %>
+<%= javascript_include_tag *webpack_asset_paths('foreman_ansible', :extension => 'js'), "data-turbolinks-track" => true, 'defer' => 'defer' %>
 <%= stylesheet 'foreman_ansible/foreman-ansible' %>
 
 <table id='report_log' class="<%= table_css_classes %>">


### PR DESCRIPTION
The reports page is not loading the Foreman webpack chunk because it's a
symbol. It needs to be a string to be loaded properly