### PR TITLE
Fixes #30648 - Make sure cloud connector is configured from internal proxy

### DIFF
--- a/app/models/foreman_ansible/ansible_provider.rb
+++ b/app/models/foreman_ansible/ansible_provider.rb
@@ -5,6 +5,11 @@ if defined? ForemanRemoteExecution
     # Provider for RemoteExecution that allows to run Ansible playbooks.
     # Read the source of other RemoteExecution providers for more.
     class AnsibleProvider < RemoteExecutionProvider
+      FEATURES_THROUGH_INTERNAL_PROXY = %w(
+        ansible_run_capsule_upgrade
+        ansible_configure_cloud_connector
+      ).freeze
+
       class << self
         def ssh_password(host)
           host_setting(host, :remote_execution_ssh_password)
@@ -67,7 +72,7 @@ if defined? ForemanRemoteExecution
         end
 
         def required_proxy_selector_for(template)
-          if template.remote_execution_features.where(:label => 'ansible_run_capsule_upgrade').any?
+          if template.remote_execution_features.where(:label => FEATURES_THROUGH_INTERNAL_PROXY).any?
             ::DefaultProxyProxySelector.new
           else
             super

--- a/app/models/foreman_ansible/ansible_provider.rb
+++ b/app/models/foreman_ansible/ansible_provider.rb
@@ -5,11 +5,6 @@ if defined? ForemanRemoteExecution
     # Provider for RemoteExecution that allows to run Ansible playbooks.
     # Read the source of other RemoteExecution providers for more.
     class AnsibleProvider < RemoteExecutionProvider
-      FEATURES_THROUGH_INTERNAL_PROXY = %w(
-        ansible_run_capsule_upgrade
-        ansible_configure_cloud_connector
-      ).freeze
-
       class << self
         def ssh_password(host)
           host_setting(host, :remote_execution_ssh_password)

--- a/app/models/foreman_ansible/ansible_provider.rb
+++ b/app/models/foreman_ansible/ansible_provider.rb
@@ -66,14 +66,6 @@ if defined? ForemanRemoteExecution
           'ForemanAnsibleCore::TaskLauncher::Playbook::PlaybookRunnerAction'
         end
 
-        def required_proxy_selector_for(template)
-          if template.remote_execution_features.where(:label => FEATURES_THROUGH_INTERNAL_PROXY).any?
-            ::DefaultProxyProxySelector.new
-          else
-            super
-          end
-        end
-
         private
 
         def ansible_command?(template)

--- a/app/views/foreman_ansible/job_templates/configure_cloud_connector_-_ansible_default.erb
+++ b/app/views/foreman_ansible/job_templates/configure_cloud_connector_-_ansible_default.erb
@@ -26,6 +26,7 @@ job_category: Maintenance Operations
 description_format: "%{template_name}"
 provider_type: Ansible
 kind: job_template
+feature: ansible_configure_cloud_connector
 %>
 
 ---

--- a/foreman_ansible.gemspec
+++ b/foreman_ansible.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   # Kept as a dev dependency so tests can run together
   s.add_development_dependency 'foreman_ansible_core', '~> 3.0'
   s.add_dependency 'deface', '< 2.0'
-  s.add_dependency 'foreman_remote_execution', '>= 4.0.0'
+  s.add_dependency 'foreman_remote_execution', '>= 4.2.0'
   s.add_dependency 'ipaddress', '>= 0.8.0', '< 1.0'
 end

--- a/lib/foreman_ansible/remote_execution.rb
+++ b/lib/foreman_ansible/remote_execution.rb
@@ -45,12 +45,14 @@ module ForemanAnsible
       RemoteExecutionFeature.register(
         :ansible_run_capsule_upgrade,
         N_('Upgrade Capsules on given hosts'),
-        :description => N_('Upgrade Capsules on given Capsule server hosts')
+        :description => N_('Upgrade Capsules on given Capsule server hosts'),
+        :proxy_selector_override => ::RemoteExecutionProxySelector::INTERNAL_PROXY
       )
       RemoteExecutionFeature.register(
         :ansible_configure_cloud_connector,
         N_('Configure Cloud Connector on given hosts'),
-        :description => N_('Configure Cloud Connector on given hosts')
+        :description => N_('Configure Cloud Connector on given hosts'),
+        :proxy_selector_override => ::RemoteExecutionProxySelector::INTERNAL_PROXY
       )
     end
   end

--- a/lib/foreman_ansible/remote_execution.rb
+++ b/lib/foreman_ansible/remote_execution.rb
@@ -47,6 +47,11 @@ module ForemanAnsible
         N_('Upgrade Capsules on given hosts'),
         :description => N_('Upgrade Capsules on given Capsule server hosts')
       )
+      RemoteExecutionFeature.register(
+        :ansible_configure_cloud_connector,
+        N_('Configure Cloud Connector on given hosts'),
+        :description => N_('Configure Cloud Connector on given hosts')
+      )
     end
   end
 end


### PR DESCRIPTION
The playbook does some local lookups so running it from another proxy would fail.

Requires
- [x] https://github.com/theforeman/foreman_remote_execution/pull/530