### PR TITLE
Refs #24262 - bump min version of REX

### DIFF
--- a/foreman_ansible.gemspec
+++ b/foreman_ansible.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'deface', '< 2.0'
   s.add_dependency 'foreman-tasks', '~> 0.8'
   s.add_dependency 'foreman_ansible_core', '~> 2.0'
-  s.add_dependency 'foreman_remote_execution', '>= 1.4.4', '< 2.0'
+  s.add_dependency 'foreman_remote_execution', '>= 1.6.3', '< 2.0'
   s.add_dependency 'ipaddress', '>= 0.8.0', '< 1.0'
 end


### PR DESCRIPTION
For 2.2-stable, I'll bump to 1.5.6 which will also get the fix today.