### PR TITLE
Fixes #25246 - Imports IPv6 facts

### DIFF
--- a/app/services/foreman_ansible/fact_parser.rb
+++ b/app/services/foreman_ansible/fact_parser.rb
@@ -55,7 +55,11 @@ module ForemanAnsible
       interface.tr!('-', '_') # virbr1-nic -> virbr1_nic
       interface_facts = facts[:"ansible_#{interface}"]
       ipaddress = ip_from_interface(interface)
-      HashWithIndifferentAccess[interface_facts.merge(:ipaddress => ipaddress)]
+      ipaddress6 = ipv6_from_interface(interface)
+      HashWithIndifferentAccess[
+        interface_facts.merge(:ipaddress => ipaddress,
+                              :ipaddress6 => ipaddress6)
+      ]
     end
 
     def ipmi_interface; end
@@ -70,6 +74,12 @@ module ForemanAnsible
     def ip_from_interface(interface)
       return if facts[:"ansible_#{interface}"]['ipv4'].blank?
       facts[:"ansible_#{interface}"]['ipv4']['address']
+    end
+
+    def ipv6_from_interface(interface)
+      return if facts[:"ansible_#{interface}"]['ipv6'].blank?
+
+      facts[:"ansible_#{interface}"]['ipv6'].first['address']
     end
 
     # Returns first non-empty fact. Needed to check for empty strings.

--- a/test/unit/services/fact_parser_test.rb
+++ b/test/unit/services/fact_parser_test.rb
@@ -60,6 +60,51 @@ module ForemanAnsible
     end
   end
 
+  # Tests for Network parser
+  class NetworkFactParserTest < ActiveSupport::TestCase
+    setup do
+      @facts_parser = ForemanAnsible::FactParser.new(
+        HashWithIndifferentAccess.new(
+          '_type' => 'ansible',
+          '_timestamp' => '2018-10-29 20:01:51 +0100',
+          'ansible_facts' =>
+          {
+            'ansible_interfaces' => [
+                'eth0'
+            ],
+            'ansible_eth0' => {
+              'active' => true,
+              'device' => 'eth0',
+              "macaddress" => '52:54:00:04:55:37',
+              'ipv4' => {
+                  'address' => '10.10.0.10',
+                  'netmask' => '255.255.0.0',
+                  'network' => '10.10.0.0'
+              },
+              'ipv6' => [
+                  {
+                      'address' => 'fd00::5054:00ff:fe04:5537',
+                      'prefix' => '64',
+                      'scope' => 'host'
+                  }
+              ],
+              'mtu' => 1500,
+              'promisc' => false,
+              'type' => 'ether'
+            }
+          }
+        )
+      )
+    end
+
+    test 'Parses IPv4 & IPv6 addresses correctly' do
+      iut = 'eth0'.dup
+      interface = @facts_parser.get_facts_for_interface(iut)
+      assert_equal '10.10.0.10', interface['ipaddress']
+      assert_equal 'fd00::5054:00ff:fe04:5537', interface['ipaddress6']
+    end
+  end
+
   # Tests for Debian parser
   class DebianFactParserTest < ActiveSupport::TestCase
     setup do


### PR DESCRIPTION
If we don't do this, seems the IPv6 address is cleared, resulting in other unwanted side-effects (rebuild not working etc.)