### PR TITLE
Refs #31980 - improve Ansible as authorized feature

### DIFF
--- a/app/services/foreman_ansible/ansible_report_importer.rb
+++ b/app/services/foreman_ansible/ansible_report_importer.rb
@@ -6,7 +6,12 @@ module ForemanAnsible
   # to the right hostname in Foreman
   module AnsibleReportImporter
     extend ActiveSupport::Concern
+
     included do
+      class << self
+        prepend PatchedClassMethods
+      end
+
       def host
         hostname = name.downcase
         if AnsibleReportScanner.ansible_report?(raw) &&
@@ -16,10 +21,6 @@ module ForemanAnsible
         end
         super
         partial_hostname_match(hostname)
-      end
-
-      def self.authorized_smart_proxy_features
-        super + ['Ansible']
       end
 
       def partial_hostname_match(hostname)
@@ -32,6 +33,12 @@ module ForemanAnsible
           return @host
         end
         @host = hosts.first || @host
+      end
+    end
+
+    module PatchedClassMethods
+      def authorized_smart_proxy_features
+        super + ['Ansible']
       end
     end
   end

--- a/test/factories/ansible_proxy.rb
+++ b/test/factories/ansible_proxy.rb
@@ -1,9 +1,31 @@
 # frozen_string_literal: true
 
 FactoryBot.modify do
+  factory :feature do
+    trait :ansible do
+      name { 'Ansible' }
+    end
+
+    factory :ansible_feature, traits: [:ansible]
+  end
+
+  factory :smart_proxy_feature do
+    trait :ansible do
+      association :feature, :ansible
+    end
+  end
+
   factory :smart_proxy do
     trait :with_ansible do
-      features { [::Feature.find_or_create_by(:name => 'Ansible')] }
+      features { [FactoryBot.create(:feature, :ansible)] }
+    end
+    trait :ansible do
+      before(:create, :build, :build_stubbed) do
+        ProxyAPI::V2::Features.any_instance.stubs(:features).returns(:ansible => { 'state' => 'running' })
+      end
+      after(:build) do |smart_proxy, _evaluator|
+        smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :ansible, smart_proxy: smart_proxy)
+      end
     end
   end
 end

--- a/test/functional/api/v2/config_reports_controller_test.rb
+++ b/test/functional/api/v2/config_reports_controller_test.rb
@@ -1,0 +1,26 @@
+require 'test_plugin_helper'
+
+module Api
+  module V2
+    class ConfigReportsControllerTest < ActionController::TestCase
+      let(:example_report) do
+        JSON.parse(File.read(ansible_fixture_file('report.json')))
+      end
+
+      context 'host with a registered smart proxy with only Ansible enabled' do
+        let(:smart_proxy) { FactoryBot.create(:smart_proxy, :ansible, url: 'http://configreports.foreman') }
+
+        test 'should create a report successfully' do
+          Setting[:restrict_registered_smart_proxies] = true
+          Setting[:require_ssl_smart_proxies] = false
+
+          host = URI.parse(smart_proxy.url).host
+          Resolv.any_instance.stubs(:getnames).returns([host])
+          post :create, params: { :config_report => example_report }
+          assert_equal smart_proxy, @controller.detected_proxy
+          assert_response :created
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In 1b90f872697c272511e95818bb986c79796fd367 we allowed Ansible as
authorized feature on smart proxy, but we acutally overriden the Array
so Puppet wouldn't be authorized_feature.

Also adding a test that config report can be created with proxy only
having Ansible feature.