### PR TITLE
Fixes #23879 - Disable Ansible Callback when running commands

### DIFF
--- a/app/models/foreman_ansible/ansible_provider.rb
+++ b/app/models/foreman_ansible/ansible_provider.rb
@@ -20,8 +20,18 @@ if defined? ForemanRemoteExecution
           super(template_invocation, host).merge(
             'ansible_inventory' => ::ForemanAnsible::InventoryCreator.new(
               [host], template_invocation
-            ).to_hash.to_json
+            ).to_hash.to_json,
+            :remote_execution_command => ansible_command?(
+              template_invocation.template
+            )
           )
+        end
+
+        private
+
+        def ansible_command?(template)
+          template.remote_execution_features.
+            where(:label => 'ansible_run_host').empty?
         end
       end
     end

--- a/test/unit/ansible_provider_test.rb
+++ b/test/unit/ansible_provider_test.rb
@@ -1,0 +1,35 @@
+require 'test_plugin_helper'
+
+# Tests for the behavior of Ansible Role, currently only validations
+class AnsibleProviderTest < ActiveSupport::TestCase
+  describe '.proxy_command_options' do
+    let(:template_invocation) { FactoryBot.create(:template_invocation) }
+    let(:dummyhost) { FactoryBot.create(:host) }
+
+    it 'adds an ansible inventory' do
+      assert command_options['ansible_inventory']
+    end
+
+    context 'when it is not using the ansible_run_host feature' do
+      it 'sets enables :remote_execution_command to true' do
+        assert command_options[:remote_execution_command]
+      end
+    end
+
+    context 'when it is using the ansible_run_host feature' do
+      let(:rex_feature) do
+        RemoteExecutionFeature.where(:label => 'ansible_run_host').first
+      end
+
+      it 'has remote_execution_command false' do
+        template_invocation.template.remote_execution_features << rex_feature
+        assert_not command_options[:remote_execution_command]
+      end
+    end
+
+    def command_options
+      ForemanAnsible::AnsibleProvider.
+        proxy_command_options(template_invocation, dummyhost)
+    end
+  end
+end

--- a/test/unit/lib/foreman_ansible_core/command_creator_test.rb
+++ b/test/unit/lib/foreman_ansible_core/command_creator_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+
+class CommandCreatorTest < ActiveSupport::TestCase
+  let(:inventory_file) { 'test_inventory' }
+  let(:playbook_file) { 'test_palybook.yml' }
+  subject do
+    ForemanAnsibleCore::CommandCreator.new(inventory_file, playbook_file, {})
+  end
+
+  test 'returns a command array including the ansible-playbook command' do
+    assert command_parts.include?('ansible-playbook')
+  end
+
+  test 'the last argument is the playbook_file' do
+    assert command_parts.last == playbook_file
+  end
+
+  describe 'environment variables' do
+    let(:environment_variables) { subject.command.first }
+
+    test 'has a JSON_INVENTORY_FILE set' do
+      assert environment_variables['JSON_INVENTORY_FILE']
+    end
+
+    test 'has no ANSIBLE_CALLBACK_WHITELIST set by default' do
+      assert_not environment_variables['ANSIBLE_CALLBACK_WHITELIST']
+    end
+
+    test 'with a REX command it sets ANSIBLE_CALLBACK_WHITELIST to empty' do
+      set_command_options(:remote_execution_command, true)
+      assert environment_variables['ANSIBLE_CALLBACK_WHITELIST']
+    end
+  end
+
+  describe 'command options' do
+    it 'can have verbosity set' do
+      level = '3'
+      level_string = Array.new(level.to_i).map { 'v' }.join
+      set_command_options(:verbosity_level, level)
+      assert command_parts.any? do |part|
+        part == "-#{level_string}"
+      end
+    end
+
+    it 'can have a timeout set' do
+      timeout = '5555'
+      set_command_options(:timeout, timeout)
+      assert command_parts.include?(timeout)
+    end
+  end
+
+  private
+
+  def command_parts
+    subject.command.flatten.map(&:to_s)
+  end
+
+  def set_command_options(option, value)
+    subject.instance_eval("@options[:#{option}] = \"#{value}\"",
+                          __FILE__, __LINE__ - 1)
+  end
+end


### PR DESCRIPTION
When a job is run via Ansible and is executing a command it should not change the configuration status, for this the callback is disabled via setting 'ANSIBLE_CALLBACK_WHITELIST' to an empty string and not run **any** callbacks, including the foreman callback that would create a report and update the configuration status.

This can be tested by running a "Run Ansible Command" job. Executing it via a Smart Proxy requires to include the `foreman_ansible_core` gem for [smart_proxy_ansible](https://github.com/theforeman/smart_proxy_ansible).