### PR TITLE
Fixes #26335 - documentation link in new tab

### DIFF
--- a/app/views/ansible_roles/welcome.html.erb
+++ b/app/views/ansible_roles/welcome.html.erb
@@ -7,7 +7,7 @@
   <p><%= _('No ansible roles were found in Foreman. If you want to assign roles to your hosts,
              you have to import them first.').html_safe %>
   </p>
-  <p><%= link_to(_('Learn more about this in the documentation.'), documentation_url('#4.1ImportingRoles', :root_url => ansible_doc_url)) %></p>
+  <p><%= link_to(_('Learn more about this in the documentation.'), documentation_url('#4.1ImportingRoles', :root_url => ansible_doc_url), target: '_blank') %></p>
   <div class="blank-slate-pf-secondary-action">
     <%= ansible_proxy_import(hash_for_import_ansible_roles_path) %>
   </div>


### PR DESCRIPTION
Would feel better if the documentation doesn't open in current tab.