### PR TITLE
Fixes #24361 - import_host arguments in foreman-core changed

### DIFF
--- a/app/models/concerns/foreman_ansible/host_managed_extensions.rb
+++ b/app/models/concerns/foreman_ansible/host_managed_extensions.rb
@@ -47,10 +47,12 @@ module ForemanAnsible
     # rubocop:enable Metrics/BlockLength
     # Class methods we may need to override or add
     module ClassMethods
-      def import_host(hostname, certname = nil, deprecated_proxy = nil)
-        host = super(hostname, certname, deprecated_proxy)
-        if IPAddress.valid?(hostname) && Nic::Interface.find_by(:ip => hostname)
-          host = Nic::Interface.find_by(:ip => hostname).host
+      def import_host(*args)
+        host = super(*args)
+        hostname = args[0]
+        if IPAddress.valid?(hostname) &&
+           (host_nic = Nic::Interface.find_by(:ip => hostname))
+          host = host_nic.host
         end
         host
       end


### PR DESCRIPTION
`import_host`'s arguments[1] in core have changed and needs to be fixed.

This change doesn't require a specific amount of arguments and should be compatible with foreman-core that still has the third argument present.

[1] https://github.com/theforeman/foreman/pull/5855