### PR TITLE
Fixes #27285 - Parameterize roles in ENC

### DIFF
--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -90,13 +90,6 @@ class Setting
               :collection => lambda do
                 Hash[%w[ansible-playbook ansible-runner].map { |x| [x, x] }]
               end
-            ),
-            set(
-              'ansible_parameterized_roles_in_enc',
-              N_('Ansible variables are parameterized under roles in ENC '\
-                 'output rather than flattened into host parameters.'),
-              false,
-              N_('Parameterized roles in ENC')
             )
           ].compact.each do |s|
             create(s.update(:category => 'Setting::Ansible'))

--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -90,14 +90,14 @@ class Setting
               :collection => lambda do
                 Hash[%w[ansible-playbook ansible-runner].map { |x| [x, x] }]
               end
-              ),
+            ),
             set(
               'ansible_parameterized_roles_in_enc',
               N_('Ansible variables are parameterized under roles in ENC '\
                  'output rather than flattened into host parameters.'),
               false,
               N_('Parameterized roles in ENC')
-              )
+            )
           ].compact.each do |s|
             create(s.update(:category => 'Setting::Ansible'))
           end

--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -90,7 +90,14 @@ class Setting
               :collection => lambda do
                 Hash[%w[ansible-playbook ansible-runner].map { |x| [x, x] }]
               end
-            )
+              ),
+              set(
+                'ansible_parameterized_roles_in_enc',
+                N_('Ansible variables are parameterized under roles in ENC '\
+                   'output rather than flattened into host parameters.'),
+                false,
+                N_('Parameterized roles in ENC')
+              )
           ].compact.each do |s|
             create(s.update(:category => 'Setting::Ansible'))
           end

--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -91,12 +91,12 @@ class Setting
                 Hash[%w[ansible-playbook ansible-runner].map { |x| [x, x] }]
               end
               ),
-              set(
-                'ansible_parameterized_roles_in_enc',
-                N_('Ansible variables are parameterized under roles in ENC '\
-                   'output rather than flattened into host parameters.'),
-                false,
-                N_('Parameterized roles in ENC')
+            set(
+              'ansible_parameterized_roles_in_enc',
+              N_('Ansible variables are parameterized under roles in ENC '\
+                 'output rather than flattened into host parameters.'),
+              false,
+              N_('Parameterized roles in ENC')
               )
           ].compact.each do |s|
             create(s.update(:category => 'Setting::Ansible'))

--- a/app/services/foreman_ansible/ansible_info.rb
+++ b/app/services/foreman_ansible/ansible_info.rb
@@ -19,4 +19,3 @@ module ForemanAnsible
     end
   end
 end
-

--- a/app/services/foreman_ansible/ansible_info.rb
+++ b/app/services/foreman_ansible/ansible_info.rb
@@ -1,22 +1,7 @@
 module ForemanAnsible
   class AnsibleInfo < ::HostInfo::Provider
     def host_info
-      if Setting[:ansible_parameterized_roles_in_enc]
-        { 'roles' => ansible_roles }
-      else
-        { 'parameters' => ansible_params }
-      end
-    end
-
-    def ansible_params
-      variables = AnsibleVariable.where(:ansible_role_id => host.all_ansible_roles.pluck(:id), :override => true)
-      values = variables.values_hash(host)
-
-      variables.each_with_object({}) do |var, memo|
-        value = values[var]
-        memo[var.key] = value if value
-        memo
-      end
+      { 'ansible_roles' => ansible_roles }
     end
 
     def ansible_roles
@@ -34,3 +19,4 @@ module ForemanAnsible
     end
   end
 end
+


### PR DESCRIPTION
This pull request adds a new setting, **ansible_parameterized_roles_in_enc**, which defaults to `false`. When this setting is `true`, the output of **/api/hosts/id:/enc** will list roles and role variables hierarchically. Something like.

```
"parameters": {
  "domainname": "example.com",
  ...
}
"roles": {
  "role1": {
    "foo": "bar" 
  }
}
```

This will allow for richer API interaction, particularly in cases where playbooks are not pushes from the Foreman server and mirrors a similar capability provided by Foreman for Puppet.