### PR TITLE
fixes #28963: Do not evaluate shell characters while returning the inventory

### DIFF
--- a/lib/foreman_ansible_core/runner/ansible_runner.rb
+++ b/lib/foreman_ansible_core/runner/ansible_runner.rb
@@ -82,7 +82,7 @@ module ForemanAnsibleCore
       def write_inventory
         inventory_script = <<~INVENTORY_SCRIPT
           #!/bin/sh
-          cat <<-EOS
+          cat <<-'EOS'
           #{JSON.dump(@inventory)}
           EOS
         INVENTORY_SCRIPT


### PR DESCRIPTION
The new ansible-runner inventory file generator evaluates environment variables while printing the Inventory with cat.

This leads to unexpected behaviour while having $variables inside of host / common parameters.

Trivial fix: just use shell built-ins (single quotes) to disable evaluating the strings inside the cat block.