### PR TITLE
Refs #29587 - Correct setting migration

### DIFF
--- a/db/migrate/20200421201839_update_ansible_inv_template_name.rb
+++ b/db/migrate/20200421201839_update_ansible_inv_template_name.rb
@@ -1,9 +1,9 @@
 class UpdateAnsibleInvTemplateName < ActiveRecord::Migration[5.2]
   def up
-    setting = Setting.find_by(:name => 'ansible_inventory_template')
-    setting.update(:default => 'Ansible - Ansible Inventory')
-    return unless setting.value == 'Ansible Inventory'
-
-    setting.update(:value => 'Ansible - Ansible Inventory')
+    Setting.where(:name => 'ansible_inventory_template').update_all(:default => 'Ansible - Ansible Inventory')
+  end
+  
+  def down
+    Setting.where(:name => 'ansible_inventory_template').update_all(:default => 'Ansible Inventory')
   end
 end


### PR DESCRIPTION
In case the setting isn't present when running the migration, migration
will fail. Also no need to update the value if it is the default - it
would be saved as nil in the database and automatically update to the
new default value.
Added down migration as well for returning it to the previous default.