### PR TITLE
Fixes #28463 - Fix missing roles in the assigned roles list

### DIFF
--- a/webpack/components/AnsibleRolesSwitcher/AnsibleRolesSwitcher.js
+++ b/webpack/components/AnsibleRolesSwitcher/AnsibleRolesSwitcher.js
@@ -89,6 +89,7 @@ class AnsibleRolesSwitcher extends React.Component {
             </div>
             <AssignedRolesList
               assignedRoles={assignedRoles}
+              allAssignedRoles={allAssignedRoles}
               pagination={assignedPagination}
               itemCount={assignedRolesCount}
               onPaginationChange={changeAssignedPage}

--- a/webpack/components/AnsibleRolesSwitcher/components/AssignedRolesList.js
+++ b/webpack/components/AnsibleRolesSwitcher/components/AssignedRolesList.js
@@ -8,13 +8,16 @@ import AnsibleRole from './AnsibleRole';
 
 const AssignedRolesList = ({
   assignedRoles,
+  allAssignedRoles,
   pagination,
   itemCount,
   onPaginationChange,
   onRemoveRole,
   resourceName,
 }) => {
-  const directlyAssignedRoles = assignedRoles.filter(role => !role.inherited);
+  const directlyAssignedRoles = allAssignedRoles.filter(
+    role => !role.inherited
+  );
 
   return (
     <div>
@@ -62,6 +65,7 @@ const AssignedRolesList = ({
 
 AssignedRolesList.propTypes = {
   assignedRoles: PropTypes.arrayOf(PropTypes.object).isRequired,
+  allAssignedRoles: PropTypes.arrayOf(PropTypes.object).isRequired,
   pagination: PropTypes.shape({
     page: PropTypes.number,
     perPage: PropTypes.number,

--- a/webpack/components/AnsibleRolesSwitcher/components/AssignedRolesList.test.js
+++ b/webpack/components/AnsibleRolesSwitcher/components/AssignedRolesList.test.js
@@ -6,7 +6,14 @@ const noop = () => {};
 
 const fixtures = {
   'should render': {
-    assignedRoles: [{ id: 1, name: 'fake.role' }, { id: 2, name: 'test.role' }],
+    allAssignedRoles: [
+      { id: 1, name: 'fake.role' },
+      { id: 2, name: 'test.role' },
+    ],
+    assignedRoles: [
+      { id: 1, name: 'fake.role' },
+      { id: 2, name: 'test.role' },
+    ],
     pagination: { page: 1, perPage: 25 },
     itemCount: 2,
     onPaginationChange: noop,


### PR DESCRIPTION
Needed to populate directlyAssignedRoles with allAssignedRoles instead of assignedRoles to get the whole list of roles not just visible ones. 