### PR TITLE
Fixes #27491 - Ensure ssh and sudo password are not leaked

### DIFF
--- a/app/models/foreman_ansible/ansible_provider.rb
+++ b/app/models/foreman_ansible/ansible_provider.rb
@@ -33,7 +33,7 @@ if defined? ForemanRemoteExecution
 
         def secrets(host)
           {
-            :'per-host' => {
+            'per-host' => {
               host.name => {
                 'ansible_ssh_pass' => rex_ssh_password(host),
                 'ansible_sudo_pass' => rex_sudo_password(host),

--- a/app/models/foreman_ansible/ansible_provider.rb
+++ b/app/models/foreman_ansible/ansible_provider.rb
@@ -31,6 +31,29 @@ if defined? ForemanRemoteExecution
           )
         end
 
+        def secrets(host)
+          {
+            :'per-host' => {
+              host.name => {
+                'ansible_ssh_pass' => rex_ssh_password(host),
+                'ansible_sudo_pass' => rex_sudo_password(host),
+              }
+            }
+          }
+        end
+
+        def rex_ssh_password(host)
+          host_setting(host, 'remote_execution_ssh_password')
+        end
+
+        def rex_sudo_password(host)
+          host_setting(host, 'remote_execution_sudo_password')
+        end
+
+        def host_setting(host, setting)
+          host.params[setting.to_s] || Setting[setting]
+        end
+
         def supports_effective_user?
           true
         end

--- a/app/models/foreman_ansible/ansible_provider.rb
+++ b/app/models/foreman_ansible/ansible_provider.rb
@@ -36,7 +36,7 @@ if defined? ForemanRemoteExecution
             'per-host' => {
               host.name => {
                 'ansible_ssh_pass' => rex_ssh_password(host),
-                'ansible_sudo_pass' => rex_sudo_password(host),
+                'ansible_sudo_pass' => rex_sudo_password(host)
               }
             }
           }

--- a/app/services/foreman_ansible/inventory_creator.rb
+++ b/app/services/foreman_ansible/inventory_creator.rb
@@ -98,8 +98,6 @@ module ForemanAnsible
     def remote_execution_options(host)
       params = {
         'ansible_user' => host_setting(host, 'remote_execution_ssh_user'),
-        'ansible_ssh_pass' => rex_ssh_password(host),
-        'ansible_sudo_pass' => rex_sudo_password(host),
         'ansible_become_method' => host_setting(host, 'remote_execution_effective_user_method'),
         'ansible_ssh_private_key_file' => ansible_or_rex_ssh_private_key(host),
         'ansible_port' => host_setting(host, 'remote_execution_ssh_port'),

--- a/app/services/foreman_ansible/inventory_creator.rb
+++ b/app/services/foreman_ansible/inventory_creator.rb
@@ -122,16 +122,6 @@ module ForemanAnsible
       result
     end
 
-    def rex_ssh_password(host)
-      @template_invocation.job_invocation.password ||
-        host_setting(host, 'remote_execution_ssh_password')
-    end
-
-    def rex_sudo_password(host)
-      @template_invocation.job_invocation.sudo_password ||
-        host_setting(host, 'remote_execution_sudo_password')
-    end
-
     def ansible_or_rex_ssh_private_key(host)
       ansible_private_file = host_setting(host, 'ansible_ssh_private_key_file')
       if !ansible_private_file.empty?

--- a/lib/foreman_ansible_core/runner/ansible_runner.rb
+++ b/lib/foreman_ansible_core/runner/ansible_runner.rb
@@ -5,7 +5,7 @@ module ForemanAnsibleCore
 
       def initialize(input, suspended_action:)
         super input, :suspended_action => suspended_action
-        @inventory = rebuild_inventory(input)
+        @inventory = rebuild_secrets(rebuild_inventory(input), input)
         @playbook = input.values.first[:input][:action_input][:script]
         @root = working_dir
       end
@@ -120,7 +120,7 @@ module ForemanAnsibleCore
       def rebuild_inventory(input)
         action_inputs = input.values.map { |hash| hash[:input][:action_input] }
         hostnames = action_inputs.map { |hash| hash[:name] }
-        inventories = action_inputs.map { |hash| JSON.parse(hash[:ansible_inventory]) }
+        inventories = action_inputs.map { |hash| hash[:ansible_inventory] }
         host_vars = inventories.map { |i| i['_meta']['hostvars'] }.reduce(&:merge)
 
         { '_meta' => { 'hostvars' => host_vars },
@@ -137,6 +137,21 @@ module ForemanAnsibleCore
         else
           Dir.mktmpdir(nil, File.expand_path(dir))
         end
+      end
+
+      def rebuild_secrets(inventory, input)
+        input.each do |host, host_input|
+          secrets = host_input['input']['action_input']['secrets']
+          per_host = secrets['per-host'][host]
+
+          new_secrets = {
+            'ansible_ssh_pass' => inventory['ssh_password'] || per_host['ansible_ssh_pass'],
+            'ansible_sudo_pass' => inventory['sudo_password'] || per_host['ansible_sudo_pass']
+          }
+          inventory['_meta']['hostvars'][host].update(new_secrets)
+        end
+
+        inventory
       end
     end
   end

--- a/test/unit/ansible_provider_test.rb
+++ b/test/unit/ansible_provider_test.rb
@@ -29,6 +29,22 @@ class AnsibleProviderTest < ActiveSupport::TestCase
       end
     end
 
+    context 'when using secrets' do
+      let(:host) { FactoryBot.build(:host) }
+
+      it 'generates secrets properly' do
+        params = {
+          'remote_execution_ssh_password' => 'password',
+          'remote_execution_sudo_password' => 'letmein'
+        }
+        host.expects(:params).twice.returns(params)
+        secrets = ForemanAnsible::AnsibleProvider.secrets(host)
+        host_secrets = secrets['per-host'][host.name]
+        assert_equal host_secrets['ansible_ssh_pass'], 'password'
+        assert_equal host_secrets['ansible_sudo_pass'], 'letmein'
+      end
+    end
+
     def command_options
       ForemanAnsible::AnsibleProvider.
         proxy_command_options(template_invocation, dummyhost)


### PR DESCRIPTION
Before this change the were stored in the inventory, but that meant they were shown in task export as these fields were not hidden.

This patch moves the secrets under a special key which is hidden while exporting. The downside is we have to rebuild the inventory on the smart proxy's side.

Requires:
- [ ] https://github.com/theforeman/foreman_remote_execution/pull/425