### PR TITLE
Refs #24163 - shutdown with 1m delay so callback can return 

### DIFF
--- a/app/views/foreman_ansible/job_templates/power_action_-_ansible_default.erb
+++ b/app/views/foreman_ansible/job_templates/power_action_-_ansible_default.erb
@@ -23,5 +23,5 @@ model: JobTemplate
           when 'restart'
             'shutdown -r +1'
           else
-            'shutdown -h now'
+            'shutdown -h +1'
           end %>


### PR DESCRIPTION
Delaying the shutdown 1 minute so the Ansible job can return and the job
invocation can be green. Otherwise 'shutdown' may work but the job
invocation will fail.

https://github.com/theforeman/community-templates/pull/493 has been submitted too

cc @lpramuk