### PR TITLE
top_level_ansible_vars not complete

### DIFF
--- a/app/services/foreman_ansible/inventory_creator.rb
+++ b/app/services/foreman_ansible/inventory_creator.rb
@@ -44,6 +44,8 @@ module ForemanAnsible
       }.merge(connection_params(host))
       if Setting['top_level_ansible_vars']
         result = result.merge(host_params(host))
+        result = result.merge(host_attributes(host))
+        result = result.merge(host_roles(host))
       end
       result
     end


### PR DESCRIPTION
Top Level Ansible Vars should include all other vars, since the foreman inventory plugin makes. foreman_location_name or by disabling the prefix 'location_name' foreman at the moment sets foreman.location_name in a own list/dict. so with this change the roles can now be executed by hand on a foreman-server or by foreman itself.