### PR TITLE
Fixes #30972 - use new mounter for ReportJsonViewer component

### DIFF
--- a/app/helpers/foreman_ansible/ansible_reports_helper.rb
+++ b/app/helpers/foreman_ansible/ansible_reports_helper.rb
@@ -42,10 +42,7 @@ module ForemanAnsible
     end
 
     def report_json_viewer(json)
-      uid = "reportjson-viewer-#{json.object_id}"
-      viewer = content_tag :div, '', :id => uid
-      viewer << mount_react_component('ReportJsonViewer',
-                                      "##{uid}", json.to_json)
+      react_component('ReportJsonViewer', data: json)
     end
 
     private


### PR DESCRIPTION
Switch to the new `react_component` React mounter for mounting ReportJsonViewer.