### PR TITLE
Fixes #23279 - Enable 'ansible_become' to work with REX

### DIFF
--- a/app/models/foreman_ansible/ansible_provider.rb
+++ b/app/models/foreman_ansible/ansible_provider.rb
@@ -27,6 +27,10 @@ if defined? ForemanRemoteExecution
           )
         end
 
+        def supports_effective_user?
+          true
+        end
+
         private
 
         def ansible_command?(template)

--- a/app/services/foreman_ansible/inventory_creator.rb
+++ b/app/services/foreman_ansible/inventory_creator.rb
@@ -91,12 +91,13 @@ module ForemanAnsible
 
     def remote_execution_options(host)
       params = {
-        'ansible_become' => @template_invocation.effective_user,
+        'ansible_become_user' => @template_invocation.effective_user,
         'ansible_user' => host_setting(host, 'remote_execution_ssh_user'),
         'ansible_ssh_pass' => rex_ssh_password(host),
         'ansible_ssh_private_key_file' => ansible_or_rex_ssh_private_key(host),
         'ansible_port' => host_setting(host, 'remote_execution_ssh_port')
       }
+      params['ansible_become'] = true if params['ansible_become_user'].present?
       # Backward compatibility for Ansible 1.x
       params['ansible_ssh_port'] = params['ansible_port']
       params['ansible_ssh_user'] = params['ansible_user']

--- a/test/unit/services/inventory_creator_test.rb
+++ b/test/unit/services/inventory_creator_test.rb
@@ -52,8 +52,9 @@ module ForemanAnsible
                                                        @template_invocation)
       connection_params = inventory.connection_params(@host)
       assert_empty extra_options.to_a - inventory.connection_params(@host).to_a
+      assert_equal true, connection_params['ansible_become']
       assert_equal @template_invocation.effective_user,
-                   connection_params['ansible_become']
+                   connection_params['ansible_become_user']
       assert_equal Setting['ansible_connection'],
                    connection_params['ansible_connection']
       refute_equal Setting['remote_execution_ssh_user'],


### PR DESCRIPTION
Since 'supports_effective_user?' was not implemented in the Ansible
provider, it was returning 'false'. That means that every time you set
an effective user in the Job Invocation form, it gets saved as nil (see
foreman_remote_execution/app/models/template_invocation#
set_effective_user)