### PR TITLE
Write cache on push to master

### DIFF
--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -1,5 +1,9 @@
 name: Ruby Testing
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+    - master
 env:
   BUNDLE_WITHOUT: journald:development:console:libvirt
   RAILS_ENV: test
@@ -53,15 +57,18 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
       - name: Setup Node
+        if: github.event_name != 'push'
         uses: actions/setup-node@v1
         with:
           node-version:  ${{ matrix.node-version }}
       - name: Prepare test env
+        if: github.event_name != 'push'
         run: |
           bundle exec rake db:create
           bundle exec rake db:migrate
           bundle exec rake db:test:prepare
       - name: Run plugin tests
+        if: github.event_name != 'push'
         run: |
           bundle exec rake test:foreman_ansible
           bundle exec rake test TEST="test/unit/foreman/access_permissions_test.rb"


### PR DESCRIPTION
In order to have the cache accessible from PR source branches, we need to create it on target one.
Cache created from different PR is not accessible to others.
We need to run the tests on master.

~~Alternative to #370~~.
Runs all test suite after merge - maybe an overkill for just creating the cache, but could be usefull for additional confidence in time overlaping merges (previous merge broke following one, but we haven't re-run the tests on the later).
EDIT: using the `event_name`, we can filter out the push triggers.