### PR TITLE
Drop tasks dependency

### DIFF
--- a/foreman_ansible.gemspec
+++ b/foreman_ansible.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   # Kept as a dev dependency so tests can run together
   s.add_development_dependency 'foreman_ansible_core', '~> 3.0'
   s.add_dependency 'deface', '< 2.0'
-  s.add_dependency 'foreman-tasks', '~> 0.8'
-  s.add_dependency 'foreman_remote_execution', '>= 2.0.0', '< 3.0'
+  s.add_dependency 'foreman_remote_execution', '>= 2.0.0'
   s.add_dependency 'ipaddress', '>= 0.8.0', '< 1.0'
 end


### PR DESCRIPTION
With foreman-tasks 1.0.0, this would no longer be compatible. However 1.0.0 bump only means, tasks now use vendor 3. Also I think we don't need to depend on this anymore since we depend on REX.