### PR TITLE
Fixes #22279 - Do not duplicate hosts on callback

### DIFF
--- a/app/services/foreman_ansible/ansible_report_importer.rb
+++ b/app/services/foreman_ansible/ansible_report_importer.rb
@@ -15,6 +15,19 @@ module ForemanAnsible
           @host = Nic::Interface.find_by(:ip => hostname).host
         end
         super
+        partial_hostname_match(hostname)
+      end
+
+      def partial_hostname_match(hostname)
+        return @host unless @host.new_record?
+        hosts = Host.where(Host.arel_table[:name].matches("#{hostname}.%"))
+        if hosts.count > 1
+          msg = "More than 1 host found for name #{hostname}, "
+          msg += 'please use host FQDN when uploading reports'
+          Rails.logger.warn msg
+          return @host
+        end
+        @host = hosts.first || @host
       end
     end
   end

--- a/test/unit/services/ansible_report_importer_test.rb
+++ b/test/unit/services/ansible_report_importer_test.rb
@@ -20,4 +20,17 @@ class AnsibleReportImporterTest < ActiveSupport::TestCase
     ForemanAnsible::AnsibleReportScanner.expects(:ansible_report?).returns(true)
     assert @importer.host.new_record?
   end
+
+  test 'finds host when given partially qualified name' do
+    host = ::FactoryBot.create(:host, :hostname => 'ansible-host.example.com')
+    ForemanAnsible::AnsibleReportScanner.expects(:ansible_report?).returns(true)
+    assert_equal host, ::ConfigReportImporter.new({ 'host' => 'ansible-host' }).host
+  end
+
+  test 'creates a new host when multiple hosts for partially qualified name are found' do
+    ::FactoryBot.create(:host, :hostname => 'ansible-host.example.com')
+    ::FactoryBot.create(:host, :hostname => 'ansible-host.dummy.org')
+    ForemanAnsible::AnsibleReportScanner.expects(:ansible_report?).returns(true)
+    assert ::ConfigReportImporter.new({ 'host' => 'ansible-host' }).host.new_record?
+  end
 end


### PR DESCRIPTION
Prevents creating duplicate hosts for Ansible callback when using partially qualified name. If there are multiple matches on partial host name, we have no way of knowing which host the report belongs to and we create a new one as before.