### PR TITLE
Fixes #28344 - Add endpoint for variable overrides

### DIFF
--- a/app/controllers/foreman_ansible/concerns/ansible_variable_overrides.rb
+++ b/app/controllers/foreman_ansible/concerns/ansible_variable_overrides.rb
@@ -1,0 +1,91 @@
+module ForemanAnsible
+  module Concerns
+    module AnsibleVariableOverrides
+      extend ActiveSupport::Concern
+
+      include Foreman::Controller::Parameters::Hostgroup
+      include Foreman::Controller::Parameters::Host
+
+      def to_response(resolver)
+        resolver.ansible_variables.group_by(&:ansible_role).each_with_object([]) do |(role, variables), memo|
+          var_hash = variables.map do |var|
+            {
+              :id => var.id,
+              :parameter => var.key,
+              :override => var.override?,
+              :description => var.description,
+              :parameter_type => var.parameter_type,
+              :hidden_value? => var.hidden_value?,
+              :omit => var.omit,
+              :required => var.required,
+              :validator_type => var.validator_type,
+              :validator_rule => var.validator_rule,
+              :default_value => var.default_value,
+              :override_values => var.lookup_values.map { |lv| { :id => lv.id, :match => lv.match, :value => lv.value, :omit => lv.omit } },
+              :current_value => resolver.resolve(var)
+            }
+          end
+
+          memo.push(:id => role.id, :name => role.name, :ansible_variables => var_hash)
+          memo
+        end
+      end
+
+      def refresh_host
+        @host = Host::Base.authorized(:view_hosts, Host).find_by(:id => params[:host_id] || params.dig(:host, :id))
+        @host ||= Host.new(host_params)
+
+        unless @host.is_a?(Host::Managed)
+          @host      = @host.becomes(Host::Managed)
+          @host.type = 'Host::Managed'
+        end
+        @host.attributes = host_params unless @host.new_record?
+
+        @host.lookup_values.each(&:validate_value)
+        @host
+      end
+
+      def hostgroup_params
+        super 'hostgroup'
+      end
+
+      def host_params
+        super 'host'
+      end
+
+      def process_hostgroup
+        define_parent
+        refresh_hostgroup
+        inherit_parent_attributes
+      end
+
+      def define_parent
+        return unless params[:hostgroup][:parent_id]
+        @parent = Hostgroup.authorized(:view_hostgroups).find(params[:hostgroup][:parent_id])
+      end
+
+      def refresh_hostgroup
+        if params[:hostgroup][:id].present?
+          @hostgroup = Hostgroup.authorized(:view_hostgroups).find(params[:hostgroup][:id])
+          @hostgroup.attributes = hostgroup_params
+        else
+          @hostgroup = Hostgroup.new(hostgroup_params)
+        end
+
+        @hostgroup.lookup_values.each(&:validate_value)
+        @hostgroup
+      end
+
+      def inherit_parent_attributes
+        return unless @parent
+
+        @hostgroup.architecture       ||= @parent.architecture
+        @hostgroup.operatingsystem    ||= @parent.operatingsystem
+        @hostgroup.domain             ||= @parent.domain
+        @hostgroup.subnet             ||= @parent.subnet
+        @hostgroup.realm              ||= @parent.realm
+        @hostgroup.environment        ||= @parent.environment
+      end
+    end
+  end
+end

--- a/app/controllers/ui_ansible_roles_controller.rb
+++ b/app/controllers/ui_ansible_roles_controller.rb
@@ -3,6 +3,8 @@ class UiAnsibleRolesController < ::Api::V2::BaseController
     super resource
   end
 
+  layout 'api/v2/layouts/index_layout', :only => [:index]
+
   def index
     @ui_ansible_roles = resource_scope_for_index(:permission => :view_ansible_roles)
   end

