### PR TITLE
Fixes #23731 - Add host key to known_hosts if not found

### DIFF
--- a/foreman_ansible_core.gemspec
+++ b/foreman_ansible_core.gemspec
@@ -20,4 +20,5 @@ DESC
   s.add_development_dependency 'rubocop', '~> 0.52'
   s.add_dependency 'foreman-tasks-core', '~> 0.1'
   s.add_dependency 'foreman_remote_execution_core', '~> 1.1'
+  s.add_dependency 'net-ssh', '~> 4.0'
 end


### PR DESCRIPTION
This ensures we are *always* able to run Ansible on remote hosts,
without compromising security too much (for example, disabling host key
verification).

1st: We look into all known hosts_files for the hosts in the inventory.
     If it's found, we just use it to prevent MITM attacks

2nd: If the host key isn't found, we fetch it with ssh-keyscan, and then
     add it to all known_hosts files.