### PR TITLE
Fixes #27937 - API for Ansible Inventory template scheduling

### DIFF
--- a/app/controllers/api/v2/ansible_inventories_controller.rb
+++ b/app/controllers/api/v2/ansible_inventories_controller.rb
@@ -31,16 +31,66 @@ module Api
         show_inventory :hostgroup_ids, :hostgroup_id
       end
 
+      api :POST, '/ansible_inventories/schedule',
+          N_('Schedule generating of Ansible Inventory report')
+      param :input_values, Hash, N_('Hash of input values of type input=>value')
+      param :report_format, ReportTemplateFormat.selectable.map(&:id),
+            N_("Report format, defaults to '%s'") % 'json'
+      example <<-EXAMPLE
+      POST /ansible/api/ansible_inventories/schedule
+      {
+        "input_values": {
+          "Organization": "yes",
+          "Location": "yes",
+          "IPv4": "yes",
+          "Facts": "no"
+        }
+      }
+      200
+      {
+        "job_id": UNIQUE-REPORT-GENERATING-JOB-UUID
+        "data_url": "/api/v2/report_templates/1/report_data/UNIQUE-REPORT-GENERATING-JOB-UUID"
+      }
+      EXAMPLE
+
+      def schedule
+        @composer = ReportComposer.from_api_params(schedule_params)
+        if @composer.valid?
+          job = @composer.schedule_rendering
+          response = { :job_id => job.provider_job_id }
+          response[:data_url] = report_data_api_report_template_path(
+            @report_template, :job_id => job.provider_job_id
+          )
+          render :json => response
+        else
+          @ansible_inventory = @composer
+          process_resource_error(:resource => @ansible_inventory)
+        end
+      rescue StandardError => e
+        render_error 'standard_error', :status => :internal_error,
+                                       :locals => { :exception => e }
+      end
+
       def action_permission
         case params[:action]
         when 'hosts', 'hostgroups'
           :view
+        when 'schedule'
+          :generate
         else
           super
         end
       end
 
       private
+
+      def schedule_params
+        template_name = Setting::Ansible.find_by(:name => 'ansible_inventory_template').value
+        @report_template = ReportTemplate.find_by!(:name => template_name)
+        params[:id] = @report_template.id
+        params[:report_format] = 'json' if params[:report_format].blank?
+        params
+      end
 
       def show_inventory(ids_key, condition_key)
         ids = params.fetch(ids_key, []).uniq

--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -80,6 +80,13 @@ class Setting
               false,
               format(N_('%{cfgmgmt} out of sync disabled'),
                      :cfgmgmt => 'Ansible')
+            ),
+            set(
+              'ansible_inventory_template',
+              N_('Foreman will use this template to schedule the report '\
+                 'with Ansible inventory'),
+              'Ansible Inventory',
+              N_('Default Ansible inventory report template')
             )
           ].compact.each do |s|
             create(s.update(:category => 'Setting::Ansible'))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,7 @@ Rails.application.routes.draw do
             get :hosts
             post :hostgroups
             get :hostgroups
+            post :schedule
           end
         end
       end

--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -71,6 +71,9 @@ Foreman::Plugin.register :foreman_ansible do
     permission :edit_hostgroups,
                { :'api/v2/hostgroups' => [:assign_ansible_roles] },
                :resource_type => 'Hostgroup'
+    permission :generate_report_templates,
+               { :'api/v2/ansible_inventories' => [:schedule] },
+               :resource_type => 'ReportTemplate'
   end
 
   role 'Ansible Roles Manager',
@@ -82,7 +85,7 @@ Foreman::Plugin.register :foreman_ansible do
         :edit_ansible_variables, :destroy_ansible_variables]
 
   role 'Ansible Tower Inventory Reader',
-       [:view_hosts, :view_hostgroups, :view_facts],
+       [:view_hosts, :view_hostgroups, :view_facts, :generate_report_templates],
        'Permissions required for the user which is used by Ansible Tower Dynamic Inventory Item'
 
   add_all_permissions_to_default_roles


### PR DESCRIPTION
Requires https://github.com/theforeman/foreman/pull/6875.

To use the endpoint there should exist the `Ansible Inventory` report template (part of this PR)