### PR TITLE
Fixes 25159 - Ansible variables overrides on hosts/hostgroups edit page

### DIFF
--- a/app/helpers/foreman_ansible/ansible_variables_helper.rb
+++ b/app/helpers/foreman_ansible/ansible_variables_helper.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module ForemanAnsible
+  # Helper methods for host and hostgroup varibales
+  module AnsibleVariablesHelper
+
+    def ansible_lookup_key_with_diagnostic(obj, values_hash, lookup_key, lookup_value)
+      value, matcher = ansible_value_matcher(obj, values_hash, lookup_key)
+      inherited_value = LookupKey.format_value_before_type_cast(value, lookup_key.key_type)
+      effective_value = lookup_value.lookup_key_id.nil? ? inherited_value.to_s : lookup_value.value_before_type_cast.to_s
+      warnings = lookup_key_warnings(lookup_key.required, effective_value.present?)
+      popover_value = lookup_key.hidden_value? ? lookup_key.hidden_value : inherited_value
+
+      parameter_value_content(
+        "#{parameters_receiver}_lookup_values_attributes_#{lookup_key.id}_value",
+        effective_value,
+        :popover => diagnostic_popover(lookup_key, matcher, popover_value, warnings),
+        :name => "#{lookup_value_name_prefix(lookup_key.id)}[value]",
+        :disabled => !lookup_key.overridden?(obj) || lookup_value.omit || !can_edit_params?,
+        :inherited_value => inherited_value,
+        :lookup_key => lookup_key,
+        :hidden_value? => lookup_key.hidden_value?,
+        :lookup_key_type => lookup_key.key_type)
+    end
+
+    def ansible_value_matcher(obj, values_hash, lookup_key)
+      if parameters_receiver == "host"
+        value = values_hash[lookup_key.id]
+        value_for_key = value.try(:[], lookup_key.key)
+        if value_for_key.present?
+          [value_for_key[:value], "#{value_for_key[:element]} (#{value_for_key[:element_name]})"]
+        else
+          [lookup_key.default_value, _("Default value")]
+        end
+      else # hostgroup
+        obj.inherited_lookup_value(lookup_key)
+      end
+    end
+  end
+end

--- a/app/helpers/foreman_ansible/ansible_variables_helper.rb
+++ b/app/helpers/foreman_ansible/ansible_variables_helper.rb
@@ -38,4 +38,3 @@ module ForemanAnsible
     end
   end
 end
-

--- a/app/helpers/foreman_ansible/ansible_variables_helper.rb
+++ b/app/helpers/foreman_ansible/ansible_variables_helper.rb
@@ -3,7 +3,6 @@
 module ForemanAnsible
   # Helper methods for host and hostgroup varibales
   module AnsibleVariablesHelper
-
     def ansible_lookup_key_with_diagnostic(obj, values_hash, lookup_key, lookup_value)
       value, matcher = ansible_value_matcher(obj, values_hash, lookup_key)
       inherited_value = LookupKey.format_value_before_type_cast(value, lookup_key.key_type)
@@ -20,7 +19,8 @@ module ForemanAnsible
         :inherited_value => inherited_value,
         :lookup_key => lookup_key,
         :hidden_value? => lookup_key.hidden_value?,
-        :lookup_key_type => lookup_key.key_type)
+        :lookup_key_type => lookup_key.key_type
+      )
     end
 
     def ansible_value_matcher(obj, values_hash, lookup_key)
@@ -38,3 +38,4 @@ module ForemanAnsible
     end
   end
 end
+

--- a/app/overrides/host_ansible_variables.rb
+++ b/app/overrides/host_ansible_variables.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Displays Ansible variables on the Host Parameters tab
+Deface::Override.new(
+  :virtual_path => 'hosts/_form',
+  :name => 'host_ansible_variables',
+  :insert_top => 'div.tab-pane#params',
+  :partial => 'foreman_ansible/ansible_variables/host_variables'
+  )

--- a/app/overrides/host_ansible_variables.rb
+++ b/app/overrides/host_ansible_variables.rb
@@ -7,4 +7,3 @@ Deface::Override.new(
   :insert_top => 'div.tab-pane#params',
   :partial => 'foreman_ansible/ansible_variables/host_variables'
 )
-

--- a/app/overrides/host_ansible_variables.rb
+++ b/app/overrides/host_ansible_variables.rb
@@ -6,4 +6,5 @@ Deface::Override.new(
   :name => 'host_ansible_variables',
   :insert_top => 'div.tab-pane#params',
   :partial => 'foreman_ansible/ansible_variables/host_variables'
-  )
+)
+

--- a/app/overrides/hostgroup_ansible_variables.rb
+++ b/app/overrides/hostgroup_ansible_variables.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Displays Ansible variables on the Hostgroup Parameters tab
+Deface::Override.new(
+  :virtual_path => 'hostgroups/_form',
+  :name => 'hostgroup_ansible_variables',
+  :insert_top => 'div.tab-pane#params',
+  :partial => 'foreman_ansible/ansible_variables/hostgroup_variables'
+)

