### PR TITLE
Fixes #29587 - Update default template name for Ansible inventory

### DIFF
--- a/app/models/setting/ansible.rb
+++ b/app/models/setting/ansible.rb
@@ -78,7 +78,7 @@ class Setting
             'ansible_inventory_template',
             N_('Foreman will use this template to schedule the report '\
                'with Ansible inventory'),
-            'Ansible Inventory',
+            'Ansible - Ansible Inventory',
             N_('Default Ansible inventory report template')
           )
         ]

--- a/db/migrate/20200421201839_update_ansible_inv_template_name.rb
+++ b/db/migrate/20200421201839_update_ansible_inv_template_name.rb
@@ -1,0 +1,9 @@
+class UpdateAnsibleInvTemplateName < ActiveRecord::Migration[5.2]
+  def up
+    setting = Setting.find_by(:name => 'ansible_inventory_template')
+    setting.update(:default => 'Ansible - Ansible Inventory')
+    return unless setting.value == 'Ansible Inventory'
+
+    setting.update(:value => 'Ansible - Ansible Inventory')
+  end
+end


### PR DESCRIPTION
@ares, I've tried to use default (changed of course) value without migration and it just worked on my setup. So, not sure if that's needed.