### PR TITLE
Fixes #27388 - migrate to @theforeman/vendor pkg

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,14 @@
   "plugins": [
     "transform-class-properties",
     "transform-object-rest-spread",
-    "transform-object-assign",
-    "lodash"
-  ]
+    "transform-object-assign"
+  ],
+  "env": {
+    "test": {
+      "presets": ["@theforeman/vendor-dev/babel.preset.js"]
+    },
+    "storybook": {
+      "presets": ["@theforeman/vendor-dev/babel.preset.js"]
+    }
+  }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,9 @@
 {
   "plugins": ["patternfly-react"],
-  "extends": ["plugin:patternfly-react/recommended"],
+  "extends": [
+    "plugin:patternfly-react/recommended",
+    "./node_modules/@theforeman/vendor-dev/eslint.extends.js",
+  ],
   "rules": {
     "prettier/prettier": ["error", {
       "singleQuote": true,

--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -2,7 +2,7 @@
 
 # rubocop:disable BlockLength
 Foreman::Plugin.register :foreman_ansible do
-  requires_foreman '>= 1.22'
+  requires_foreman '>= 1.23'
 
   security_block :foreman_ansible do
     permission :play_roles_on_host,

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "@theforeman/vendor": "^0.1.1",
-    "react-json-tree": "^0.11.0"
-    "react-bootstrap": "^0.32.1",
+    "react-json-tree": "^0.11.0",
+    "react-bootstrap": "^0.32.1"
   },
   "devDependencies": {
     "@theforeman/vendor-dev": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -7,22 +7,12 @@
     "test": "test"
   },
   "dependencies": {
-    "babel-polyfill": "^6.26.0",
-    "classnames": "^2.2.5",
-    "lodash": "^4.17.11",
-    "patternfly": "^3.58.0",
-    "patternfly-react": "^2.25.4",
-    "prop-types": "^15.6.2",
-    "react": "^16.6.3",
-    "react-bootstrap": "^0.32.1",
-    "react-dom": "^16.6.3",
-    "react-json-tree": "^0.11.0",
-    "reselect": "^3.0.1",
-    "seamless-immutable": "^7.1.3"
+    "@theforeman/vendor": "^0.1.1",
+    "react-json-tree": "^0.11.0"
   },
   "devDependencies": {
+    "@theforeman/vendor-dev": "^0.1.1",
     "babel-eslint": "^8.2.1",
-    "babel-plugin-lodash": "^3.3.2",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
@@ -63,6 +53,7 @@
   "jest": {
     "verbose": true,
     "moduleDirectories": [
+      "node_modules/@theforeman/vendor-core/node_modules",
       "node_modules",
       "webpack"
     ],

--- a/webpack/components/AnsibleRolesSwitcher/AnsibleRolesSwitcher.scss
+++ b/webpack/components/AnsibleRolesSwitcher/AnsibleRolesSwitcher.scss
@@ -1,6 +1,4 @@
-@import '~patternfly/dist/sass/patternfly/_color-variables';
-@import '~patternfly/dist/sass/patternfly/_variables';
-@import '~patternfly/dist/sass/patternfly/_loading-state';
+@import '~@theforeman/vendor/scss/variables';
 
 #ansibleRolesSwitcher {
   .list-view-pf {


### PR DESCRIPTION
Migrate to use the new [@theforeman/vendor](https://github.com/theforeman/foreman-js/tree/master/packages/vendor) package from `npm`.

Don't forget to `rm -rf node_modules package-lock.json` and `npm i` before you test it.

### What to test?

1. `npm run lint` should work properly with no errors.
2. `npm test` should work properly with no errors.
3. running foreman dev-server should work
4. We shouldn't notice any UI changes. especially in the scss file that changed.

Thanks