### PR TITLE
Fixes #28447 - fix the permission definition

### DIFF
--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -71,9 +71,8 @@ Foreman::Plugin.register :foreman_ansible do
     permission :edit_hostgroups,
                { :'api/v2/hostgroups' => [:assign_ansible_roles] },
                :resource_type => 'Hostgroup'
-    permission :generate_report_templates,
-               { :'api/v2/ansible_inventories' => [:schedule] },
-               :resource_type => 'ReportTemplate'
+    permission :generate_ansible_inventory,
+               { :'api/v2/ansible_inventories' => [:schedule] }
   end
 
   role 'Ansible Roles Manager',
@@ -85,7 +84,8 @@ Foreman::Plugin.register :foreman_ansible do
         :edit_ansible_variables, :destroy_ansible_variables]
 
   role 'Ansible Tower Inventory Reader',
-       [:view_hosts, :view_hostgroups, :view_facts, :generate_report_templates],
+       [:view_hosts, :view_hostgroups, :view_facts, :generate_report_templates, :generate_ansible_inventory,
+        :view_report_templates],
        'Permissions required for the user which is used by Ansible Tower Dynamic Inventory Item'
 
   add_all_permissions_to_default_roles

--- a/test/functional/api/v2/ansible_inventories_controller_test.rb
+++ b/test/functional/api/v2/ansible_inventories_controller_test.rb
@@ -32,6 +32,16 @@ module Api
         hosts_inventory_assertions(@hostgroup.hosts)
       end
 
+      test 'schedule inventory by user' do
+        report = FactoryBot.create(:report_template)
+        setting = Setting::Ansible.create! :name => 'ansible_inventory_template', :value  => report.name,
+          :default => report.name, :description => 'inventory'
+        user = FactoryBot.create(:user)
+        user.roles << Role.find_by_name('Ansible Tower Inventory Reader')
+        post :schedule, { :session => set_session_user(user) }
+        assert_response :success
+      end
+
       private
 
       def hosts_inventory_assertions(hosts)


### PR DESCRIPTION
@ofedoren this fixes the permission issue, the generate_report_template wouldn't match the ansible_invetories controller and it seems we can't extend core permissions this way