### PR TITLE
Fixes #24163 - Power Action does not do anything

### DIFF
--- a/app/views/foreman_ansible/job_templates/power_action_-_ansible_default.erb
+++ b/app/views/foreman_ansible/job_templates/power_action_-_ansible_default.erb
@@ -19,7 +19,6 @@ model: JobTemplate
 - hosts: all
   tasks:
     - command: |
-        echo <%= input('action') %> host && sleep 3
         <%= case input('action')
           when 'restart'
             'shutdown -r +1'


### PR DESCRIPTION
The playbook first runs 'echo' of 'shutdown host' - that fails because
that returns -1 'Failed to parse time specification:' ('host' is not a
valid time specification)

I don't find much of an use for that line, so the template currently
just runs the action and works.