### PR TITLE
Fixes #28431 - Fix double encoded JSON issue

### DIFF
--- a/app/models/foreman_ansible/ansible_provider.rb
+++ b/app/models/foreman_ansible/ansible_provider.rb
@@ -22,7 +22,7 @@ if defined? ForemanRemoteExecution
           super(template_invocation, host).merge(
             'ansible_inventory' => ::ForemanAnsible::InventoryCreator.new(
               [host], template_invocation
-            ).to_hash.to_json,
+            ).to_hash,
             :verbosity_level => Setting[:ansible_verbosity],
             :remote_execution_command => ansible_command?(
               template_invocation.template


### PR DESCRIPTION
Ansible core expects ansible_inventory to be a hash, not a String. Let's skip
one round of the encoding.