### PR TITLE
Fixes #29138 - Fix rendering overriden False variables in YAML output

### DIFF
--- a/app/services/foreman_ansible/ansible_info.rb
+++ b/app/services/foreman_ansible/ansible_info.rb
@@ -10,7 +10,7 @@ module ForemanAnsible
 
       variables.each_with_object({}) do |var, memo|
         value = values[var]
-        memo[var.key] = value if value
+        memo[var.key] = value unless value.nil?
         memo
       end
     end


### PR DESCRIPTION
"if value" checks if value is either true or not nil. So the test is false if the value is false.
Whereas "unless value.nil?" checks if the value not nil.