### PR TITLE
Add job template - Ansible Roles with tags support

### DIFF
--- a/app/views/foreman_ansible/job_templates/ansible_roles_-_tag_support.erb
+++ b/app/views/foreman_ansible/job_templates/ansible_roles_-_tag_support.erb
@@ -1,0 +1,46 @@
+---
+- hosts: all
+  connection: local
+  gather_facts: no
+
+  tasks:
+    - name: Run local playbook with assigned tag meta
+      local_action:
+        module: ansible.builtin.command
+        argv: 
+          - /bin/ansible-playbook
+          - -i 
+          - "{{ inventory_dir }}"
+          - -c 
+          - local
+<% unless input('Tags').blank? -%>
+          - --tags
+          - <%= input('Tags') %>
+<% end -%>
+<% unless input('Skip Tags').blank? -%>
+          - --skip-tags
+          - <%= input('Skip Tags') %>
+<% end -%>
+          - /dev/stdin
+        stdin:  |
+                ---
+                - hosts: all
+                  pre_tasks:
+                    - name: Display all parameters known for the Foreman host
+                      debug:
+                        var: foreman
+                      tags:
+                        - always
+                  tasks:
+                    - name: Apply roles
+                      include_role:
+                        name: "{{ '{{' }} role {{ '}}' }}"
+                      loop: "{{ '{{' }} foreman_ansible_roles {{ '}}' }}"
+                      loop_control:
+                        loop_var: role
+                      tags:
+                        - always
+      register: cmd_output
+    - name: debug
+      debug:
+          var: cmd_output

--- a/app/views/foreman_ansible/job_templates/ansible_roles_-_tag_support.erb
+++ b/app/views/foreman_ansible/job_templates/ansible_roles_-_tag_support.erb
@@ -1,3 +1,26 @@
+<%#
+name: Ansible Roles - Tag Support
+snippet: false
+template_inputs:
+- name: Tags
+  required: false
+  input_type: user
+  advanced: false
+  value_type: plain
+  resource_type: Katello::ActivationKey
+- name: Skip Tags
+  required: false
+  input_type: user
+  advanced: false
+  value_type: plain
+  resource_type: Katello::ActivationKey
+model: JobTemplate
+job_category: Ansible Playbook
+description_format: Run Ansible roles
+provider_type: Ansible
+kind: job_template
+%>
+
 ---
 - hosts: all
   connection: local


### PR DESCRIPTION
Create job template for running Ansible roles with --tags and --skip-tags support.