### PR TITLE
Make deb OS facts parsing more reliable

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,5 +34,8 @@ Style/SymbolArray:
 Style/FormatStringToken:
   EnforcedStyle: template
 
+Rails/SkipsModelValidations:
+  Enabled: false
+
 Metrics:
   Enabled: false

--- a/app/controllers/api/v2/ansible_override_values_controller.rb
+++ b/app/controllers/api/v2/ansible_override_values_controller.rb
@@ -25,7 +25,7 @@ module Api
 
       def create
         @ansible_variable = AnsibleVariable.authorized(:edit_external_variables).
-          find_by_id(params[:ansible_variable_id].to_i)
+                            find_by(:id => params[:ansible_variable_id].to_i)
         @override_value = @ansible_variable.lookup_values.create!(lookup_value_params['override_value'])
         @ansible_variable.update_attribute(:override, true)
         render 'api/v2/ansible_override_values/show'
@@ -35,7 +35,7 @@ module Api
       param :id, :identifier, :required => true
 
       def destroy
-        @override_value = LookupValue.find_by_id(params[:id])
+        @override_value = LookupValue.find_by(:id => params[:id])
         if @override_value
           @ansible_variable = AnsibleVariable.where(:id => @override_value.lookup_key_id)
           @override_value.destroy

--- a/app/services/foreman_ansible/operating_system_parser.rb
+++ b/app/services/foreman_ansible/operating_system_parser.rb
@@ -5,7 +5,7 @@ module ForemanAnsible
   module OperatingSystemParser
     def operatingsystem
       args = { :name => os_name, :major => os_major, :minor => os_minor }
-      args[:release_name] = os_release_name if os_name == 'Debian'
+      args[:release_name] = os_release_name if os_name == 'Debian' || os_name == 'Ubuntu'
       return @local_os if local_os(args).present?
       return @new_os if new_os(args).present?
       logger.debug do
@@ -40,13 +40,9 @@ module ForemanAnsible
       end
     end
 
-    def deb_release_map
-      { '7' => 'wheezy', '8' => 'jessie', '9' => 'stretch', '10' => 'buster' }
-    end
-
     def os_release_name
-      return '' unless os_name == 'Debian'
-      deb_release_map[debian_os_major_sid]
+      return '' if os_name != 'Debian' && os_name != 'Ubuntu'
+      facts[:ansible_distribution_release]
     end
 
     # rubocop:disable AbcSize, CyclomaticComplexity, PerceivedComplexity

--- a/test/unit/services/fact_parser_test.rb
+++ b/test/unit/services/fact_parser_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_plugin_helper'
 
 module ForemanAnsible
@@ -115,18 +116,23 @@ module ForemanAnsible
           '_timestamp' => '2015-10-29 20:01:51 +0100',
           'ansible_facts' =>
           {
-            'ansible_distribution_major_version' => 'buster/sid',
-            'ansible_distribution' => 'Debian'
+            "ansible_distribution" => "Debian",
+            "ansible_distribution_file_parsed" => true,
+            "ansible_distribution_file_path" => "/etc/os-release",
+            "ansible_distribution_file_variety" => "Debian",
+            "ansible_distribution_major_version" => "8",
+            "ansible_distribution_release" => "jessie",
+            "ansible_distribution_version" => "8.7"
           }
         )
       )
     end
 
-    test 'Parses debian unstable aka sid correctly' do
+    test 'Parses debian jessie correctly' do
       as_admin do
         os = @facts_parser.operatingsystem
 
-        assert_equal '10', os.major
+        assert_equal '8', os.major
         assert_equal 'Debian', os.name
       end
     end


### PR DESCRIPTION
@xprazak2 this should be more robust way for https://github.com/theforeman/foreman_ansible/pull/238 that should also support ubuntu, mind to take a look? Instead of hardcoding the mapping, we do what core does for puppet, looking at lsb info that ansible setup modules provide under ansible_distribution_release