### PR TITLE
Parameterized roles in ENC (Feature #27285)

### DIFF
--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -90,6 +90,13 @@ class Setting
               :collection => lambda do
                 Hash[%w[ansible-playbook ansible-runner].map { |x| [x, x] }]
               end
+            ),
+            set(
+              'ansible_parameterized_roles_in_enc',
+              N_('Ansible variables are parameterized under roles in ENC '\
+                 'output rather than flattened into host parameters.'),
+              false,
+              N_('Parameterized roles in ENC')
             )
           ].compact.each do |s|
             create(s.update(:category => 'Setting::Ansible'))

--- a/app/services/foreman_ansible/ansible_info.rb
+++ b/app/services/foreman_ansible/ansible_info.rb
@@ -1,7 +1,11 @@
 module ForemanAnsible
   class AnsibleInfo < ::HostInfo::Provider
     def host_info
-      { 'parameters' => ansible_params }
+      if Setting[:ansible_parameterized_roles_in_enc]
+        { 'roles' => ansible_roles }
+      else
+        { 'parameters' => ansible_params }
+      end
     end
 
     def ansible_params
@@ -14,5 +18,20 @@ module ForemanAnsible
         memo
       end
     end
+
+    def ansible_roles
+      roles = host.all_ansible_roles.pluck(:id, :name)
+
+      roles.each_with_object({}) do |role, rmemo|
+        variables = AnsibleVariable.where(:ansible_role_id => role[0], :override => true)
+        values = variables.values_hash(host)
+
+        rmemo[role[1]] = variables.each_with_object({}) do |var, memo|
+          value = values[var]
+          memo[var.key] = value if value
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This pull request adds a new setting, ansible_parameterized_roles_in_enc, which defaults to false. When this setting is enabled, the output of  /api/hosts/id:/enc will list roles and role variables hierarchically. Something like.

```
"parameters": {
  "domainname": "example.com",
  ...
}
"roles": {
  "role1": {
    "foo": "bar" 
  }
}
```

This will allow for richer API interaction, particularly in cases where playbooks are not pushes from the Foreman server.