### PR TITLE
Fixes #26645 - delay React mount after jquery inserts DOM

### DIFF
--- a/app/views/foreman_ansible/ansible_roles/_select_tab_content.html.erb
+++ b/app/views/foreman_ansible/ansible_roles/_select_tab_content.html.erb
@@ -2,14 +2,22 @@
 <%= webpacked_plugins_css_for :foreman_ansible %>
 
 <div class='tab-pane' id='ansible_roles'>
-  <div id='ansible_roles_switcher'></div>
   <% roles = f.object.is_a?(Hostgroup) ? roles_attrs(f.object.inherited_and_own_ansible_roles) : roles_attrs(f.object.all_ansible_roles) %>
   <% class_name = f.object.is_a?(Hostgroup) ? 'Hostgroup' : 'Host' %>
-  <%= mount_react_component('AnsibleRolesSwitcher', '#ansible_roles_switcher', { :initialAssignedRoles => roles,
-                                                                                 :inheritedRoleIds => f.object.inherited_ansible_roles.map(&:id),
-                                                                                 :availableRolesUrl => ui_ansible_roles_path,
-                                                                                 :resourceId => f.object.id,
-                                                                                 :resourceName => class_name,
-                                                                                 :canView => User.current.can?(:view_ansible_roles)
-                                                                                }.to_json) %>
+  <%= content_tag(:div, '',
+                  :id => 'ansible_roles_switcher',
+                  'data-roles' => {
+                    :initialAssignedRoles => roles,
+                    :inheritedRoleIds => f.object.inherited_ansible_roles.map(&:id),
+                    :availableRolesUrl => ui_ansible_roles_path,
+                    :resourceId => f.object.id,
+                    :resourceName => class_name,
+                    :canView => User.current.can?(:view_ansible_roles)
+                  }.to_json
+  ) %>
+  <% unless request.xhr? %>
+    <script type="text/javascript">
+      tfm.initAnsibleRoleSwitcher();
+    </script>
+  <% end %>
 </div>

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -2,6 +2,7 @@ import componentRegistry from 'foremanReact/components/componentRegistry';
 import injectReducer from 'foremanReact/redux/reducers/registerReducer';
 import ReportJsonViewer from './components/ReportJsonViewer';
 import AnsibleRolesSwitcher from './components/AnsibleRolesSwitcher';
+import $ from 'jquery';
 
 import reducer from './reducer';
 
@@ -15,3 +16,13 @@ componentRegistry.register({
 });
 
 injectReducer('foremanAnsible', reducer);
+
+window.tfm.initAnsibleRoleSwitcher = () => {
+  $(document).on('ContentLoad', evt => {
+    tfm.reactMounter.mount(
+      'AnsibleRolesSwitcher',
+      '#ansible_roles_switcher',
+      $('#ansible_roles_switcher').data('roles')
+    );
+  });
+}


### PR DESCRIPTION
Solution proposal to be constructive, not just destructive on #262.
I have investigated a bit and it is not really easy to do, I believe the `Vue.js` is solving it by integrating itself into https://github.com/w3c/webcomponents

In this case it means just wait a bit before mounting. This is proposing a solution.