### PR TITLE
Fixes #31419 - Update f-m pkg if already installed

### DIFF
--- a/app/views/foreman_ansible/job_templates/capsule_upgrade_-_ansible_default.erb
+++ b/app/views/foreman_ansible/job_templates/capsule_upgrade_-_ansible_default.erb
@@ -34,11 +34,10 @@ feature: ansible_run_capsule_upgrade
         msg: "This playbook cannot be executed on a Satellite server. Use only on a Capsule server."
       when: "'satellite' in ansible_facts.packages"
 
-    - name: Install satellite-maintain if not present
+    - name: Install|Update satellite-maintain if not present
       package:
         name: rubygem-foreman_maintain
-        state: present
-      when: "'rubygem-foreman_maintain' not in ansible_facts.packages"
+        state: latest
 
     - block:
       <%- whitelist_option = if input('whitelist_options').present?


### PR DESCRIPTION
foreman-maintain package needs to be at the latest version when running the Capsule upgrade playbook otherwise the newer versions wouldn't be detected.