### PR TITLE
Check to see if variables is nil before proceeding

### DIFF
--- a/app/services/foreman_ansible/variables_importer.rb
+++ b/app/services/foreman_ansible/variables_importer.rb
@@ -29,6 +29,7 @@ module ForemanAnsible
     def import_variables(role_variables, new_roles)
       detect_changes(
         role_variables.map do |role_name, variables|
+          next if variables.blank?
           role = import_new_role(role_name, new_roles)
           next if role.blank?
           initialize_variables(variables, role)


### PR DESCRIPTION
Ref: https://community.theforeman.org/t/openscap-plugin-with-ansible-role-variables-import-failed/16601

When attempting ansible variables import through the Foreman UI, there is a case where
clicking **Configure** > **Ansible Variables** > **Import from Foreman** will fail. The error that gets
thrown is the following:

```
*NoMethodError*
**undefined method `map' for nil:NilClass**

/opt/theforeman/tfm/root/usr/share/gems/gems/foreman_ansible-3.0.9/app/services/foreman_ansible/variables_importer.rb:48:in `initialize_variables'
/opt/theforeman/tfm/root/usr/share/gems/gems/foreman_ansible-3.0.9/app/services/foreman_ansible/variables_importer.rb:34:in `block in import_variables'
/opt/theforeman/tfm/root/usr/share/gems/gems/foreman_ansible-3.0.9/app/services/foreman_ansible/variables_importer.rb:31:in `each'
/opt/theforeman/tfm/root/usr/share/gems/gems/foreman_ansible-3.0.9/app/services/foreman_ansible/variables_importer.rb:31:in `map'
/opt/theforeman/tfm/root/usr/share/gems/gems/foreman_ansible-3.0.9/app/services/foreman_ansible/variables_importer.rb:31:in `import_variables'
/opt/theforeman/tfm/root/usr/share/gems/gems/foreman_ansible-3.0.9/app/services/foreman_ansible/variables_importer.rb:25:in `import_variable_names'
```

This commit will skip those nil variables, which then makes Foreman operate as expected.