### PR TITLE
fixes #25018 - convert parameters to unsafe hash

### DIFF
--- a/app/controllers/ansible_roles_controller.rb
+++ b/app/controllers/ansible_roles_controller.rb
@@ -33,7 +33,7 @@ class AnsibleRolesController < ::ApplicationController
   end
 
   def confirm_import
-    @importer.finish_import(params[:changed])
+    @importer.finish_import(params[:changed]&.to_unsafe_h)
     notice _('Import of roles successfully finished.')
     redirect_to ansible_roles_path
   end


### PR DESCRIPTION
This fixes
```
NoMethodError undefined method `each_value' for #<ActionController::Parameters:0x00007f96fb95a490>
```
on 1.19.

Note: This is a PR against the `2.2-stable` branch, master is already fixed.