### PR TITLE
Fixes #27273 - Specify order for ansible roles

### DIFF
--- a/app/models/concerns/foreman_ansible/host_managed_extensions.rb
+++ b/app/models/concerns/foreman_ansible/host_managed_extensions.rb
@@ -9,8 +9,11 @@ module ForemanAnsible
         include ::ForemanAnsible::Concerns::JobInvocationHelper
 
         has_many :host_ansible_roles, :foreign_key => :host_id
-        has_many :ansible_roles, :through => :host_ansible_roles,
-                                 :dependent => :destroy
+        accepts_nested_attributes_for :host_ansible_roles, :allow_destroy => true
+        has_many :ansible_roles,
+                 -> { order('host_ansible_roles.position ASC') },
+                 :through => :host_ansible_roles,
+                 :dependent => :destroy
         scoped_search :relation => :ansible_roles, :on => :name,
                       :complete_value => true, :rename => :ansible_role,
                       :only_explicit => true
@@ -47,7 +50,7 @@ module ForemanAnsible
     end
 
     def all_ansible_roles
-      (ansible_roles + inherited_ansible_roles).uniq
+      (inherited_ansible_roles + ansible_roles).uniq
     end
 
     # Class methods we may need to override or add

--- a/app/models/concerns/foreman_ansible/hostgroup_extensions.rb
+++ b/app/models/concerns/foreman_ansible/hostgroup_extensions.rb
@@ -7,8 +7,11 @@ module ForemanAnsible
 
     included do
       has_many :hostgroup_ansible_roles, :foreign_key => :hostgroup_id
-      has_many :ansible_roles, :through => :hostgroup_ansible_roles,
-                               :dependent => :destroy
+      has_many :ansible_roles,
+               -> { order('hostgroup_ansible_roles.position ASC') },
+               :through => :hostgroup_ansible_roles,
+               :dependent => :destroy
+      accepts_nested_attributes_for :hostgroup_ansible_roles, :allow_destroy => true
       audit_associations :ansible_roles
 
       def inherited_ansible_roles
@@ -24,14 +27,14 @@ module ForemanAnsible
       end
 
       def host_ansible_roles
-        hosts.all.includes(:ansible_roles).flat_map(&:ansible_roles)
+        hosts.includes(:host_ansible_roles).flat_map(&:ansible_roles)
       end
 
       # includes also roles of all assigned hosts, useful to determine if
       # at least one host in this hostgroup has some ansible role assigned
       # either directly or through hostgroup
       def all_ansible_roles
-        (ansible_roles + inherited_ansible_roles + host_ansible_roles).uniq
+        (inherited_ansible_roles + ansible_roles + host_ansible_roles).uniq
       end
     end
   end

--- a/app/models/host_ansible_role.rb
+++ b/app/models/host_ansible_role.rb
@@ -4,6 +4,7 @@
 class HostAnsibleRole < ApplicationRecord
   belongs_to_host
   belongs_to :ansible_role
+  acts_as_list scope: :host
 
   validates :ansible_role_id, :presence => true,
                               :uniqueness => { :scope => :host_id }

--- a/app/models/hostgroup_ansible_role.rb
+++ b/app/models/hostgroup_ansible_role.rb
@@ -4,6 +4,7 @@
 class HostgroupAnsibleRole < ApplicationRecord
   belongs_to :hostgroup
   belongs_to :ansible_role
+  acts_as_list scope: :hostgroup
 
   validates :ansible_role_id, :presence => true,
                               :uniqueness => { :scope => :hostgroup_id }

--- a/app/views/foreman_ansible/ansible_roles/_select_tab_content.html.erb
+++ b/app/views/foreman_ansible/ansible_roles/_select_tab_content.html.erb
@@ -2,10 +2,9 @@
 <%= webpacked_plugins_css_for :foreman_ansible %>
 
 <div class='tab-pane' id='ansible_roles'>
