### PR TITLE
Fixes #26850 - set ansible_become_method per REX effective method

### DIFF
--- a/app/services/foreman_ansible/inventory_creator.rb
+++ b/app/services/foreman_ansible/inventory_creator.rb
@@ -100,6 +100,7 @@ module ForemanAnsible
         'ansible_user' => host_setting(host, 'remote_execution_ssh_user'),
         'ansible_ssh_pass' => rex_ssh_password(host),
         'ansible_sudo_pass' => rex_sudo_password(host),
+        'ansible_become_method' => host_setting(host, 'remote_execution_effective_user_method'),
         'ansible_ssh_private_key_file' => ansible_or_rex_ssh_private_key(host),
         'ansible_port' => host_setting(host, 'remote_execution_ssh_port'),
         'ansible_host' => AnsibleProvider.find_ip_or_hostname(host)

--- a/test/unit/services/inventory_creator_test.rb
+++ b/test/unit/services/inventory_creator_test.rb
@@ -49,6 +49,8 @@ module ForemanAnsible
         returns(true).at_least_once
       Setting.expects(:[]).with('ansible_connection').
         returns('ssh').at_least_once
+      Setting.expects(:[]).with('remote_execution_effective_user_method').
+        returns('sudo').at_least_once
       @host.expects(:host_params).returns(extra_options).at_least_once
       @template_invocation.job_invocation.expects(:password).
         returns(nil).at_least_once
@@ -77,6 +79,8 @@ module ForemanAnsible
                    connection_params['ansible_sudo_pass']
       assert_equal Setting['ansible_winrm_server_cert_validation'],
                    connection_params['ansible_winrm_server_cert_validation']
+      assert_equal Setting['remote_execution_effective_user_method'],
+                   connection_params['ansible_become_method']
     end
 
     test 'job invocation ssh password is passed when available' do
@@ -105,6 +109,8 @@ module ForemanAnsible
         returns('root')
       host.params.expects(:[]).with('remote_execution_ssh_port').
         returns('2222')
+      host.params.expects(:[]).with('remote_execution_effective_user_method').
+        returns('sudo')
       connection_params = inventory.connection_params(host)
       assert_equal path_to_key,
                    connection_params['ansible_ssh_private_key_file']


### PR DESCRIPTION
Set ansible privilege escalation method `ansible_become_method` per REX `remote_execution_effective_user_method` setting.