### PR TITLE
Fixes #29343 - update Ansible Inventory template name

### DIFF
--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -78,7 +78,7 @@ class Setting
             'ansible_inventory_template',
             N_('Foreman will use this template to schedule the report '\
                'with Ansible inventory'),
-            'Ansible Inventory',
+            'Ansible - Ansible Inventory',
             N_('Default Ansible inventory report template')
           )
         ]


### PR DESCRIPTION
Foreman 2.1 will probably contain a change that renames the inventory
report template, thanks to the mass renaming in https://github.com/theforeman/community-templates/pull/680

We have the name set as the default value in Settings. For people who
didn't change it, changing the default will do. For people who changed
the value to some other template, their value remains unchanged, which
is expected. No more actions are needed therefore.