### PR TITLE
Fixes #26851 - refactor ansible password params

### DIFF
--- a/app/models/foreman_ansible/ansible_provider.rb
+++ b/app/models/foreman_ansible/ansible_provider.rb
@@ -35,7 +35,7 @@ if defined? ForemanRemoteExecution
           {
             'per-host' => {
               host.name => {
-                'ansible_ssh_pass' => rex_ssh_password(host),
+                'ansible_password' => rex_ssh_password(host),
                 'ansible_become_password' => rex_effective_user_password(host)
               }
             }

--- a/lib/foreman_ansible_core/runner/ansible_runner.rb
+++ b/lib/foreman_ansible_core/runner/ansible_runner.rb
@@ -162,7 +162,7 @@ module ForemanAnsibleCore
           per_host = secrets['per-host'][host]
 
           new_secrets = {
-            'ansible_ssh_pass' => inventory['ssh_password'] || per_host['ansible_ssh_pass'],
+            'ansible_password' => inventory['ssh_password'] || per_host['ansible_password'],
             'ansible_become_password' => inventory['effective_user_password'] || per_host['ansible_become_password']
           }
           inventory['_meta']['hostvars'][host].update(new_secrets)

--- a/lib/foreman_ansible_core/runner/playbook.rb
+++ b/lib/foreman_ansible_core/runner/playbook.rb
@@ -124,7 +124,7 @@ module ForemanAnsibleCore
           per_host = secrets['per-host'][name]
 
           new_secrets = {
-            'ansible_ssh_pass' => inventory['ssh_password'] || per_host['ansible_ssh_pass'],
+            'ansible_password' => inventory['ssh_password'] || per_host['ansible_password'],
             'ansible_become_password' => inventory['effective_user_password'] || per_host['ansible_become_password']
           }
           inventory['_meta']['hostvars'][name].update(new_secrets)

--- a/test/unit/ansible_provider_test.rb
+++ b/test/unit/ansible_provider_test.rb
@@ -40,7 +40,7 @@ class AnsibleProviderTest < ActiveSupport::TestCase
         host.expects(:params).twice.returns(params)
         secrets = ForemanAnsible::AnsibleProvider.secrets(host)
         host_secrets = secrets['per-host'][host.name]
-        assert_equal host_secrets['ansible_ssh_pass'], 'password'
+        assert_equal host_secrets['ansible_password'], 'password'
         assert_equal host_secrets['ansible_become_password'], 'letmein'
       end
     end

--- a/test/unit/lib/foreman_ansible_core/ansible_runner_test.rb
+++ b/test/unit/lib/foreman_ansible_core/ansible_runner_test.rb
@@ -24,7 +24,7 @@ module ForemanAnsibleCore
             '_meta' => { 'hostvars' => { 'foreman.example.com' => {} } } }
         end
         let(:input) do
-          host_secrets = { 'ansible_ssh_pass' => 'letmein', 'ansible_become_password' => 'iamroot' }
+          host_secrets = { 'ansible_password' => 'letmein', 'ansible_become_password' => 'iamroot' }
           secrets = { 'per-host' => { 'foreman.example.com' => host_secrets } }
           host_input = { 'input' => { 'action_input' => { 'secrets' => secrets } } }
           { 'foreman.example.com' => host_input }
@@ -35,14 +35,14 @@ module ForemanAnsibleCore
           test_inventory = inventory.merge('ssh_password' => 'sshpass', 'effective_user_password' => 'mypass')
           rebuilt = runner.send(:rebuild_secrets, test_inventory, input)
           host_vars = rebuilt.dig('_meta', 'hostvars', 'foreman.example.com')
-          assert_equal 'sshpass', host_vars['ansible_ssh_pass']
+          assert_equal 'sshpass', host_vars['ansible_password']
           assert_equal 'mypass', host_vars['ansible_become_password']
         end
 
         test 'host secrets are used when not overriden by inventory secrest' do
           rebuilt = runner.send(:rebuild_secrets, inventory, input)
           host_vars = rebuilt.dig('_meta', 'hostvars', 'foreman.example.com')
-          assert_equal 'letmein', host_vars['ansible_ssh_pass']
+          assert_equal 'letmein', host_vars['ansible_password']
           assert_equal 'iamroot', host_vars['ansible_become_password']
         end
       end

--- a/test/unit/lib/foreman_ansible_core/playbook_runner_test.rb
+++ b/test/unit/lib/foreman_ansible_core/playbook_runner_test.rb
@@ -87,7 +87,7 @@ class PlaybookRunnerTest < ActiveSupport::TestCase
         '_meta' => { 'hostvars' => { 'foreman.example.com' => {} } } }
     end
     let(:secrets) do
-      host_secrets = { 'ansible_ssh_pass' => 'letmein', 'ansible_become_password' => 'iamroot' }
+      host_secrets = { 'ansible_password' => 'letmein', 'ansible_become_password' => 'iamroot' }
       { 'per-host' => { 'foreman.example.com' => host_secrets } }
     end
     let(:runner) { ForemanAnsibleCore::Runner::Playbook.allocate }
@@ -96,14 +96,14 @@ class PlaybookRunnerTest < ActiveSupport::TestCase
       test_inventory = inventory.merge('ssh_password' => 'sshpass', 'effective_user_password' => 'mypass')
       rebuilt = runner.send(:rebuild_secrets, test_inventory, secrets)
       host_vars = rebuilt.dig('_meta', 'hostvars', 'foreman.example.com')
-      assert_equal 'sshpass', host_vars['ansible_ssh_pass']
+      assert_equal 'sshpass', host_vars['ansible_password']
       assert_equal 'mypass', host_vars['ansible_become_password']
     end
 
     test 'host secrets are used when not overriden by inventory secrest' do
       rebuilt = runner.send(:rebuild_secrets, inventory, secrets)
       host_vars = rebuilt.dig('_meta', 'hostvars', 'foreman.example.com')
-      assert_equal 'letmein', host_vars['ansible_ssh_pass']
+      assert_equal 'letmein', host_vars['ansible_password']
       assert_equal 'iamroot', host_vars['ansible_become_password']
     end
   end

--- a/test/unit/services/inventory_creator_test.rb
+++ b/test/unit/services/inventory_creator_test.rb
@@ -69,7 +69,7 @@ module ForemanAnsible
                    connection_params['ansible_winrm_server_cert_validation']
       assert_equal Setting['remote_execution_effective_user_method'],
                    connection_params['ansible_become_method']
-      refute connection_params.key?('ansible_ssh_pass')
+      refute connection_params.key?('ansible_password')
       refute connection_params.key?('ansible_become_password')
     end
 


### PR DESCRIPTION
Refactoring `ansible_ssh_pass` and `ansible_sudo_pass` to `ansible_password` and `ansible_become_password` as per https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html