### PR TITLE
Fixes #29784 - Use InternalProxy selector for capsule upgrade

### DIFF
--- a/app/models/foreman_ansible/ansible_provider.rb
+++ b/app/models/foreman_ansible/ansible_provider.rb
@@ -62,6 +62,14 @@ if defined? ForemanRemoteExecution
           'ansible-runner'
         end
 
+        def required_proxy_selector_for(template)
+          if template.remote_execution_features.where(:label => 'ansible_run_capsule_upgrade').any?
+            ::InternalProxyProxySelector.new
+          else
+            super
+          end
+        end
+
         private
 
         def ansible_command?(template)

--- a/app/models/foreman_ansible/ansible_provider.rb
+++ b/app/models/foreman_ansible/ansible_provider.rb
@@ -64,7 +64,7 @@ if defined? ForemanRemoteExecution
 
         def required_proxy_selector_for(template)
           if template.remote_execution_features.where(:label => 'ansible_run_capsule_upgrade').any?
-            ::InternalProxyProxySelector.new
+            ::DefaultProxyProxySelector.new
           else
             super
           end

--- a/foreman_ansible.gemspec
+++ b/foreman_ansible.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   # Kept as a dev dependency so tests can run together
   s.add_development_dependency 'foreman_ansible_core', '~> 3.0'
   s.add_dependency 'deface', '< 2.0'
-  s.add_dependency 'foreman_remote_execution', '>= 2.0.0'
+  s.add_dependency 'foreman_remote_execution', '>= 3.3.0'
   s.add_dependency 'ipaddress', '>= 0.8.0', '< 1.0'
 end

--- a/lib/foreman_ansible/remote_execution.rb
+++ b/lib/foreman_ansible/remote_execution.rb
@@ -42,6 +42,11 @@ module ForemanAnsible
         :description => N_('Run an Ansible playbook to enable web console on given hosts'),
         :host_action_button => true
       )
+      RemoteExecutionFeature.register(
+        :ansible_run_capsule_upgrade,
+        N_('Upgrade capsules on given hosts'),
+        :description => N_('Upgrade capsules on given capsule server hosts')
+      )
     end
   end
 end

--- a/lib/foreman_ansible/remote_execution.rb
+++ b/lib/foreman_ansible/remote_execution.rb
@@ -44,8 +44,8 @@ module ForemanAnsible
       )
       RemoteExecutionFeature.register(
         :ansible_run_capsule_upgrade,
-        N_('Upgrade capsules on given hosts'),
-        :description => N_('Upgrade capsules on given capsule server hosts')
+        N_('Upgrade Capsules on given hosts'),
+        :description => N_('Upgrade Capsules on given Capsule server hosts')
       )
     end
   end


### PR DESCRIPTION
Requires
- [x] https://github.com/theforeman/foreman_remote_execution/pull/490
- [x] https://github.com/theforeman/community-templates/pull/731