### PR TITLE
Fixes #28937 - ansible variable type form field

### DIFF
--- a/app/views/ansible_variables/_fields.erb
+++ b/app/views/ansible_variables/_fields.erb
@@ -15,7 +15,7 @@
         ) %>
 
     <% version = Foreman::Version.new %>
-    <% if version.major.to_i >= 1 && version.minor.to_i >= 22 %>
+    <% if version.major.to_i > 1 || version.minor.to_i >= 22 %>
       <%= param_type_selector(f, false, :onchange => 'keyTypeChange(this)', :disabled => !f.object.override) %>
     <% else %>
       <%= param_type_selector(f, :onchange => 'keyTypeChange(this)', :disabled => !f.object.override) %>


### PR DESCRIPTION
On foreman 2.0 we go to the else branch and render old method.