### PR TITLE
Fixes #26704 - Show inventory preview

### DIFF
--- a/app/controllers/api/v2/ansible_inventories_controller.rb
+++ b/app/controllers/api/v2/ansible_inventories_controller.rb
@@ -1,0 +1,51 @@
+module Api
+  module V2
+    class AnsibleInventoriesController < ::Api::V2::BaseController
+      include ::Api::Version2
+
+      api :POST, '/ansible_inventories/hosts',
+      N_('Show Ansible inventory for hosts')
+      param :host_ids, Array, N_('IDs of hosts included in inventory'),
+            :required => true
+
+      api :GET, '/ansible_inventories/hosts',
+      N_('Show Ansible inventory for hosts')
+      param :host_ids, Array, N_('IDs of hosts included in inventory'),
+            :required => true
+
+      api :POST, '/ansible_inventories/hostgroups',
+      N_('Show Ansible inventory for hostgroups')
+      param :hostgroup_ids, Array, N_('IDs of hostgroups included in inventory'),
+            :required => true
+
+      api :GET, '/ansible_inventories/hostgroups',
+      N_('Show Ansible inventory for hostgroups')
+      param :hostgroup_ids, Array, N_('IDs of hostgroups included in inventory'),
+            :required => true
+
+      def hosts
+        show_inventory :host_ids, :id
+      end
+
+      def hostgroups
+        show_inventory :hostgroup_ids, :hostgroup_id
+      end
+
+      def action_permission
+        case params[:action]
+        when 'hosts', 'hostgroups'
+          :view
+        else
+          super
+        end
+      end
+
+      private
+
+      def show_inventory(ids_key, condition_key)
+        ids = params.fetch(ids_key, []).uniq
+        render :json => ForemanAnsible::InventoryCreator.new(Host.where(condition_key => ids)).to_hash.to_json
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,15 @@ Rails.application.routes.draw do
         end
 
         resources :ansible_override_values, :only => [:create, :destroy]
+
+        resources :ansible_inventories, :only => [] do
+          collection do
+            post :hosts
+            get :hosts
+            post :hostgroups
+            get :hostgroups
+          end
+        end
       end
     end
   end

--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -58,10 +58,12 @@ Foreman::Plugin.register :foreman_ansible do
                },
                :resource_type => 'AnsibleVariable'
     permission :view_hosts,
-               { :'api/v2/hosts' => [:ansible_roles] },
+               { :'api/v2/hosts' => [:ansible_roles],
+                 :'api/v2/ansible_inventories' => [:hosts] },
                :resource_type => 'Host'
     permission :view_hostgroups,
-               { :'api/v2/hostgroups' => [:ansible_roles] },
+               { :'api/v2/hostgroups' => [:ansible_roles],
+                 :'api/v2/ansible_inventories' => [:hostgroups] },
                :resource_type => 'Hostgroup'
     permission :edit_hosts,
                { :'api/v2/hosts' => [:assign_ansible_roles] },

--- a/test/functional/api/v2/ansible_inventories_controller_test.rb
+++ b/test/functional/api/v2/ansible_inventories_controller_test.rb
@@ -1,0 +1,51 @@
+require 'test_plugin_helper'
+
+module Api
+  module V2
+    class AnsibleInventoriesControllerTest < ActionController::TestCase
+      setup do
+        @hostgroup = FactoryBot.create(:hostgroup)
+        @host1 = FactoryBot.create(:host, :hostgroup_id => @hostgroup.id)
+        @host2 = FactoryBot.create(:host, :hostgroup_id => @hostgroup.id)
+        @host3 = FactoryBot.create(:host)
+      end
+
+      test 'should show inventory for hosts by GET' do
+        hosts = [@host1, @host3]
+        get :hosts, :params => { :host_ids => hosts.pluck(:id) }, :session => set_session_user
+        hosts_inventory_assertions(hosts)
+      end
+
+      test 'should show inventory for hosts by POST' do
+        hosts = [@host1, @host3]
+        post :hosts, :params => { :host_ids => hosts.pluck(:id) }, :session => set_session_user
+        hosts_inventory_assertions(hosts)
+      end
+
+      test 'should show inventory for hostgroup by GET' do
+        get :hostgroups, :params => { :hostgroup_ids => [@hostgroup.id] }, :session => set_session_user
+        hosts_inventory_assertions(@hostgroup.hosts)
+      end
+
+      test 'should show inventory for hostgroup by POST' do
+        get :hostgroups, :params => { :hostgroup_ids => [@hostgroup.id] }, :session => set_session_user
+        hosts_inventory_assertions(@hostgroup.hosts)
+      end
+
+      private
+
+      def hosts_inventory_assertions(hosts)
+        response = JSON.parse(@response.body)
+        all_hosts = response['all']['hosts']
+        hosts.each do |host|
+          assert all_hosts.include?(host.name)
+        end
+        hostvars = response["_meta"]["hostvars"]
+        hosts.each do |host|
+          assert hostvars[host.name]
+        end
+        assert_equal hosts.count, hostvars.keys.count
+      end
+    end
+  end
+end


### PR DESCRIPTION
Needs tests, permissions.

A draft of what inventory preview endpoints might look like. I would like to have the same paths for GET and POST, but I cannot extend hosts controller and use `/hosts/ansible_inventory` path for GET, because `HostsController#show` gets hit with that.