### PR TITLE
Fixes #27834 - Expect runner json may miss event_data key 

### DIFF
--- a/lib/foreman_ansible_core/runner/ansible_runner.rb
+++ b/lib/foreman_ansible_core/runner/ansible_runner.rb
@@ -41,7 +41,7 @@ module ForemanAnsibleCore
         logger.debug("[foreman_ansible] - parsing event file #{event_file}")
         begin
           event = JSON.parse(File.read(event_file))
-          if (hostname = event['event_data']['host'])
+          if (hostname = event.dig('event_data', 'host'))
             handle_host_event(hostname, event)
           else
             handle_broadcast_data(event)

--- a/test/unit/lib/foreman_ansible_core/ansible_runner_test.rb
+++ b/test/unit/lib/foreman_ansible_core/ansible_runner_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module ForemanAnsibleCore
+  module Runner
+    class AnsibleRunnerTest < ActiveSupport::TestCase
+      describe AnsibleRunner do
+        it 'parses files without event data' do
+          content = <<~JSON
+            {"uuid": "a29d8592-f805-4d0e-b73d-7a53cc35a92e", "stdout": " [WARNING]: Consider using the yum module rather than running 'yum'.  If you", "counter": 8, "end_line": 8, "runner_ident": "e2d9ae11-026a-4f9f-9679-401e4b852ab0", "start_line": 7, "event": "verbose"}
+          JSON
+
+          File.expects(:read).with('fake.json').returns(content)
+          runner = AnsibleRunner.allocate
+          runner.expects(:handle_broadcast_data)
+          assert runner.send(:handle_event_file, 'fake.json')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Sometimes ansible-runner gives hints not related to a specific host, but these messages have a different file format than the regular output files.