### PR TITLE
Fixes #24296 - Remove option to import roles from Foreman host

### DIFF
--- a/app/helpers/foreman_ansible/ansible_roles_helper.rb
+++ b/app/helpers/foreman_ansible/ansible_roles_helper.rb
@@ -2,19 +2,11 @@ module ForemanAnsible
   # Small convenience to list all roles in the UI
   module AnsibleRolesHelper
     def ansible_proxy_links(hash, classes = nil)
-      links = SmartProxy.with_features('Ansible').map do |proxy|
+      SmartProxy.with_features('Ansible').map do |proxy|
         display_link_if_authorized(_('From %s') % proxy.name,
                                    hash.merge(:proxy => proxy),
                                    :class => classes)
       end.flatten
-      host_text = if links.any?
-                    _('From Foreman host')
-                  else
-                    _('Import from Foreman host')
-                  end
-      links.unshift display_link_if_authorized(host_text,
-                                               hash,
-                                               :class => classes)
     end
 
     def ansible_proxy_import(hash)


### PR DESCRIPTION
In the past, the duplicity of being able to do everything through
proxies or Foreman itself has led to bugs and confusion in some users.
We are removing these methods one by one, to begin with, removing the
import roles option is very easy to do.