### PR TITLE
Fixes #24362 - Ansible Variables can be imported as LookupKeys

### DIFF
--- a/app/controllers/ansible_roles_controller.rb
+++ b/app/controllers/ansible_roles_controller.rb
@@ -1,11 +1,7 @@
 # UI controller for ansible roles
 class AnsibleRolesController < ::ApplicationController
   include Foreman::Controller::AutoCompleteSearch
-
-  before_action :find_resource, :only => [:destroy]
-  before_action :find_proxy, :only => [:import]
-  before_action :create_importer, :only => [:import, :confirm_import]
-  before_action :default_order, :only => [:index]
+  include ForemanAnsible::Concerns::ImportControllerHelper
 
   def index
     @ansible_roles = resource_base.search_for(params[:search],
@@ -42,11 +38,6 @@ class AnsibleRolesController < ::ApplicationController
 
   def default_order
     params[:order] ||= 'name ASC'
-  end
-
-  def find_proxy
-    return nil unless params[:proxy]
-    @proxy = SmartProxy.authorized(:view_smart_proxies).find(params[:proxy])
   end
 
   def create_importer

--- a/app/controllers/ansible_variables_controller.rb
+++ b/app/controllers/ansible_variables_controller.rb
@@ -1,0 +1,78 @@
+# UI controller for ansible variables
+class AnsibleVariablesController < ::LookupKeysController
+  include Foreman::Controller::AutoCompleteSearch
+  include ForemanAnsible::Concerns::ImportControllerHelper
+  include Foreman::Controller::Parameters::AnsibleVariable
+
+  before_action :import_new_roles, :only => [:confirm_import]
+  before_action :find_required_proxy, :only => [:import]
+  before_action :find_resource, :only => [:edit, :update, :destroy],
+                                :if => proc { params[:id] }
+
+  def index
+    @ansible_variables = resource_base.search_for(params[:search],
+                                                  :order => params[:order]).
+                         paginate(:page => params[:page],
+                                  :per_page => params[:per_page])
+  end
+
+  def import
+    import_roles = @importer_roles.import_role_names
+    import_roles[:new_roles] = import_roles[:new]
+    import_variables = @importer.import_variable_names(import_roles[:new_roles])
+    render 'ansible_variables/import',
+           :locals => { :changed => import_variables }
+  end
+
+  def confirm_import
+    results = @importer.finish_import(new_vars, old_vars)
+    info _(
+      "Import of variables successfully finished.\n"\
+      "Added: #{results[:added].join(', ')} \n "\
+      "Removed: #{results[:obsolete].join(', ')}"
+    )
+    redirect_to ansible_variables_path
+  end
+
+  private
+
+  def default_order; end
+
+  def resource
+    @ansible_variable
+  end
+
+  def resource_params
+    ansible_variable_params
+  end
+
+  def new_vars
+    params[:changed] ? params[:changed][:new].as_json : {}
+  end
+
+  def old_vars
+    params[:changed] ? params[:changed][:obsolete].as_json : {}
+  end
+
+  def import_new_roles
+    return if new_vars.blank?
+    new_vars.each_key do |role_name|
+      ::AnsibleRole.find_or_create_by(:name => role_name)
+    end
+  end
+
+  def create_importer
+    @importer = ForemanAnsible::VariablesImporter.new(@proxy)
+    @importer_roles = ForemanAnsible::UiRolesImporter.new(@proxy)
+  end
+
+  def find_required_proxy
+    id = params['proxy']
+    @smart_proxy = SmartProxy.authorized(:view_smart_proxies).find(id)
+    unless @smart_proxy && @smart_proxy.has_feature?('Ansible')
+      not_found _('No proxy found to import variables from, ensure that the '\
+                  'smart proxy has the Ansible feature enabled.')
+    end
+    @smart_proxy
+  end
+end

--- a/app/controllers/concerns/foreman/controller/parameters/ansible_variable.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/ansible_variable.rb
@@ -1,0 +1,34 @@
+module Foreman
+  module Controller
+    module Parameters
+      # Keys to allow as parameters in the AnsibleVariable controller
+      module AnsibleVariable
+        extend ActiveSupport::Concern
+        include Foreman::Controller::Parameters::LookupKey
+
+        class_methods do
+          def ansible_variable_params_filter
+            Foreman::ParameterFilter.new(::AnsibleVariable).tap do |filter|
+              filter.permit :ansible_roles => [], :ansible_role_ids => [],
+                            :ansible_role_names => [],
+                            :param_classes => [], :param_classes_ids => [],
+                            :param_classes_names => []
+              filter.permit_by_context :required, :nested => true
+              filter.permit_by_context :id, :ui => false, :api => false,
+                                            :nested => true
+
+              add_lookup_key_params_filter(filter)
+            end
+          end
+        end
+
+        def ansible_variable_params
+          self.class.ansible_variable_params_filter.filter_params(
+            params,
+            parameter_filter_context
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/foreman_ansible/concerns/import_controller_helper.rb
+++ b/app/controllers/foreman_ansible/concerns/import_controller_helper.rb
@@ -1,0 +1,22 @@
+module ForemanAnsible
+  module Concerns
+    # Helpers to select proxy and call ProxyAPI
+    module ImportControllerHelper
+      extend ActiveSupport::Concern
+
+      included do
+        # rubocop:disable Rails/LexicallyScopedActionFilter
+        before_action :find_resource, :only => [:destroy]
+        before_action :find_proxy, :only => [:import]
+        before_action :create_importer, :only => [:import, :confirm_import]
+        before_action :default_order, :only => [:index]
+        # rubocop:enable Rails/LexicallyScopedActionFilter
+      end
+
+      def find_proxy
+        return nil unless params[:proxy]
+        @proxy = SmartProxy.authorized(:view_smart_proxies).find(params[:proxy])
+      end
+    end
+  end
+end

--- a/app/lib/proxy_api/ansible.rb
+++ b/app/lib/proxy_api/ansible.rb
@@ -24,5 +24,19 @@ module ProxyAPI
     rescue *PROXY_ERRORS => e
       raise ProxyException.new(url, e, N_('Unable to get roles from Ansible'))
     end
+
+    def all_variables
+      parse(get('roles/variables'))
+    rescue *PROXY_ERRORS => e
+      raise ProxyException.new(url, e,
+                               N_('Unable to get roles/variables from Ansible'))
+    end
+
+    def variables(role)
+      parse(get("roles/#{role}/variables"))
+    rescue *PROXY_ERRORS => e
+      raise ProxyException.new(url, e,
+                               N_('Unable to get roles/variables from Ansible'))
+    end
   end
 end

--- a/app/models/ansible_role.rb
+++ b/app/models/ansible_role.rb
@@ -10,6 +10,9 @@ class AnsibleRole < ApplicationRecord
   has_many :hostgroup_ansible_roles
   has_many :hostgroups, :through => :hostgroup_ansible_roles,
                         :dependent => :destroy
+  has_many :ansible_variables, :inverse_of => :ansible_role,
+                               :dependent => :destroy,
+                               :class_name => 'AnsibleVariable'
 
   scoped_search :on => :name, :complete_value => true
   scoped_search :on => :updated_at

--- a/app/models/ansible_variable.rb
+++ b/app/models/ansible_variable.rb
@@ -1,0 +1,16 @@
+# Represents the variables used in Ansible to parameterize playbooks
+class AnsibleVariable < LookupKey
+  belongs_to :ansible_role, :inverse_of => :ansible_variables
+  validates :ansible_role, :presence => true
+  scoped_search :on => :key, :aliases => [:name], :complete_value => true
+  scoped_search :relation => :ansible_role, :on => :name,
+                :complete_value => true, :rename => :ansible_role
+
+  def ansible?
+    true
+  end
+
+  def self.humanize_class_name
+    'Ansible variable'
+  end
+end

--- a/app/overrides/ansible_variables_edit.rb
+++ b/app/overrides/ansible_variables_edit.rb
@@ -1,0 +1,13 @@
+Deface::Override.new(
+  :virtual_path => 'lookup_keys/_fields',
+  :name => 'ansible_variables_edit',
+  :replace => "erb[loud]:contains('show_puppet_class')",
+  :partial => 'ansible_variables/ansible_roles_list'
+)
+
+Deface::Override.new(
+  :virtual_path => 'lookup_keys/_fields',
+  :name => 'ansible_variables_validator_text',
+  :replace => '.out.collapse > h6',
+  :partial => 'ansible_variables/validator_text'
+)

--- a/app/services/foreman_ansible/proxy_api.rb
+++ b/app/services/foreman_ansible/proxy_api.rb
@@ -1,0 +1,22 @@
+module ForemanAnsible
+  # Helper methods to create a ProxyAPI object for Ansible
+  module ProxyAPI
+    extend ActiveSupport::Concern
+
+    included do
+      attr_reader :ansible_proxy
+
+      def find_proxy_api
+        if ansible_proxy.blank?
+          raise ::Foreman::Exception.new(N_('Proxy not found'))
+        end
+        @proxy_api = ::ProxyAPI::Ansible.new(:url => ansible_proxy.url)
+      end
+
+      def proxy_api
+        return @proxy_api if @proxy_api
+        find_proxy_api
+      end
+    end
+  end
+end

--- a/app/services/foreman_ansible/roles_importer.rb
+++ b/app/services/foreman_ansible/roles_importer.rb
@@ -1,14 +1,14 @@
 module ForemanAnsible
   # Imports roles from smart proxy
   class RolesImporter
-    attr_reader :ansible_proxy
+    include ::ForemanAnsible::ProxyAPI
 
     def initialize(proxy = nil)
       @ansible_proxy = proxy
     end
 
     def import_role_names
-      return import_roles remote_roles if ansible_proxy
+      return import_roles remote_roles if @ansible_proxy.present?
       import_roles local_roles
     end
 
@@ -27,16 +27,6 @@ module ForemanAnsible
     end
 
     private
-
-    def find_proxy_api
-      raise ::Foreman::Exception.new(N_('Proxy not found')) unless ansible_proxy
-      @proxy_api = ::ProxyAPI::Ansible.new(:url => ansible_proxy.url)
-    end
-
-    def proxy_api
-      return @proxy_api if @proxy_api
-      find_proxy_api
-    end
 
     def local_roles
       ::ForemanAnsibleCore::RolesReader.list_roles

--- a/app/services/foreman_ansible/variables_importer.rb
+++ b/app/services/foreman_ansible/variables_importer.rb
@@ -1,0 +1,96 @@
+module ForemanAnsible
+  # Methods to transform variable names coming from the proxy into
+  # Foreman AnsibleVariable objects
+  class VariablesImporter
+    include ::ForemanAnsible::ProxyAPI
+
+    def initialize(proxy = nil)
+      @ansible_proxy = proxy
+    end
+
+    def import_variable_names(new_roles)
+      return import_variables(remote_variables, new_roles) if @ansible_proxy
+      import_variables(local_variables, new_roles)
+    end
+
+    def import_variables(role_variables, new_roles)
+      detect_changes(
+        role_variables.map do |role_name, variables|
+          role = import_new_role(role_name, new_roles)
+          next if role.blank?
+          initialize_variables(variables, role)
+        end.select(&:present?).flatten.compact
+      )
+    end
+
+    def import_new_role(role_name, new_roles)
+      role = AnsibleRole.find_by(:name => role_name)
+      if role.blank? && new_roles.map(&:name).include?(role_name)
+        role = new_roles.select { |r| r.name == role_name }.first
+      end
+      role
+    end
+
+    def initialize_variables(variables, role)
+      variables.map do |variable|
+        variable = AnsibleVariable.find_or_initialize_by(
+          :key => variable
+          # :key_type, :default_value, :required
+        )
+        variable.ansible_role = role
+        variable.valid? ? variable : nil
+      end
+    end
+
+    def detect_changes(imported)
+      changes = {}.with_indifferent_access
+      old, changes[:new] = imported.partition { |role| role.id.present? }
+      changes[:obsolete] = AnsibleVariable.where.not(:id => old.map(&:id))
+      changes
+    end
+
+    def finish_import(new, obsolete)
+      results = { :added => [], :obsolete => [] }
+      results[:added] = create_new_variables(new) if new.present?
+      results[:obsolete] = delete_old_variables(obsolete) if obsolete.present?
+      results
+    end
+
+    def create_new_variables(new)
+      added = []
+      new.each do |role, variables|
+        variables.each_value do |variable_properties|
+          variable = AnsibleVariable.new(
+            JSON.parse(variable_properties)['ansible_variable']
+          )
+          variable.ansible_role = ::AnsibleRole.find_by(:name => role)
+          variable.save
+          added << variable.key
+        end
+      end
+      added
+    end
+
+    def delete_old_variables(old)
+      removed = []
+      old.each_value do |variable_properties|
+        variable = AnsibleVariable.find(
+          JSON.parse(variable_properties)['ansible_variable']['id']
+        )
+        removed << variable.key
+        variable.destroy
+      end
+      removed
+    end
+
+    private
+
+    def local_variables
+      ::AnsibleVariable.all
+    end
+
+    def remote_variables
+      proxy_api.all_variables
+    end
+  end
+end

--- a/app/views/ansible_roles/index.html.erb
+++ b/app/views/ansible_roles/index.html.erb
@@ -22,8 +22,18 @@
         <td class="ellipsis"><%= import_time role %></td>
         <td>
           <%
-            links = [display_delete_if_authorized(hash_for_ansible_role_path(:id => role).merge(:auth_object => role, :authorizer => authorizer),
-                      :data => { :confirm => _("Delete %s?") % role.name }, :action => :delete)]
+              links = [
+                link_to(
+                  _('Variables'),
+                  ansible_variables_path(:search => "ansible_role = #{role}")
+                ),
+                display_delete_if_authorized(
+                  hash_for_ansible_role_path(:id => role).
+                  merge(:auth_object => role, :authorizer => authorizer),
+                  :data => { :confirm => _("Delete %s?") % role.name },
+                  :action => :delete
+                )
+              ]
           %>
           <%= action_buttons(*links) %>
         </td>

--- a/app/views/ansible_variables/_ansible_roles_list.html.erb
+++ b/app/views/ansible_variables/_ansible_roles_list.html.erb
@@ -1,0 +1,15 @@
+<% if f.object.is_a? ::AnsibleVariable %>
+  <%=
+    select_f(
+      f,
+      :ansible_role_id,
+      [f.object.ansible_role],
+      :id,
+      :to_label,
+      {},
+      { :label => _("Ansible Role"), :disabled => true }
+    )
+  %>
+<% else %>
+  <%= show_puppet_class(f) %>
+<% end %>

--- a/app/views/ansible_variables/_validator_text.html.erb
+++ b/app/views/ansible_variables/_validator_text.html.erb
@@ -1,0 +1,5 @@
+<% if f.object.is_a? ::AnsibleVariable %>
+  <h6><%= _('Before including these variables on your playbooks, Foreman will validate that your variables comply with the validation.') %></h6>
+<% else %>
+  <h6><%= _('If ERB is used in a parameter value, the validation of the value will happen during the ENC request. If the value is invalid, the ENC request will fail.') %></h6>
+<% end %>

--- a/app/views/ansible_variables/edit.html.erb
+++ b/app/views/ansible_variables/edit.html.erb
@@ -1,0 +1,17 @@
+<%= breadcrumbs(
+  :items => [
+    {
+      :caption => _('Ansible Variables'),
+      :url => url_for(ansible_variables_path)
+    },
+    {
+      :caption => _('Edit %s' % @ansible_variable.key)
+    }
+  ],
+  :switchable => false
+) %>
+<% title(_('Edit Ansible Variable')) %>
+<%= form_for(@ansible_variable) do |f| %>
+    <%= render 'lookup_keys/fields', :f => f %>
+    <%= submit_or_cancel f %>
+<% end %>

--- a/app/views/ansible_variables/import.html.erb
+++ b/app/views/ansible_variables/import.html.erb
@@ -1,0 +1,53 @@
+<% title _("Changed Ansible variables") %>
+<%= form_tag confirm_import_ansible_variables_path do %>
+  <h4><%= _("Select the changes you want to realize in Foreman") %></h4>
+  <h6>
+  <%= _("Toggle") %>:
+  <%= link_to_function(icon_text("check", _("New")),
+                       "toggleCheckboxesBySelector('.variable_select_boxes_new')",
+                       :title => _("Check/Uncheck new")) %> |
+  <%= link_to_function(icon_text("check", _("Obsolete")),
+                       "toggleCheckboxesBySelector('.variable_select_boxes_obsolete')",
+                       :title => _("Check/Uncheck obsolete")) %>
+  </h6>
+  <table class="<%= table_css_classes %>">
+    <thead>
+      <tr>
+        <th class="ca">
+          <%= link_to_function(icon_text("check"),
+                               "toggleCheckboxesBySelector('.variable_select_boxes')",
+                               :title => _("Check/Uncheck all")) %>
+        </th>
+        <th><%= _("Name") %></th>
+        <th><%= _("Ansible role") %></th>
+        <th class="col-md-2"><%= _("Hosts count") %></th>
+        <th class="col-md-2"><%= _("Hostgroups count") %></th>
+        <th><%= _("Operation") %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% changed.each do |kind, variables| %>
+        <% variables.each do |variable| %>
+          <tr>
+            <td>
+              <%= check_box_tag "changed[#{kind}][#{variable.ansible_role}][#{variable}]", variable.to_json, false, :class => "variable_select_boxes variable_select_boxes_#{kind} variable_select_boxes_variable_#{variable}" %>
+            </td>
+            <td>
+              <%= link_to_function("#{variable}", "toggleCheckboxesBySelector('.variable_select_boxes_variable_#{variable}')", :title => _("Check/Uncheck all %s changes") % variable) %>
+            </td>
+            <td><%= variable.ansible_role %></td>
+            <td><%= variable.ansible_role.hosts.count %></td>
+            <td><%= variable.ansible_role.hostgroups.count %></td>
+            <td>
+              <%= { "new" => _("Add"), "obsolete" => _("Remove") }[kind] %>
+            </td>
+          </tr>
+        <% end %>
+      <% end %>
+    </tbody>
+  </table>
+  <div>
+    <%= link_to _("Cancel"), ansible_variables_path, :class => "btn btn-default" %>
+    <%= submit_tag _("Update"), :class => "btn btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/ansible_variables/index.html.erb
+++ b/app/views/ansible_variables/index.html.erb
@@ -1,0 +1,46 @@
+<% title _("Ansible Variables") %>
+
+<% title_actions ansible_proxy_import(hash_for_import_ansible_variables_path),
+  documentation_button('#4.3Variables', :root_url => ansible_doc_url) %>
+
+<table class="<%= table_css_classes 'table-fixed' %>">
+  <thead>
+    <tr>
+      <th class='col-md-6'><%= sort :name, :as => s_('Variable|Name') %></th>
+      <th class='col-md-2'><%= sort :ansible_role, :as => s_('Variable|Role') %></th>
+      <th class='col-md-2'><%= _('Type') %></th>
+      <th class='col-md-2'><%= _('Actions') %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @ansible_variables.each do |variable| %>
+      <tr>
+        <td class="ellipsis"><%= link_to_if_authorized(
+          variable.key,
+          hash_for_edit_ansible_variable_path(:id => variable).
+          merge(:auth_object => variable,
+                :permission => 'edit_external_parameters',
+                :authorizer => authorizer)
+        ) %></td>
+        <td class="ellipsis"><%= link_to_if_authorized(
+          variable.ansible_role.name,
+          hash_for_ansible_variables_path(:search => "ansible_role = #{variable.ansible_role}")
+        ) %></td>
+        <td class="ellipsis"><%= "String" %></td>
+        <td class="ellipsis">
+          <% links = [
+            display_delete_if_authorized(
+              hash_for_ansible_variable_path(:id => variable.id).merge(
+                :auth_object => variable,
+                :authorizer => authorizer),
+                :data => { :confirm => _("Delete %s?") % variable.key },
+                :action => :delete)
+          ] %>
+          <%= action_buttons(*links) %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= will_paginate_with_info @ansible_variables %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,15 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :ansible_variables, :except => [:show, :new, :create] do
+      resources :lookup_values, :only => [:index, :create, :update, :destroy]
+      collection do
+        get :import
+        post :confirm_import
+        get 'auto_complete_search'
+      end
+    end
+
     namespace :api do
       scope '(:apiv)',
             :module      => :v2,

--- a/db/migrate/20180410125416_rename_ansible_job_categories.rb
+++ b/db/migrate/20180410125416_rename_ansible_job_categories.rb
@@ -1,7 +1,7 @@
 class RenameAnsibleJobCategories < ActiveRecord::Migration[5.1]
   def up
-    unless User.unscoped.find_by_login(User::ANONYMOUS_ADMIN)
-      puts "No ANONYMOUS_ADMIN found. Skipping renaming Ansible jobs"
+    unless User.unscoped.find_by(:login => User::ANONYMOUS_ADMIN)
+      puts 'No ANONYMOUS_ADMIN found. Skipping renaming Ansible jobs'
       return
     end
     User.as_anonymous_admin do
@@ -16,7 +16,7 @@ class RenameAnsibleJobCategories < ActiveRecord::Migration[5.1]
           job_template.job_category = "Ansible #{job_template.job_category}"
           job_template.save
         end
-  
+
         service_template = JobTemplate.where(
           :name => 'Service Action - Ansible Default'
         ).first

--- a/db/migrate/20180628125416_add_ansible_role_id_to_lookup_keys.rb
+++ b/db/migrate/20180628125416_add_ansible_role_id_to_lookup_keys.rb
@@ -1,0 +1,12 @@
+# to keep track of when the roles were imported
+class AddAnsibleRoleIdToLookupKeys < ActiveRecord::Migration[4.2]
+  def up
+    add_column :lookup_keys, :ansible_role_id, :integer
+    add_index :lookup_keys, :ansible_role_id
+  end
+
+  def down
+    remove_index :lookup_keys, :ansible_role_id
+    remove_column :lookup_keys, :ansible_role_id
+  end
+end

--- a/foreman_ansible.gemspec
+++ b/foreman_ansible.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |s|
   s.licenses    = ['GPL-3.0']
 
   s.files = Dir['{app,config,db,lib/foreman_ansible,locale,webpack}/**/*'] +
-    ['lib/foreman_ansible.rb', 'LICENSE', 'Rakefile', 'README.md'] +
-    ['package.json']
+            ['lib/foreman_ansible.rb', 'LICENSE', 'Rakefile', 'README.md'] +
+            ['package.json']
   s.test_files = Dir['test/**/*']
 
   s.add_development_dependency 'rubocop', '~> 0.52'

--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -25,6 +25,18 @@ Foreman::Plugin.register :foreman_ansible do
                { :ansible_roles => [:import, :confirm_import],
                  :'api/v2/ansible_roles' => [:import] },
                :resource_type => 'AnsibleRole'
+    permission :view_ansible_variables,
+               { :ansible_variables => [:index, :auto_complete_search] },
+               :resource_type => 'AnsibleVariable'
+    permission :edit_ansible_variables,
+               { :ansible_variables => [:edit, :update] },
+               :resource_type => 'AnsibleVariable'
+    permission :destroy_ansible_variables,
+               { :ansible_variables => [:destroy] },
+               :resource_type => 'AnsibleVariable'
+    permission :import_ansible_variables,
+               { :ansible_variables => [:import, :confirm_import] },
+               :resource_type => 'AnsibleVariable'
   end
 
   role 'Ansible Roles Manager',
@@ -45,6 +57,10 @@ Foreman::Plugin.register :foreman_ansible do
   menu :top_menu, :ansible_roles,
        :caption => N_('Roles'),
        :url_hash => { :controller => :ansible_roles, :action => :index },
+       :parent => :configure_menu
+  menu :top_menu, :ansible_variables,
+       :caption => N_('Variables'),
+       :url_hash => { :controller => :ansible_variables, :action => :index },
        :parent => :configure_menu
 
   apipie_documented_controllers [

--- a/test/factories/ansible_variables.rb
+++ b/test/factories/ansible_variables.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :ansible_variable do
+    sequence(:key) { |n| "ansible_variable_#{n}" }
+    ansible_role
+  end
+end

--- a/test/functional/ansible_variables_controller_test.rb
+++ b/test/functional/ansible_variables_controller_test.rb
@@ -1,0 +1,34 @@
+require 'test_plugin_helper'
+# functional tests for AnsibleVariablesController
+class AnsibleVariablesControllerTest < ActionController::TestCase
+  setup do
+    @model = FactoryBot.create(:ansible_variable)
+  end
+
+  basic_index_test
+  basic_edit_test @variable
+  basic_pagination_per_page_test
+  basic_pagination_rendered_test
+
+  test 'should destroy variable' do
+    assert_difference('AnsibleVariable.count', -1) do
+      delete :destroy,
+             :params => { :id => @model.id },
+             :session => set_session_user
+    end
+    assert_redirected_to ansible_variables_url
+  end
+
+  test 'there are no problems when the import hash is empty' do
+    ForemanAnsible::VariablesImporter.any_instance.
+      expects(:import_variable_names).returns({})
+    ForemanAnsible::UiRolesImporter.any_instance.
+      expects(:import_role_names).returns({})
+
+    proxy = FactoryBot.create(:smart_proxy, :with_ansible)
+    get :import,
+        :params => { :proxy => proxy.id },
+        :session => set_session_user
+    assert_response :success
+  end
+end

--- a/test/unit/ansible_role_test.rb
+++ b/test/unit/ansible_role_test.rb
@@ -1,12 +1,6 @@
 require 'test_plugin_helper'
 
-# Tests for the behavior of Ansible Role, currently only validations
-class AnsibleRoleTest < ActiveSupport::TestCase
-  should have_many(:host_ansible_roles)
-  should have_many(:hosts).through(:host_ansible_roles).dependent(:destroy)
-  should validate_presence_of(:name)
-  context 'with new role' do
-    subject { AnsibleRole.new(:name => 'foo') }
-    should validate_uniqueness_of(:name)
-  end
+# Tests for the behavior of Ansible Variable, currently only validations
+class AnsibleVariableTest < ActiveSupport::TestCase
+  should belong_to(:ansible_role)
 end

--- a/test/unit/ansible_variable_test.rb
+++ b/test/unit/ansible_variable_test.rb
@@ -1,0 +1,12 @@
+require 'test_plugin_helper'
+
+# Tests for the behavior of Ansible Role, currently only validations
+class AnsibleRoleTest < ActiveSupport::TestCase
+  should have_many(:host_ansible_roles)
+  should have_many(:hosts).through(:host_ansible_roles).dependent(:destroy)
+  should validate_presence_of(:name)
+  context 'with new role' do
+    subject { AnsibleRole.new(:name => 'foo') }
+    should validate_uniqueness_of(:name)
+  end
+end

--- a/test/unit/services/ansible_variables_importer_test.rb
+++ b/test/unit/services/ansible_variables_importer_test.rb
@@ -1,0 +1,37 @@
+require 'test_plugin_helper'
+# Unit tests for importing variables
+# This service is meant to take in essentially a string coming from
+# the proxy API, and parse that into AnsibleVariables.
+class AnsibleVariablesImporterTest < ActiveSupport::TestCase
+  setup do
+    @importer = ForemanAnsible::VariablesImporter.new
+  end
+  test 'does not reimport already existing variables' do
+    already_existing = FactoryBot.create(:ansible_variable)
+    new_role = FactoryBot.create(:ansible_role)
+    api_response = {
+      new_role.name => ['new_var'],
+      already_existing.ansible_role.name => [already_existing.key]
+    }
+    changes = @importer.import_variables(api_response, [new_role.name])
+    assert_not_empty changes['new']
+    assert_equal 'new_var', changes['new'].first.key
+    assert_equal new_role, changes['new'].first.ansible_role
+  end
+
+  test "variables attempts to remove variables that don't exist anymore" do
+    obsolete_variable = FactoryBot.create(:ansible_variable)
+    changes = @importer.import_variables({}, [])
+    assert_not_empty changes['obsolete']
+    assert_equal obsolete_variable.key, changes['obsolete'].first.key
+    assert_equal(
+      obsolete_variable.ansible_role,
+      changes['obsolete'].first.ansible_role
+    )
+  end
+
+  test 'does not do anything if response is empty' do
+    changes = @importer.import_variables({}, [])
+    assert_equal({ 'new' => [], 'obsolete' => [] }, changes)
+  end
+end


### PR DESCRIPTION
It would be really useful to be able to override parameters the same way
we do with Puppet: having smart matchers, default values, etc..
Since the LookupKey object has been written in a way that is really
reusable, we may essentially adapt Ansible Variables to be a kind of
LookupKey.

Pending tests, and a PR with the API should follow. It's critical to show these variables in the same fashion we show puppet params in the Host and Host Group form (Parameters tab).

It's necessary to have https://github.com/theforeman/smart_proxy_ansible/pull/9 for it to work.

[![Screenshot%20from%202018-07-02%2016-55-42|690x276](https://community.theforeman.org/uploads/default/optimized/2X/b/babe9cd8ad6f2a7efcf79c8771e0489fd80a193c_1_690x276.png)
Screenshot from 2018-07-02 16-55-42.png1910x765 85.7 KB
](https://community.theforeman.org/uploads/default/original/2X/b/babe9cd8ad6f2a7efcf79c8771e0489fd80a193c.png)

Menu entry:

[![Screenshot%20from%202018-07-02%2016-54-17|690x388](https://community.theforeman.org/uploads/default/optimized/2X/5/5a48dba669d4a16c83d472c592a30d8748a7e0c0_1_690x388.png)
Screenshot from 2018-07-02 16-54-17.png1920x1080 161 KB
](https://community.theforeman.org/uploads/default/original/2X/5/5a48dba669d4a16c83d472c592a30d8748a7e0c0.png)

Edit page:

[![Screenshot%20from%202018-07-02%2016-56-23|690x370](https://community.theforeman.org/uploads/default/optimized/2X/9/9e79a91f3433a3b940280941c62241fe0be785b0_1_690x370.png)](https://community.theforeman.org/uploads/default/original/2X/9/9e79a91f3433a3b940280941c62241fe0be785b0.png)