--- a/app/views/foreman_ansible/ansible_variables/_host_variables.html.erb
+++ b/app/views/foreman_ansible/ansible_variables/_host_variables.html.erb
@@ -1,0 +1,4 @@
+<fieldset>
+  <h2><%= _('Ansible Role Variables') %></h2>
+  <%= render 'foreman_ansible/ansible_variables/roles_variables', :obj => @host %>
+</fieldset>

--- a/app/views/foreman_ansible/ansible_variables/_hostgroup_variables.html.erb
+++ b/app/views/foreman_ansible/ansible_variables/_hostgroup_variables.html.erb
@@ -1,0 +1,4 @@
+<fieldset>
+  <h2><%= _('Ansible Role Variables') %></h2>
+  <%= render 'foreman_ansible/ansible_variables/roles_variables', :obj => @hostgroup %>
+</fieldset>

--- a/app/views/foreman_ansible/ansible_variables/_role_variables.html.erb
+++ b/app/views/foreman_ansible/ansible_variables/_role_variables.html.erb
@@ -1,0 +1,46 @@
+<% lookup_keys = AnsibleVariable.where(:ansible_role_id => ansiblerole.id, :override => true) %>
+<% values_hash = obj.is_a?(Hostgroup) ? {} : lookup_keys.inherited_values(obj).raw %>
+<% lookup_keys.each_with_index do |lookup_key, index| %>
+  <% lookup_value = lookup_value(obj, lookup_key) %>
+  <%
+    # LookupValue#match is generated automatically by Host#lookup_values_attributes=
+    # from the name, so don't present errors directly to the user.  Any validation
+    # errors should also be visible against the Host#name field.
+    if lookup_value.errors[:match].any?
+        logger.debug("Ignoring #{lookup_value.inspect} match errors: #{lookup_value.errors[:match]}")
+        lookup_value.errors.delete(:match)
+    end
+  %>
+  <% overridden = lookup_key.overridden?(obj) %>
+  <% error = lookup_value.errors %>
+  <tr id="ansiblerole_<%= ansiblerole.id %>_params[<%= lookup_key.id %>]"
+    class="fields <%= 'overridden' if overridden %>">
+    <%= content_tag(:td, ansiblerole.name, :rowspan => lookup_keys.size, :class => "ellipsis") if index == 0 %>
+    <td class="ellipsis param_name">
+      <%= lookup_key.key %>
+    </td>
+    <td <%= "class=has-error" if error.present? %>>
+      <div class="input-group">
+        <%= ansible_lookup_key_with_diagnostic(obj, values_hash, lookup_key, lookup_value) %>
+        <span class="input-group-btn">
+          <%= hidden_toggle(lookup_key.hidden_value?, 'font', 'font', true) if lookup_key.hidden_value? %>
+          <%= fullscreen_button("$(this).parent().prev()") unless lookup_key.key_type == "boolean" %>
+          <%= override_toggle(overridden) %>
+        </span>
+      </div>
+      <%= content_tag(:span, error.full_messages.to_sentence, :class => "help-block") if error.present? %>
+    </td>
+    <td class="ca">
+      <%= check_box(lookup_value_name_prefix(lookup_key.id), :omit,
+                    :value    => lookup_value.id,
+                    :disabled => !overridden || !can_edit_params?,
+                    :onchange => "toggleOmitValue(this, 'value')",
+                    :hidden   => !overridden,
+                    :title    => _('Omit from classification output'),
+                    :checked  => lookup_value.omit)
+      %>
+      <%= hidden_lookup_value_fields(lookup_key, lookup_value, !overridden) %>
+
+    </td>
+  </tr>
+<% end %>

--- a/app/views/foreman_ansible/ansible_variables/_roles_variables.html.erb
+++ b/app/views/foreman_ansible/ansible_variables/_roles_variables.html.erb
@@ -1,0 +1,16 @@
+<table class="table table-fixed" id="inherited_ansible_role_variables">
+  <thead class="white-header">
+    <tr>
+      <th class='col-md-2'><%= _('Ansible Role') %></th>
+      <th class='col-md-2'><%= _('Name') %></th>
+      <th class='col-md-5'><%= _('Value') %></th>
+      <th class='col-md-1 ca'><%= _("Omit") %>&nbsp;<%= omit_help %></th>
+    </tr>
+  </thead>
+  <tbody>
+  <%= render :partial => 'foreman_ansible/ansible_variables/role_variables',
+    :collection => obj.is_a?(Hostgroup) ? obj.inherited_and_own_ansible_roles : obj.all_ansible_roles,
+    :as => :ansiblerole,
+    :locals => { :obj => obj } %>
+    </tbody>
+    </table>


### PR DESCRIPTION
This updates the host and group edit pages to display and allow editing of Ansible variables on the parameters tab.

The omit checkbox will set the omit value, but it is not honored yet as @xprazak2 mentioned in https://github.com/theforeman/foreman_ansible/pull/241#issuecomment-465555679.

Ansible variables also seem to default to hidden. I'm not sure if that was intentional, but should probably not be the default.