### PR TITLE
Fixes #28612 - Fix runs when proxy batch triggering is disabled

### DIFF
--- a/app/models/foreman_ansible/ansible_provider.rb
+++ b/app/models/foreman_ansible/ansible_provider.rb
@@ -62,6 +62,10 @@ if defined? ForemanRemoteExecution
           'ansible-runner'
         end
 
+        def proxy_action_class
+          'ForemanAnsibleCore::TaskLauncher::Playbook::PlaybookRunnerAction'
+        end
+
         def required_proxy_selector_for(template)
           if template.remote_execution_features.where(:label => 'ansible_run_capsule_upgrade').any?
             ::DefaultProxyProxySelector.new


### PR DESCRIPTION
Before this change, the playbook was interpreted as a shell script on the proxy side because a default action class from REX was being used.

requires:
- [x] https://github.com/theforeman/foreman_remote_execution/pull/457