### PR TITLE
Fixes #24207 - don't display run buttons for unauthorized users

### DIFF
--- a/app/views/foreman_ansible/ansible_roles/_hostgroup_ansible_roles_button.erb
+++ b/app/views/foreman_ansible/ansible_roles/_hostgroup_ansible_roles_button.erb
@@ -5,9 +5,12 @@
     display_link_if_authorized(_('Play Roles'),   hash_for_play_roles_hostgroup_path(:id => hostgroup),   :'data-no-turbolink' => true)
   end
 
-  action_buttons(
-              display_link_if_authorized(_('Nest'),    hash_for_nest_hostgroup_path(:id => hostgroup)),
-              display_link_if_authorized(_('Clone'),   hash_for_clone_hostgroup_path(:id => hostgroup)),
-              play_roles,
-              display_delete_if_authorized(hash_for_hostgroup_path(:id => hostgroup).merge(:auth_object => hostgroup, :authorizer => authorizer), :data => { :confirm => warning_message(hostgroup) }))
+  actions = [
+    display_link_if_authorized(_('Nest'),    hash_for_nest_hostgroup_path(:id => hostgroup)),
+    display_link_if_authorized(_('Clone'),   hash_for_clone_hostgroup_path(:id => hostgroup))
+  ]
+  actions.push play_roles if User.current.can?(:create_job_invocations)
+  actions.push display_delete_if_authorized(hash_for_hostgroup_path(:id => hostgroup).merge(:auth_object => hostgroup, :authorizer => authorizer), :data => { :confirm => warning_message(hostgroup) })
+
+  action_buttons(*actions)
 %>


### PR DESCRIPTION
This fixes the authorization for all means of playing roles - button on host detail page, button for hostgroup and bulk action on hosts list page. If user is missing create_job_invocations permission, they can't play roles. I was thinking of extending ansible roles manager role with this permission, but this permission grants also access to whole SSH stack so that would be probably unexpected. The minimal set of built in roles for using ansible is following:

* Viewer
* Ansible Roles Manager
* Remote Execution User