### PR TITLE
Fixes #29627 - fixed ansible-runner verbosity in plays

### DIFF
--- a/lib/foreman_ansible_core/runner/ansible_runner.rb
+++ b/lib/foreman_ansible_core/runner/ansible_runner.rb
@@ -10,6 +10,7 @@ module ForemanAnsibleCore
         @inventory = rebuild_secrets(rebuild_inventory(input), input)
         @playbook = input.values.first[:input][:action_input][:script]
         @root = working_dir
+        @verbosity_level = input.values.first[:input][:action_input][:verbosity_level]
       end
 
       def start
@@ -99,8 +100,17 @@ module ForemanAnsibleCore
 
       def start_ansible_runner
         command = ['ansible-runner', 'run', @root, '-p', 'playbook.yml']
+        command << verbosity if verbose?
         initialize_command(*command)
         logger.debug("[foreman_ansible] - Running command '#{command.join(' ')}'")
+      end
+
+      def verbosity
+        '-' + 'v' * @verbosity_level.to_i
+      end
+
+      def verbose?
+        @verbosity_level.to_i.positive?
       end
 
       def prepare_directory_structure


### PR DESCRIPTION



With this patch, Ansible execution through foreman shows debug/verbose output as per the `ansible_verbosity` setting.

~~~
 1: ansible-playbook 2.8.10
   2:   config file = /usr/share/foreman-proxy/.ansible.cfg
   3:   configured module search path = [u'/usr/share/foreman-proxy/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
   4:   ansible python module location = /usr/lib/python2.7/site-packages/ansible
   5:   executable location = /usr/bin/ansible-playbook
   6:   python version = 2.7.5 (default, Sep 26 2019, 13:23:47) [GCC 4.8.5 20150623 (Red Hat 4.8.5-39)]
   7: Using /usr/share/foreman-proxy/.ansible.cfg as config file
   8: host_list declined parsing /tmp/d20200427-20155-1ddcn1c/inventory/hosts as it did not pass it's verify_file() method
   9: Parsed /tmp/d20200427-20155-1ddcn1c/inventory/hosts inventory source with script plugin
  10:

  11: PLAYBOOK: playbook.yml *********************************************************
  12: 1 plays in playbook.yml
  13:

  14: PLAY [Patching] ****************************************************************
  15:

  16: TASK [Gathering Facts] *********************************************************
  17: task path: /tmp/d20200427-20155-1ddcn1c/project/playbook.yml:2
  18: <client.example.com> ESTABLISH SSH CONNECTION FOR USER: root
  19: <client.example.com> SSH: EXEC ssh -o ProxyCommand=none -o StrictHostKeyChecking=no -o Port=22 -o 'IdentityFile="/usr/share/foreman-proxy/.ssh/id_rsa_foreman_proxy"' -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o 'User="root"' -o ConnectTimeout=10 client.example.com '/bin/sh -c '"'"'echo ~root && sleep 0'"'"''
~~~