### PR TITLE
Fix running js tests

### DIFF
--- a/.github/workflows/js_tests.yml
+++ b/.github/workflows/js_tests.yml
@@ -15,19 +15,11 @@ jobs:
         node-version: [10, 12]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
-        with:
-          repository: theforeman/foreman
-          ref: develop
-          path: foreman
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version:  ${{ matrix.node-version }}
-      - name: Foreman npm install
-        working-directory: './foreman'
-        run: npm install
-      - name: Plugin npm install
+          node-version: ${{ matrix.node-version }}
+      - name: Npm install
         run: npm install
       - name: Run plugin linter
         run: npm run lint


### PR DESCRIPTION
Core is not needed to run plugin
js tests. It was not even being used
since it was not linked to plugin
and was causing failures.