### PR TITLE
Use absolute_import for foreman_callback plugin

### DIFF
--- a/extras/foreman_callback.py
+++ b/extras/foreman_callback.py
@@ -15,6 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 import os
 from datetime import datetime
 from collections import defaultdict


### PR DESCRIPTION
Ansible plugin directory contains `json` callback plugin next to
foreman_callback plugin. Without absolute import foreman_callback
plugin fails with json errors (which occurs due to namespace collision).

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>