### PR TITLE
Fixes #25030 - importer works with Parameters

### DIFF
--- a/app/services/foreman_ansible/ui_roles_importer.rb
+++ b/app/services/foreman_ansible/ui_roles_importer.rb
@@ -14,13 +14,13 @@ module ForemanAnsible
     end
 
     def create_new_roles(changes)
-      changes.each_value do |new_role|
+      changes.each_pair do |_, new_role|
         ::AnsibleRole.create(JSON.parse(new_role))
       end
     end
 
     def delete_old_roles(changes)
-      changes.each_value do |old_role|
+      changes.each_pair do |_, old_role|
         ::AnsibleRole.find(JSON.parse(old_role)['id']).destroy
       end
     end


### PR DESCRIPTION
The problem is that Rails Parameters object is passed into the UiRolesImporter instead of hash and that does not have each_value. Result: `each_value' for <ActionController::Parameters:0x00007faa5d0cb3b8> Did you mean? each_pair"