### PR TITLE
Fixes #25455 - Add variables into host_params

### DIFF
--- a/app/models/concerns/foreman_ansible/host_managed_extensions.rb
+++ b/app/models/concerns/foreman_ansible/host_managed_extensions.rb
@@ -4,51 +4,70 @@ require 'ipaddress'
 module ForemanAnsible
   # Relations to make Host::Managed 'have' ansible roles
   module HostManagedExtensions
-    extend ActiveSupport::Concern
-    include ::ForemanAnsible::Concerns::JobInvocationHelper
-
     # rubocop:disable Metrics/BlockLength
-    included do
-      has_many :host_ansible_roles, :foreign_key => :host_id
-      has_many :ansible_roles, :through => :host_ansible_roles,
-                               :dependent => :destroy
-      scoped_search :relation => :ansible_roles, :on => :name,
-                    :complete_value => true, :rename => :role,
-                    :only_explicit => true
+    def self.prepended(base)
+      base.instance_eval do
+        include ::ForemanAnsible::Concerns::JobInvocationHelper
 
-      before_provision :play_ansible_roles
-      audit_associations :ansible_roles
+        has_many :host_ansible_roles, :foreign_key => :host_id
+        has_many :ansible_roles, :through => :host_ansible_roles,
+                                 :dependent => :destroy
+        scoped_search :relation => :ansible_roles, :on => :name,
+                      :complete_value => true, :rename => :role,
+                      :only_explicit => true
 
-      def inherited_ansible_roles
-        return [] unless hostgroup
-        hostgroup.inherited_and_own_ansible_roles
+        before_provision :play_ansible_roles
+        audit_associations :ansible_roles
       end
 
-      # This one should be fixed, disabled for the moment as we're
-      # in a rush to get the release out
-      # rubocop:disable Metrics/AbcSize
-      def play_ansible_roles
-        return true unless ansible_roles.present? ||
-                           inherited_ansible_roles.present?
-        composer = job_composer(:ansible_run_host, self)
-        composer.triggering.mode = :future
-        composer.triggering.start_at = (
-          Time.zone.now +
-          Setting::Ansible[:ansible_post_provision_timeout].to_i.seconds
-        )
-        composer.trigger!
-        logger.info("Task for Ansible roles on #{self} before_provision: "\
-                    "#{job_invocation_path(composer.job_invocation)}")
-      rescue Foreman::Exception => e
-        logger.info("Error running Ansible roles on #{self} before_provision: "\
-                    "#{e.message}")
-      end
-      # rubocop:enable Metrics/AbcSize
-
-      def all_ansible_roles
-        (ansible_roles + inherited_ansible_roles).uniq
-      end
+      base.singleton_class.prepend ClassMethods
     end
+
+    def inherited_ansible_roles
+      return [] unless hostgroup
+      hostgroup.inherited_and_own_ansible_roles
+    end
+
+    # This one should be fixed, disabled for the moment as we're
+    # in a rush to get the release out
+    # rubocop:disable Metrics/AbcSize
+    def play_ansible_roles
+      return true unless ansible_roles.present? ||
+                         inherited_ansible_roles.present?
+      composer = job_composer(:ansible_run_host, self)
+      composer.triggering.mode = :future
+      composer.triggering.start_at = (
+        Time.zone.now +
+        Setting::Ansible[:ansible_post_provision_timeout].to_i.seconds
+      )
+      composer.trigger!
+      logger.info("Task for Ansible roles on #{self} before_provision: "\
+                  "#{job_invocation_path(composer.job_invocation)}")
+    rescue Foreman::Exception => e
+      logger.info("Error running Ansible roles on #{self} before_provision: "\
+                  "#{e.message}")
+    end
+    # rubocop:enable Metrics/AbcSize
+
+    def all_ansible_roles
+      (ansible_roles + inherited_ansible_roles).uniq
+    end
+
+    def host_params_hash
+      values = AnsibleVariable.where(:ansible_role_id => all_ansible_roles.pluck(:id)).
+               values_hash(self).raw.values
+      transformed = values.each_with_object({}) do |item, memo|
+        item.map do |name, hash|
+          variable = AnsibleVariable.find_by :key => name
+          safe_value = variable.hidden_value? ? variable.safe_value : hash[:value]
+          memo[name] = { :value => hash[:value], :safe_value => safe_value, :source => 'global' }
+        end
+        memo
+      end
+
+      super.merge transformed
+    end
+
     # rubocop:enable Metrics/BlockLength
     # Class methods we may need to override or add
     module ClassMethods

--- a/lib/foreman_ansible/engine.rb
+++ b/lib/foreman_ansible/engine.rb
@@ -85,7 +85,7 @@ module ForemanAnsible
           )
         end
         ::FactParser.register_fact_parser(:ansible, ForemanAnsible::FactParser)
-        ::Host::Managed.send(:include, ForemanAnsible::HostManagedExtensions)
+        ::Host::Managed.send(:prepend, ForemanAnsible::HostManagedExtensions)
         ::Hostgroup.send(:include, ForemanAnsible::HostgroupExtensions)
         ::HostsHelper.send(:include, ForemanAnsible::HostsHelperExtensions)
         ::HostsController.send(


### PR DESCRIPTION
This puts values for Ansible variables from Classification's `values_hash` into `host_params`.

foreman_scap_client_{port,server} come from oprazak.foreman_scap_client:
![](https://imgur.com/6fn6XhK.png)