### PR TITLE
Fixes #31488, #23288 - Galaxy install location

### DIFF
--- a/app/views/foreman_ansible/job_templates/ansible_roles_-_install_from_galaxy.erb
+++ b/app/views/foreman_ansible/job_templates/ansible_roles_-_install_from_galaxy.erb
@@ -25,7 +25,7 @@ model: JobTemplate
 ---
 - hosts: all
   tasks:
-    - command: ansible-galaxy install {{ item }} <% "-p #{input('location')}" if input('location').present? %>
+    - command: ansible-galaxy install {{ item }} -p <%= input('location').present? ? input('location') : '/etc/ansible/roles' %>
       register: out
       with_items:
         - <%= input('ansible_roles_list') %>


### PR DESCRIPTION
We didn't output from the ruby helper, so the option was never used.
Also the default for ansible-galaxy has changed and this is a quick fix to use our default.
This should be overpassed by local configuration file in working directory we run ansible from.