### PR TITLE
Fixes #30788 - Bring enable web console template

### DIFF
--- a/app/views/foreman_ansible/job_templates/service_action_-_enable_web_console.erb
+++ b/app/views/foreman_ansible/job_templates/service_action_-_enable_web_console.erb
@@ -1,0 +1,16 @@
+<%#
+name: Service Action - Enable Web Console
+job_category: Ansible Services
+snippet: false
+provider_type: Ansible
+kind: job_template
+model: JobTemplate
+feature: ansible_enable_web_console
+%>
+---
+- hosts: all
+  tasks:
+  - name: ensure cockpit is installed
+    package:
+      name: "cockpit-system"
+      state: present


### PR DESCRIPTION
This template got left behind when the community-templates repo got closed.