--- a/app/services/foreman_ansible/override_resolver.rb
+++ b/app/services/foreman_ansible/override_resolver.rb
@@ -1,0 +1,56 @@
+module ForemanAnsible
+  # Service which resolves override values for hosts and hostgroups
+  class OverrideResolver
+    attr_reader :overrides, :ansible_variables
+
+    def initialize(host_or_hg)
+      @overrides = calculate_variable_overrides(host_or_hg)
+    end
+
+    def resolve(ansible_variable)
+      override = @overrides[ansible_variable.id]
+      return unless override
+      override[ansible_variable.key]
+    end
+
+    private
+
+    def calculate_variable_overrides(resource)
+      if resource.is_a? Hostgroup
+        @ansible_variables = AnsibleVariable.where(:ansible_role_id => resource.inherited_and_own_ansible_roles, :override => true)
+        hostgroup_values_hash resource
+      else
+        @ansible_variables = AnsibleVariable.where(:ansible_role_id => resource.all_ansible_roles, :override => true)
+        @ansible_variables.values_hash(resource).raw
+      end
+    end
+
+    def hostgroup_values_hash(hostgroup)
+      @ansible_variables.each_with_object({}) do |ansvar, memo|
+        next memo unless ansvar.override
+        hash_result = inherited_hostgroup_value(hostgroup, ansvar)
+        next memo unless hash_result
+        memo[ansvar.id] = {
+          ansvar.key => {
+            :value => hash_result[:lookup_value].value,
+            :element => 'hostgroup',
+            :element_name => hash_result[:hostgroup].name
+          }
+        }
+        memo
+      end
+    end
+
+    def inherited_hostgroup_value(hostgroup, ansvar)
+      return if !ansvar.path_elements.flatten.include?('hostgroup') && !Setting['matchers_inheritance']
+
+      value = nil
+      matched_hg = hostgroup.path.reverse.find do |hg|
+        value = LookupValue.find_by(:lookup_key_id => ansvar.id, :id => hg.lookup_values)
+      end
+
+      return unless value
+      { :lookup_value => value, :hostgroup => matched_hg }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
         get :import
         post :confirm_import
         get 'auto_complete_search'
+        post :overrides
       end
     end
 

--- a/lib/foreman_ansible/engine.rb
+++ b/lib/foreman_ansible/engine.rb
@@ -18,6 +18,7 @@ module ForemanAnsible
     config.autoload_paths += Dir["#{config.root}/app/services"]
     config.autoload_paths += Dir["#{config.root}/app/views"]
     config.autoload_paths += Dir["#{config.root}/app/lib"]
+    config.autoload_paths += Dir["#{config.root}/test/"]
 
     initializer 'foreman_ansible.load_default_settings',
                 :before => :load_config_initializers do

--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -29,7 +29,7 @@ Foreman::Plugin.register :foreman_ansible do
                :resource_type => 'AnsibleRole'
     permission :view_ansible_variables,
                {
-                 :ansible_variables => [:index, :auto_complete_search],
+                 :ansible_variables => [:index, :auto_complete_search, :overrides],
                  :'api/v2/ansible_variables' => [:index, :show]
                },
                :resource_type => 'AnsibleVariable'

