### PR TITLE
Fixes #30518 - Remove working directory

### DIFF
--- a/lib/foreman_ansible_core/runner/ansible_runner.rb
+++ b/lib/foreman_ansible_core/runner/ansible_runner.rb
@@ -38,6 +38,11 @@ module ForemanAnsibleCore
         end
       end
 
+      def close
+        super
+        FileUtils.remove_entry(@root) if @tmp_working_dir
+      end
+
       private
 
       def handle_event_file(event_file)


### PR DESCRIPTION
Removing the working directory once the job is executed. 