### PR TITLE
Fixes #23653 - Do not rename interfaces names

### DIFF
--- a/app/services/foreman_ansible/fact_parser.rb
+++ b/app/services/foreman_ansible/fact_parser.rb
@@ -54,11 +54,14 @@ module ForemanAnsible
       end
     end
 
-    def get_facts_for_interface(interface)
-      interface.tr!('-', '_') # virbr1-nic -> virbr1_nic
+    def get_facts_for_interface(iface_name)
+      interface = iface_name.tr('-', '_') # virbr1-nic -> virbr1_nic
       interface_facts = facts[:"ansible_#{interface}"]
-      ipaddress = ip_from_interface(interface)
-      HashWithIndifferentAccess[interface_facts.merge(:ipaddress => ipaddress)]
+      iface_facts = HashWithIndifferentAccess[interface_facts.merge(
+        :ipaddress => ip_from_interface(interface)
+      )]
+      logger.debug { "Interface #{interface} facts: #{iface_facts.inspect}" }
+      iface_facts
     end
 
     def ipmi_interface; end


### PR DESCRIPTION
It is antipattern to change non-local variable passed as a parameter.
This commit bring the same behaviour used in the puppet_fact_parser
and also adds the same debug logging.

Signed-off-by: Maksim Malchuk <maksim.malchuk@gmail.com>
(cherry picked from commit f780f2ec6dce45d4130e002909e8b1a30c03ef68)