--- a/test/unit/services/override_resolver_test.rb
+++ b/test/unit/services/override_resolver_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'test_plugin_helper'
+
+module ForemanAnsible
+  class OverrideResolverTest < ActiveSupport::TestCase
+    test 'should return no overrides when no roles assigned to host' do
+      assert_empty OverrideResolver.new(FactoryBot.build(:host)).overrides
+    end
+
+    test 'should return no overrides when no roles assigned to hostgroup' do
+      assert_empty OverrideResolver.new(FactoryBot.build(:hostgroup)).overrides
+    end
+
+    test 'should return overrides for existing host' do
+      first_role = FactoryBot.create(:ansible_role)
+      first_var = FactoryBot.create(:ansible_variable, :override => true, :ansible_role => first_role)
+      second_role = FactoryBot.create(:ansible_role)
+      second_var = FactoryBot.create(:ansible_variable, :override => true, :ansible_role => second_role)
+      host = FactoryBot.create(:host, :ansible_roles => [first_role])
+      another_host = FactoryBot.create(:host)
+
+      FactoryBot.create(:lookup_value, :match => "fqdn=#{host.name}", :lookup_key_id => first_var.id)
+      FactoryBot.create(:lookup_value, :match => "fqdn=#{another_host.name}", :lookup_key_id => first_var.id)
+      FactoryBot.create(:lookup_value, :match => "fqdn=#{host.name}", :lookup_key_id => second_var.id)
+
+      assert_not_nil OverrideResolver.new(host).resolve(first_var)
+      assert_nil OverrideResolver.new(another_host).resolve(first_var)
+      assert_nil OverrideResolver.new(host).resolve(second_var)
+    end
+
+    test 'should return overrides for existing hostgroup without parent' do
+      first_role = FactoryBot.create(:ansible_role)
+      first_var = FactoryBot.create(:ansible_variable, :override => true, :ansible_role => first_role)
+      hostgroup = FactoryBot.create(:hostgroup, :ansible_roles => [first_role])
+
+      second_role = FactoryBot.create(:ansible_role)
+      second_var = FactoryBot.create(:ansible_variable, :override => true, :ansible_role => second_role)
+      another_hostgroup = FactoryBot.create(:hostgroup)
+
+      FactoryBot.create(:lookup_value, :match => "hostgroup=#{hostgroup.name}", :lookup_key_id => first_var.id)
+      FactoryBot.create(:lookup_value, :match => "hostgroup=#{another_hostgroup.name}", :lookup_key_id => first_var.id)
+      FactoryBot.create(:lookup_value, :match => "hostgroup=#{hostgroup.name}", :lookup_key_id => second_var.id)
+
+      assert_not_nil OverrideResolver.new(hostgroup).resolve(first_var)
+      assert_nil OverrideResolver.new(another_hostgroup).resolve(first_var)
+      assert_nil OverrideResolver.new(hostgroup).resolve(second_var)
+    end
+
+    test 'should return overrides for existing hostgroup inheriteded from parent' do
+      first_role = FactoryBot.create(:ansible_role)
+      first_var = FactoryBot.create(:ansible_variable, :override => true, :ansible_role => first_role)
+
+      parent = FactoryBot.create(:hostgroup, :ansible_roles => [first_role])
+      hostgroup = FactoryBot.create(:hostgroup, :parent_id => parent.id)
+
+      second_role = FactoryBot.create(:ansible_role)
+      second_var = FactoryBot.create(:ansible_variable, :override => true, :ansible_role => second_role)
+      another_hostgroup = FactoryBot.create(:hostgroup)
+
+      FactoryBot.create(:lookup_value, :match => "hostgroup=#{parent.name}", :lookup_key_id => first_var.id)
+      FactoryBot.create(:lookup_value, :match => "hostgroup=#{another_hostgroup.name}", :lookup_key_id => first_var.id)
+      FactoryBot.create(:lookup_value, :match => "hostgroup=#{parent.name}", :lookup_key_id => second_var.id)
+
+      assert_not_nil OverrideResolver.new(hostgroup).resolve(first_var)
+      assert_nil OverrideResolver.new(another_hostgroup).resolve(first_var)
+      assert_nil OverrideResolver.new(hostgroup).resolve(second_var)
+    end
+
+    test 'should return overrides for existing hostgroup not inherited from parent' do
+      first_role = FactoryBot.create(:ansible_role)
+      first_var = FactoryBot.create(:ansible_variable, :override => true, :ansible_role => first_role)
+
+      parent = FactoryBot.create(:hostgroup, :ansible_roles => [first_role])
+      hostgroup = FactoryBot.create(:hostgroup, :parent_id => parent.id)
+
+      second_role = FactoryBot.create(:ansible_role)
+      second_var = FactoryBot.create(:ansible_variable, :override => true, :ansible_role => second_role)
+      another_hostgroup = FactoryBot.create(:hostgroup)
+
+      FactoryBot.create(:lookup_value, :match => "hostgroup=#{parent.name}", :lookup_key_id => first_var.id, :value => 'foo')
+      lookup_value = FactoryBot.create(:lookup_value, :match => "hostgroup=#{hostgroup.title}", :lookup_key_id => first_var.id, :value => 'bar')
+      FactoryBot.create(:lookup_value, :match => "hostgroup=#{parent.name}", :lookup_key_id => second_var.id)
+
+      resolver = OverrideResolver.new(hostgroup)
+
+      override = resolver.resolve(first_var)
+      assert_equal hostgroup.name, override[:element_name]
+      assert_equal lookup_value.value, override[:value]
+      assert_nil OverrideResolver.new(another_hostgroup).resolve(first_var)
+      assert_nil resolver.resolve(second_var)
+    end
+
+    test 'should return override for new host with hostgroup based on os' do
+      host_os = FactoryBot.create(:operatingsystem)
+      hostgroup_os = FactoryBot.create(:operatingsystem)
+      first_role = FactoryBot.create(:ansible_role)
+      first_var = FactoryBot.create(:ansible_variable, :override => true, :ansible_role => first_role)
+      hostgroup = FactoryBot.create(:hostgroup, :ansible_roles => [first_role], :operatingsystem => hostgroup_os)
+      host = FactoryBot.build(:host, :hostgroup => hostgroup, :operatingsystem => host_os)
+      assert_nil host.id
+
+      FactoryBot.create(:lookup_value, :match => "os=#{hostgroup_os.title}", :lookup_key_id => first_var.id, :value => 'foo')
+      lookup_value = FactoryBot.create(:lookup_value, :match => "os=#{host_os.title}", :lookup_key_id => first_var.id, :value => 'bar')
+
+      resolver = OverrideResolver.new(host)
+
+      override = resolver.resolve(first_var)
+      assert_equal host_os.title, override[:element_name]
+      assert_equal lookup_value.value, override[:value]
+    end
+  end
+end


### PR DESCRIPTION
This adds an endpoint that serves ansible variables and overrides, which will be needed for displaying them in host(group) form. 

Includes changes in AnsibleRolesSwitcher to query the endpoint. There are no changes from user's perspective, but you can notice the request and new data in store.

I intentionally did not include any visible UI changes to keep this as small as possible.