### PR TITLE
Fixes #23715 - Verify OS facts before submitting them

### DIFF
--- a/app/services/foreman_ansible/operating_system_parser.rb
+++ b/app/services/foreman_ansible/operating_system_parser.rb
@@ -1,0 +1,73 @@
+module ForemanAnsible
+  # Methods to parse facts related to the OS
+  module OperatingSystemParser
+    def operatingsystem
+      args = { :name => os_name, :major => os_major, :minor => os_minor }
+      return @local_os if local_os(args).present?
+      return @new_os if new_os(args).present?
+      logger.debug do
+        'Ansible facts parser: No OS could be created with '\
+        "os_name='#{os_name}' os_major='#{os_major}' "\
+        "os_minor='#{os_minor}': "\
+        "#{@new_os.errors if @new_os.present?}"
+      end
+      nil
+    end
+
+    def local_os(args)
+      @local_os = Operatingsystem.where(args).first
+    end
+
+    def new_os(args)
+      return @new_os if @new_os.present?
+      @new_os = Operatingsystem.new(args.merge(:description => os_description))
+      @new_os if @new_os.valid? && @new_os.save
+    end
+
+    def os_name
+      facts[:ansible_distribution] ||
+        facts[:ansible_lsb] && facts[:ansible_lsb]['id']
+    end
+
+    def debian_os_major_sid
+      case facts[:ansible_distribution_major_version]
+      when /wheezy/i
+        '7'
+      when /jessie/i
+        '8'
+      when /stretch/i
+        '9'
+      when /buster/i
+        '10'
+      end
+    end
+
+    # rubocop:disable AbcSize, CyclomaticComplexity, PerceivedComplexity
+    def os_major
+      if os_name == 'Debian' &&
+         facts[:ansible_distribution_major_version][%r{\/sid}i]
+        debian_os_major_sid
+      else
+        facts[:ansible_distribution_major_version] ||
+          facts[:ansible_lsb] && facts[:ansible_lsb]['major_release'] ||
+          (facts[:version].split('R')[0] if os_name == 'junos')
+      end
+    end
+    # rubocop:enable AbcSize, CyclomaticComplexity, PerceivedComplexity
+
+    def os_release
+      facts[:ansible_distribution_version] ||
+        facts[:ansible_lsb] && facts[:ansible_lsb]['release']
+    end
+
+    def os_minor
+      _, minor = (os_release.split('.') unless os_release.nil?) ||
+                 (facts[:version].split('R') if os_name == 'junos')
+      minor || ''
+    end
+
+    def os_description
+      facts[:ansible_lsb] && facts[:ansible_lsb]['description']
+    end
+  end
+end

--- a/test/unit/services/fact_parser_test.rb
+++ b/test/unit/services/fact_parser_test.rb
@@ -38,6 +38,15 @@ module ForemanAnsible
       @facts_parser.operatingsystem
     end
 
+    test 'does not fail if facts are not enough to create OS' do
+      @facts_parser.expects(:os_name).returns('fakeos').at_least_once
+      @facts_parser.expects(:os_major).returns('').at_least_once
+      @facts_parser.expects(:os_minor).returns('').at_least_once
+      @facts_parser.expects(:os_description).returns('').at_least_once
+      Operatingsystem.any_instance.expects(:valid?).returns(false)
+      assert_nil @facts_parser.operatingsystem
+    end
+
     private
 
     def expect_where(model, fact_name)


### PR DESCRIPTION
Before this PR, some roles would collect only a few facts from the
machine, but not 'os_major' 'os_minor' 'os_name', so these facts were
empty. The entire POST request would fail with a 500 in that case, as we
were submitting Operatingsystem.create! without any facts to create it.