### PR TITLE
Fixes #24038 - don't display host roles in hg form

### DIFF
--- a/app/models/concerns/foreman_ansible/hostgroup_extensions.rb
+++ b/app/models/concerns/foreman_ansible/hostgroup_extensions.rb
@@ -16,6 +16,12 @@ module ForemanAnsible
         end.uniq
       end
 
+      def inherited_and_own_ansible_roles
+        path.reduce([]) do |roles, hostgroup|
+          roles + hostgroup.ansible_roles
+        end.uniq
+      end
+
       def host_ansible_roles
         hosts.all.includes(:ansible_roles).flat_map(&:ansible_roles)
       end

--- a/app/views/foreman_ansible/ansible_roles/_select_tab_content.html.erb
+++ b/app/views/foreman_ansible/ansible_roles/_select_tab_content.html.erb
@@ -3,7 +3,7 @@
     f,
     :ansible_roles,
     AnsibleRole,
-    f.object.all_ansible_roles.map(&:id),
+    f.object.is_a?(Hostgroup) ? (f.object.inherited_and_own_ansible_roles).map(&:id) : f.object.all_ansible_roles.map(&:id),
     {
       :disabled => f.object.inherited_ansible_roles.map(&:id),
       :label => _('Available roles'),


### PR DESCRIPTION
`all_ansible_roles` method of hostgroup also loads roles from hosts, this is used e.g. when we decide whether to display "Play roles" button for hostgroup. For displaying selected records, we only need to load hostgroup's roles and all roles inherited from its parents.