-  <% roles = f.object.is_a?(Hostgroup) ? roles_attrs(f.object.inherited_and_own_ansible_roles) : roles_attrs(f.object.all_ansible_roles) %>
   <% class_name = f.object.is_a?(Hostgroup) ? 'Hostgroup' : 'Host' %>
   <%= react_component('AnsibleRolesSwitcher', {
-                                                :initialAssignedRoles => roles,
+                                                :initialAssignedRoles => role_attributes_for_roles_switcher(f.object),
                                                 :inheritedRoleIds => f.object.inherited_ansible_roles.map(&:id),
                                                 :availableRolesUrl => ui_ansible_roles_path,
                                                 :resourceId => f.object.id,

--- a/db/migrate/20210120150019_add_position_to_ansible_role.rb
+++ b/db/migrate/20210120150019_add_position_to_ansible_role.rb
@@ -1,0 +1,27 @@
+class AddPositionToAnsibleRole < ActiveRecord::Migration[6.0]
+  def change
+    add_column :host_ansible_roles, :position, :integer
+    add_column :hostgroup_ansible_roles, :position, :integer
+
+    update_hostgroup_ansible_roles
+    update_host_ansible_roles
+    change_column_null :host_ansible_roles, :position, false
+    change_column_null :hostgroup_ansible_roles, :position, false
+  end
+
+  def update_host_ansible_roles
+    HostAnsibleRole.all.pluck(:host_id, :id).group_by(&:first).each do |_host_id, role_ids|
+      role_ids.each_with_index do |(_host_id, host_role_id), idx|
+        HostAnsibleRole.find(host_role_id).update(position: idx + 1)
+      end
+    end
+  end
+
+  def update_hostgroup_ansible_roles
+    HostgroupAnsibleRole.all.pluck(:hostgroup_id, :id).group_by(&:first).each do |_hostgroup_id, role_ids|
+      role_ids.each_with_index do |(_hostgroup_id, hostgroup_role_id), idx|
+        HostgroupAnsibleRole.find(hostgroup_role_id).update(position: idx + 1)
+      end
+    end
+  end
+end

--- a/foreman_ansible.gemspec
+++ b/foreman_ansible.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   # Kept as a dev dependency so tests can run together
   s.add_development_dependency 'foreman_ansible_core', '~> 3.0'
+  s.add_dependency 'acts_as_list', '~> 1.0.3'
   s.add_dependency 'deface', '< 2.0'
   s.add_dependency 'foreman_remote_execution', '>= 4.2.0'
   s.add_dependency 'ipaddress', '>= 0.8.0', '< 1.0'

--- a/lib/foreman_ansible/engine.rb
+++ b/lib/foreman_ansible/engine.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'deface'
+require 'acts_as_list'
 require 'fast_gettext'
 require 'gettext_i18n_rails'
 require 'foreman_ansible_core' if Rails.env.test?

--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -91,10 +91,10 @@ Foreman::Plugin.register :foreman_ansible do
   extend_template_helpers ForemanAnsible::RendererMethods
   allowed_template_helpers :insights_remediation
 
-  role_assignment_params = { :ansible_role_ids => [],
-                             :ansible_roles => [] }
-  parameter_filter Host::Managed, role_assignment_params
-  parameter_filter Hostgroup, role_assignment_params
+  base_role_assignment_params = { :ansible_role_ids => [],
+                                  :ansible_roles => [] }
+  parameter_filter Host::Managed, base_role_assignment_params.merge(:host_ansible_roles_attributes => {})
+  parameter_filter Hostgroup, base_role_assignment_params.merge(:hostgroup_ansible_roles_attributes => {})
 
   divider :top_menu, :caption => N_('Ansible'), :parent => :configure_menu
   menu :top_menu, :ansible_roles,

--- a/test/factories/ansible_roles.rb
+++ b/test/factories/ansible_roles.rb
@@ -4,4 +4,16 @@ FactoryBot.define do
   factory :ansible_role do
     sequence(:name) { |n| "ansible_role_#{n}" }
   end
+
+  factory :host_ansible_role do
+    position { nil }
+    host
+    ansible_role
+  end
+
+  factory :hostgroup_ansible_role do
+    position { nil }
+    hostgroup
+    ansible_role
+  end
 end

--- a/test/functional/api/v2/hostgroups_controller_test.rb
+++ b/test/functional/api/v2/hostgroups_controller_test.rb
@@ -9,6 +9,7 @@ module Api
     class HostgroupsControllerTest < ActionController::TestCase
       setup do
         @ansible_role1 = FactoryBot.create(:ansible_role)
+        @ansible_role2 = FactoryBot.create(:ansible_role)
         @host1 = FactoryBot.create(:host, :with_hostgroup)
         @host2 = FactoryBot.create(:host, :with_hostgroup)
         @host3 = FactoryBot.create(:host, :with_hostgroup)
@@ -44,23 +45,23 @@ module Api
       end
 
       test 'should list ansible roles for a host group' do
-        @host3.hostgroup.ansible_roles = [@ansible_role1]
+        FactoryBot.create(:hostgroup_ansible_role, hostgroup_id: @host3.hostgroup.id, ansible_role_id: @ansible_role1.id, position: 0)
         get :ansible_roles, :params => { :id => @host3.hostgroup.id }
         response = JSON.parse(@response.body)
         assert_equal @ansible_role1.id, response.first['id']
       end
 
-      test 'should assign a role to a hostgroup' do
+      test 'should assign a role to a hostgroup with a correct ordering' do
         hostgroup = FactoryBot.create(:hostgroup,
                                       :ansible_role_ids => [])
         post :assign_ansible_roles,
              :params => {
                :id => hostgroup.id,
-               :ansible_role_ids => [@ansible_role1.id]
+               :ansible_role_ids => [@ansible_role2.id, @ansible_role1.id]
              },
              :session => set_session_user
         assert_response :success
-        assert assigns('hostgroup').ansible_roles, [@ansible_role1]
+        assert_equal assigns('hostgroup').ansible_roles, [@ansible_role2, @ansible_role1]
       end
     end
   end

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -16,7 +16,9 @@ class HostsControllerExtensionsTest < ActionController::TestCase
     test 'create a host with ansible roles' do
       host = { :name => 'foo',
                :managed => false,
-               :ansible_role_ids => [@role.id] }
+               :host_ansible_roles_attributes => {
+                 0 => { :ansible_role_id => @role.id, :position => 0 }
+               } }
       post :create, :params => { :host => host }, :session => set_session_user
       assert_redirected_to host_url(assigns('host'))
       assert assigns('host').ansible_roles, [@role]
@@ -27,17 +29,19 @@ class HostsControllerExtensionsTest < ActionController::TestCase
       post :update,
            :params => {
              :id => host.id,
-             :host => { :ansible_role_ids => [@role.id] }
+             :host => { :host_ansible_roles_attributes => {
+               0 => { :ansible_role_id => @role.id, :position => 0 }
+             } }
            },
            :session => set_session_user
       assert_redirected_to host_url(assigns('host'))
-      assert assigns('host').ansible_roles, [@role]
+      assert_equal assigns('host').ansible_roles, [@role]
     end
 
     test 'delete a host with ansible roles' do
-      host = FactoryBot.create(:host,
-                               :managed => false,
-                               :ansible_roles => [@role])
+      host = FactoryBot.create(:host, :managed => false)
+      FactoryBot.create(:host_ansible_role, host_id: host.id, ansible_role_id: @role.id, position: 0)
+
       assert_include @role.hosts, host
       delete :destroy,
              :params => { :id => host.id },

--- a/test/unit/concerns/host_managed_extensions_test.rb
+++ b/test/unit/concerns/host_managed_extensions_test.rb
@@ -9,8 +9,8 @@ class HostManagedExtensionsTest < ActiveSupport::TestCase
     @role2 = FactoryBot.create(:ansible_role)
     @role3 = FactoryBot.create(:ansible_role)
 
-    @hostgroup_parent = FactoryBot.create(:hostgroup,
-                                          :ansible_roles => [@role2])
+    @hostgroup_parent = FactoryBot.create(:hostgroup)
+    FactoryBot.create(:hostgroup_ansible_role, hostgroup_id: @hostgroup_parent.id, ansible_role_id: @role2.id)
     @hostgroup = FactoryBot.create(:hostgroup, :parent => @hostgroup_parent)
     @host = FactoryBot.build_stubbed(:host, :ansible_roles => [@role1])
     @another_host = FactoryBot.build_stubbed(:host, :ansible_roles => [@role3])
@@ -23,7 +23,7 @@ class HostManagedExtensionsTest < ActiveSupport::TestCase
 
     test 'returns assigned and inherited roles for host with a hostgroup' do
       @host.hostgroup = @hostgroup
-      @host.all_ansible_roles.must_equal [@role1, @role2]
+      @host.all_ansible_roles.must_equal [@role2, @role1]
     end
   end
 
@@ -47,5 +47,19 @@ class HostManagedExtensionsTest < ActiveSupport::TestCase
     test 'when hostname looks like an IP but there is no host with that IP' do
       assert Host::Managed.import_host('192.168.128.27').new_record?
     end
+  end
+
+  test 'should correctly order roles for host' do
+    host = FactoryBot.create(:host)
+    FactoryBot.create(:host_ansible_role, :ansible_role_id => @role1.id, :position => 1, :host_id => host.id)
+    FactoryBot.create(:host_ansible_role, :ansible_role_id => @role2.id, :position => 2, :host_id => host.id)
+    FactoryBot.create(:host_ansible_role, :ansible_role_id => @role3.id, :position => 0, :host_id => host.id)
+    host.ansible_roles.must_equal [@role3, @role1, @role2]
+  end
+
+  test 'should order hostgroup roles before host roles' do
+    host = FactoryBot.create(:host, :hostgroup => @hostgroup)
+    FactoryBot.create(:host_ansible_role, :ansible_role_id => @role1.id, :position => 0, :host_id => host.id)
+    host.all_ansible_roles.must_equal [@role2, @role1]
   end
 end

--- a/test/unit/concerns/hostgroup_extensions_test.rb
+++ b/test/unit/concerns/hostgroup_extensions_test.rb
@@ -9,22 +9,23 @@ class HostgroupExtensionsTest < ActiveSupport::TestCase
     @role2 = FactoryBot.create(:ansible_role)
     @role3 = FactoryBot.create(:ansible_role)
 
-    @hostgroup_parent = FactoryBot.create(:hostgroup,
-                                          :ansible_roles => [@role2])
-    @hostgroup = FactoryBot.create(:hostgroup, :ansible_roles => [@role1])
-    @host = FactoryBot.create(:host,
-                              :ansible_roles => [@role3],
-                              :hostgroup => @hostgroup)
+    @hostgroup_parent = FactoryBot.create(:hostgroup)
+    FactoryBot.create(:hostgroup_ansible_role, :hostgroup_id => @hostgroup_parent.id, :ansible_role_id => @role2.id, :position => 1)
+    @hostgroup = FactoryBot.create(:hostgroup)
+    FactoryBot.create(:hostgroup_ansible_role, :hostgroup_id => @hostgroup.id, :ansible_role_id => @role1.id, :position => 10)
+    @host = FactoryBot.create(:host, :hostgroup => @hostgroup)
+    FactoryBot.create(:host_ansible_role, :host_id => @host.id, :ansible_role_id => @role3.id)
   end
 
   describe '#all_ansible_roles' do
     test 'returns assigned roles without any parent hostgroup' do
+      @hostgroup.host_ansible_roles
       @hostgroup.all_ansible_roles.must_equal [@role1, @role3]
     end
 
     test 'returns assigned and inherited roles with from parent hostgroup' do
       @hostgroup.parent = @hostgroup_parent
-      @hostgroup.all_ansible_roles.must_equal [@role1, @role2, @role3]
+      @hostgroup.all_ansible_roles.must_equal [@role2, @role1, @role3]
     end
   end
 
@@ -48,5 +49,10 @@ class HostgroupExtensionsTest < ActiveSupport::TestCase
       @hostgroup.parent = @hostgroup_parent
       @hostgroup.inherited_and_own_ansible_roles.must_equal [@role2, @role1]
     end
+  end
+
+  test 'should return ordered roles for hostgroup' do
+    @hostgroup.parent = @hostgroup_parent
+    @hostgroup.inherited_and_own_ansible_roles.must_equal [@role2, @role1]
   end
 end

--- a/test/unit/host_ansible_role_test.rb
+++ b/test/unit/host_ansible_role_test.rb
@@ -12,7 +12,8 @@ class HostAnsibleRoleTest < ActiveSupport::TestCase
   describe 'uniqueness' do
     subject do
       HostAnsibleRole.new(:host => FactoryBot.build(:host),
-                          :ansible_role => FactoryBot.build(:ansible_role))
+                          :ansible_role => FactoryBot.build(:ansible_role),
+                          :position => 0)
     end
     should validate_uniqueness_of(:ansible_role_id).scoped_to(:host_id)
   end

--- a/test/unit/hostgroup_ansible_role_test.rb
+++ b/test/unit/hostgroup_ansible_role_test.rb
@@ -13,7 +13,8 @@ class HostgroupAnsibleRoleTest < ActiveSupport::TestCase
     subject do
       HostgroupAnsibleRole.new(
         :hostgroup => FactoryBot.build(:hostgroup),
-        :ansible_role => FactoryBot.build(:ansible_role)
+        :ansible_role => FactoryBot.build(:ansible_role),
+        :position => 0
       )
     end
     should validate_uniqueness_of(:ansible_role_id).scoped_to(:hostgroup_id)


### PR DESCRIPTION
Packaging for `acts_as_list`:
- [x] rpm: https://github.com/theforeman/foreman-packaging/pull/6312
- [ ] deb: https://github.com/theforeman/foreman-packaging/pull/6331 (that takes over for previous ~~https://github.com/theforeman/foreman-packaging/pull/6313~~)