### PR TITLE
Fix #31709 - prefer lsb facts for OS

### DIFF
--- a/app/services/foreman_ansible/operating_system_parser.rb
+++ b/app/services/foreman_ansible/operating_system_parser.rb
@@ -80,7 +80,7 @@ module ForemanAnsible
         facts[:ansible_os_name].tr(" \n\t", '') ||
           facts[:ansible_distribution].tr(" \n\t", '')
       else
-        distribution = facts[:ansible_distribution] || facts[:ansible_lsb].try(:[], 'id')
+        distribution = facts[:ansible_lsb].try(:[], 'id') || facts[:ansible_distribution]
 
         if distribution == 'RedHat' &&
             facts[:ansible_lsb].try(:[], 'id') == 'RedHatEnterpriseWorkstation'


### PR DESCRIPTION
LSB facts contain more specific information about OS, e.g. Raspbian vs
Debian. They shoud have higher priority for the OS name.