### PR TITLE
Fixes #24623 - Correct documented API endpoints for playing roles

### DIFF
--- a/app/controllers/foreman_ansible/api/v2/hostgroups_controller_extensions.rb
+++ b/app/controllers/foreman_ansible/api/v2/hostgroups_controller_extensions.rb
@@ -12,7 +12,7 @@ module ForemanAnsible
         included do
           api :POST, '/hostgroups/:id/play_roles',
               N_('Plays Ansible roles on a hostgroup')
-          param :id, String, :required => true
+          param :id, :identifier, :required => true
 
           def play_roles
             find_resource
@@ -20,9 +20,10 @@ module ForemanAnsible
             process_response composer.trigger!, composer.job_invocation
           end
 
-          api :POST, '/hostgroups/play_roles',
+          api :POST, '/hostgroups/multiple_play_roles',
               N_('Plays Ansible roles on hostgroups')
-          param :id, Array, :required => true
+          param :hostgroup_ids, Array, N_('IDs of hostgroups to play roles on'),
+                :required => true
 
           def multiple_play_roles
             find_multiple
@@ -49,7 +50,7 @@ module ForemanAnsible
 
         def action_permission
           case params[:action]
-          when 'play_roles'
+          when 'play_roles', 'multiple_play_roles'
             :view
           else
             super

--- a/app/controllers/foreman_ansible/api/v2/hosts_controller_extensions.rb
+++ b/app/controllers/foreman_ansible/api/v2/hosts_controller_extensions.rb
@@ -8,20 +8,28 @@ module ForemanAnsible
         include ::ForemanAnsible::Concerns::JobInvocationHelper
 
         included do
+          def find_resource
+            return true if params[:action] == 'multiple_play_roles'
+            super
+          end
+
           api :POST, '/hosts/:id/play_roles',
               N_('Plays Ansible roles on a host')
-          param :id, String, :required => true
+          param :id, :identifier, :required => true
 
           def play_roles
             composer = job_composer(:ansible_run_host, @host)
             process_response composer.trigger!, composer.job_invocation
           end
 
-          api :POST, '/hosts/play_roles', N_('Plays Ansible roles on hosts')
-          param :id, Array, :required => true
+          api :POST, '/hosts/multiple_play_roles',
+              N_('Plays Ansible roles on hosts')
+          param :host_ids, Array, N_('IDs of hosts to play roles on'),
+                :required => true
 
           def multiple_play_roles
-            composer = job_composer(:ansible_run_host, @host.pluck(:id))
+            host_ids = params.fetch(:host_ids, []).uniq
+            composer = job_composer(:ansible_run_host, host_ids)
             process_response composer.trigger!, composer.job_invocation
           end
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,32 @@
 # rubocop:disable BlockLength
 Rails.application.routes.draw do
+  namespace :api do
+    scope '(:apiv)',
+          :module      => :v2,
+          :defaults    => { :apiv => 'v2' },
+          :apiv        => /v1|v2/,
+          :constraints => ApiConstraints.new(:version => 2) do
+
+      constraints(:id => %r{[^\/]+}) do
+        resources :hosts, :only => [] do
+          member do
+            post :play_roles
+          end
+          collection do
+            post :multiple_play_roles
+          end
+        end
+        resources :hostgroups, :only => [] do
+          member do
+            post :play_roles
+          end
+          collection do
+            post :multiple_play_roles
+          end
+        end
+      end
+    end
+  end
   scope '/ansible' do
     constraints(:id => %r{[^\/]+}) do
       resources :hosts, :only => [] do
@@ -30,26 +57,6 @@ Rails.application.routes.draw do
             :defaults    => { :apiv => 'v2' },
             :apiv        => /v1|v2/,
             :constraints => ApiConstraints.new(:version => 2) do
-
-        constraints(:id => %r{[^\/]+}) do
-          resources :hosts, :only => [] do
-            member do
-              post :play_roles
-            end
-            collection do
-              post :multiple_play_roles
-            end
-          end
-
-          resources :hostgroups, :only => [] do
-            member do
-              post :play_roles
-            end
-            collection do
-              post :multiple_play_roles
-            end
-          end
-        end
 
         resources :ansible_roles, :only => [:show, :index, :destroy] do
           collection do

--- a/test/functional/api/v2/hosts_controller_test.rb
+++ b/test/functional/api/v2/hosts_controller_test.rb
@@ -34,7 +34,7 @@ module Api
         ::JobInvocationComposer.any_instance.expects(:trigger!).returns(true)
         targets = [@host1.id, @host2.id]
 
-        post :multiple_play_roles, :params => { :id => targets }
+        post :multiple_play_roles, :params => { :host_ids => targets }
         response = JSON.parse(@response.body)
         assert_job_invocation_is_ok(response, targets)
       end


### PR DESCRIPTION
I've moved routes `/host(group)s/(multiple)_play_roles` from `/ansible/api` namespace to global `/api/` so they actually work. Because apidocs documents them without `/ansible` prefix there were 2 options:

1. Change documentation from e.g. `api :POST, '/hosts/play_roles'` to `api :POST, '/ansible/api/hosts/play_roles'`. See https://github.com/theforeman/foreman_ansible/blob/ec84e8b201ef4a9179c356608e930f1f0f58f5c6/app/controllers/api/v2/ansible_roles_controller.rb#L7.
or
2. Move routes from `/ansible/api` namespace to global `/api/` because those routes use documentation defined in the Foreman's `hosts` resource. In other words: after including the `HostsControllerExtensions` the `base_url` for all new endpoints will be `/api/` not the `/ansible/api`. So. if use the first one approach, Apipie will generate something like `/api/ansible/api/` which is wrong.