### PR TITLE
Fixes #32030 - Don't crash upon `localhost` Ansible tasks

### DIFF
--- a/lib/foreman_ansible_core/runner/ansible_runner.rb
+++ b/lib/foreman_ansible_core/runner/ansible_runner.rb
@@ -63,7 +63,9 @@ module ForemanAnsibleCore
 
       def handle_host_event(hostname, event)
         log_event("for host: #{hostname.inspect}", event)
-        publish_data_for(hostname, event['stdout'] + "\n", 'stdout') if event['stdout']
+        if event['stdout'] && @outputs[hostname] # rubocop:disable Style/IfUnlessModifier
+          publish_data_for(hostname, event['stdout'] + "\n", 'stdout')
+        end
         case event['event']
         when 'runner_on_ok'
           publish_exit_status_for(hostname, 0) if @exit_statuses[hostname].nil?

--- a/lib/foreman_ansible_core/runner/ansible_runner.rb
+++ b/lib/foreman_ansible_core/runner/ansible_runner.rb
@@ -63,8 +63,14 @@ module ForemanAnsibleCore
 
       def handle_host_event(hostname, event)
         log_event("for host: #{hostname.inspect}", event)
-        if event['stdout'] && @outputs[hostname] # rubocop:disable Style/IfUnlessModifier
-          publish_data_for(hostname, event['stdout'] + "\n", 'stdout')
+        if event['stdout']
+          if @outputs[hostname]
+            publish_data_for(hostname, event['stdout'] + "\n", 'stdout')
+          elsif hostname == 'localhost'
+            broadcast_data(event['stdout'] + "\n", 'stdout')
+          else
+            raise "handle_host_event: unknown host #{hostname}"
+          end
         end
         case event['event']
         when 'runner_on_ok'


### PR DESCRIPTION
When ansible-runner executes a local task (through `delegate_to: localhost` or any other available mechanism in Ansible to do so), it breaks the implicit assumption that all logs are related to a host that we know about (with “we” being Foreman in general, and the `inputs["targets"]` Dynflow structure in this particular case).
- Broadcast log entries for `localhost`, under the assumption that they consist of some kind of prep step that concerns all hosts
- Still fail in case we are presented with a log entry that is for an unknown host