### PR TITLE
Fixes #24487 - Ansible Variables API

### DIFF
--- a/app/controllers/api/v2/ansible_variables_controller.rb
+++ b/app/controllers/api/v2/ansible_variables_controller.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    # API controller for Ansible Variables
+    class AnsibleVariablesController < ::Api::V2::BaseController
+      include ::Api::Version2
+
+      resource_description do
+        api_version 'v2'
+        api_base_url '/ansible/api'
+      end
+
+      before_action :find_resource, :only => [:show, :destroy]
+      before_action :find_proxy, :only => [:import, :obsolete]
+      before_action :create_importer, :only => [:import, :obsolete]
+
+      api :GET, '/ansible_variables/:id', N_('Show variable')
+      param :id, :identifier, :required => true
+      def show; end
+
+      api :GET, '/ansible_variables', N_('List Ansible variables')
+      param_group :search_and_pagination, ::Api::V2::BaseController
+      def index
+        @ansible_variables = resource_scope_for_index
+      end
+
+      api :DELETE, '/ansible_variables/:id', N_('Deletes Ansible variable')
+      param :id, :identifier, :required => true
+      def destroy
+        process_response @ansible_variable.destroy
+      end
+
+      api :PUT, '/ansible_variables/import',
+          N_('Import Ansible variables. This will only import variables '\
+             'for already existing roles, it will not import any new roles')
+      param :proxy_id, :identifier, N_('Smart Proxy to import from')
+      def import
+        new_variables = @importer.import_variable_names([])[:new]
+        new_variables.map(&:save)
+        @imported = new_variables
+      end
+
+      api :PUT, '/ansible_variables/obsolete',
+          N_('Obsolete Ansible variables. This will only obsolete variables '\
+             'for already existing roles, it will not delete any old roles')
+      param :proxy_id, :identifier, N_('Smart Proxy to import from')
+      def obsolete
+        old_variables = @importer.import_variable_names([])[:obsolete]
+        old_variables.map(&:destroy)
+        @obsoleted = old_variables
+      end
+
+      private
+
+      def find_proxy
+        return nil unless params[:proxy_id]
+        @proxy = SmartProxy.
+                 authorized(:view_smart_proxies).
+                 find(params[:proxy_id])
+      end
+
+      def create_importer
+        @importer = ForemanAnsible::VariablesImporter.new(@proxy)
+      end
+    end
+  end
+end

--- a/app/models/ansible_variable.rb
+++ b/app/models/ansible_variable.rb
@@ -15,4 +15,9 @@ class AnsibleVariable < LookupKey
   def self.humanize_class_name
     'Ansible variable'
   end
+
+  def editable_by_user?
+    AnsibleVariable.authorized(:edit_external_parameters).
+      where(:id => id).exists?
+  end
 end

--- a/app/views/api/v2/ansible_variables/import.json.rabl
+++ b/app/views/api/v2/ansible_variables/import.json.rabl
@@ -1,0 +1,3 @@
+collection @imported => :imported
+
+extends 'api/v2/ansible_variables/show'

--- a/app/views/api/v2/ansible_variables/index.json.rabl
+++ b/app/views/api/v2/ansible_variables/index.json.rabl
@@ -1,0 +1,3 @@
+collection @ansible_variables
+
+extends 'api/v2/ansible_variables/show'

--- a/app/views/api/v2/ansible_variables/obsolete.json.rabl
+++ b/app/views/api/v2/ansible_variables/obsolete.json.rabl
@@ -1,0 +1,3 @@
+collection @obsoleted => :obsoleted
+
+extends 'api/v2/ansible_variables/show'

--- a/app/views/api/v2/ansible_variables/show.json.rabl
+++ b/app/views/api/v2/ansible_variables/show.json.rabl
@@ -1,0 +1,20 @@
+object @ansible_variable
+
+attribute :parameter
+attributes :id, :ansible_role, :description, :override, :parameter_type,
+           :hidden_value?, :omit, :required, :validator_type, :validator_rule,
+           :merge_overrides, :merge_default, :avoid_duplicates,
+           :override_value_order, :created_at, :updated_at
+
+node do |ansible_variable|
+  {
+    :override_values => partial(
+      'api/v2/override_values/index',
+      :object => ansible_variable.lookup_values
+    )
+  }
+end
+
+node :override_values_count do |lk|
+  lk.lookup_values.count
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,13 @@ Rails.application.routes.draw do
             put :obsolete
           end
         end
+
+        resources :ansible_variables, :only => [:show, :index, :destroy] do
+          collection do
+            put :import
+            put :obsolete
+          end
+        end
       end
     end
   end

--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -28,16 +28,25 @@ Foreman::Plugin.register :foreman_ansible do
                  :'api/v2/ansible_roles' => [:import] },
                :resource_type => 'AnsibleRole'
     permission :view_ansible_variables,
-               { :ansible_variables => [:index, :auto_complete_search] },
+               {
+                 :ansible_variables => [:index, :auto_complete_search],
+                 :'api/v2/ansible_variables' => [:index, :show]
+               },
                :resource_type => 'AnsibleVariable'
     permission :edit_ansible_variables,
                { :ansible_variables => [:edit, :update] },
                :resource_type => 'AnsibleVariable'
     permission :destroy_ansible_variables,
-               { :ansible_variables => [:destroy] },
+               {
+                 :ansible_variables => [:destroy],
+                 :'api/v2/ansible_variables' => [:destroy, :obsolete]
+               },
                :resource_type => 'AnsibleVariable'
     permission :import_ansible_variables,
-               { :ansible_variables => [:import, :confirm_import] },
+               {
+                 :ansible_variables => [:import, :confirm_import],
+                 :'api/v2/ansible_variables' => [:import]
+               },
                :resource_type => 'AnsibleVariable'
   end
 

--- a/test/functional/api/v2/ansible_variables_controller_test.rb
+++ b/test/functional/api/v2/ansible_variables_controller_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'test_plugin_helper'
+
+module Api
+  module V2
+    # Tests for the controller to CRUD Ansible Variables
+    class AnsibleVariablesControllerTest < ActionController::TestCase
+      setup do
+        @variable = FactoryBot.create(:ansible_variable)
+      end
+
+      test 'should get index' do
+        get :index, :session => set_session_user
+        response = JSON.parse(@response.body)
+        refute_empty response['results']
+        assert_response :success
+      end
+
+      test 'should destroy' do
+        delete :destroy,
+               :params => { :id => @variable.id },
+               :session => set_session_user
+        assert_response :ok
+        refute AnsibleVariable.exists?(@variable.id)
+      end
+
+      test 'should import' do
+        put :import,
+            :session => set_session_user
+        assert_response :success
+      end
+
+      test 'should obsolete' do
+        put :obsolete,
+            :session => set_session_user
+        assert_response :success
+      end
+    end
+  end
+end


### PR DESCRIPTION
CRUD operations + import/obsolete for Ansible Variables. Lookup Values
can be set through the Foreman API already.

Do not merge yet, this has only been tested manually. Make sure to merge after https://github.com/theforeman/foreman_ansible/pull/193 is merged & rebase this PR against master when that happens.