### PR TITLE
Fixes #27311 - Assume job is successful for a host unless indicated

### DIFF
--- a/lib/foreman_ansible_core/runner/ansible_runner.rb
+++ b/lib/foreman_ansible_core/runner/ansible_runner.rb
@@ -57,6 +57,8 @@ module ForemanAnsibleCore
         log_event("for host: #{hostname.inspect}", event)
         publish_data_for(hostname, event['stdout'] + "\n", 'stdout') if event['stdout']
         case event['event']
+        when 'runner_on_ok'
+          publish_exit_status_for(hostname, 0) if @exit_statuses[hostname].nil?
         when 'runner_on_unreachable'
           publish_exit_status_for(hostname, 1)
         when 'runner_on_failed'


### PR DESCRIPTION
The previous implementation explicitly set exit codes when there was an error during a task and it was assumed that exit code 0 will be inherited from the parent process. The issue was that when there was at least one failed host, the parent process ended with a higher number and propagated the error even to successful hosts.