### PR TITLE
Change Plugin Manual link to direct to parent page

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Reporting and facts import from Ansible to Foreman.
 
 * Main website: [theforeman.org](http://theforeman.org)
-* Plugin manual: [foreman_ansible manual](http://theforeman.org/plugins/foreman_ansible/1.x/index.html)
+* Plugin manual: [foreman_ansible manual](http://theforeman.org/plugins/foreman_ansible)
 * ServerFault tag: [Foreman](http://serverfault.com/questions/tagged/foreman)
 * Issues: [foreman ansible on Redmine](http://projects.theforeman.org/projects/ansible/issues)
 * Community and support: [#theforeman](https://kiwiirc.com/client/irc.freenode.net/?#theforeman) for general support, [#theforeman-dev](https://kiwiirc.com/client/irc.freenode.net/?#theforeman-dev) for development chat in [Freenode](irc.freenode.net)


### PR DESCRIPTION
After spending a lot of time setting up ansible/foreman, many times I clicked on the plugin documentation.  However, it links to the original 1x version.  This could confuse new users.  Made change to documentation to direct users to parent page of the document, so users can see what the latest version is and choose it.