### PR TITLE
Fixes #32031 - proxy batch size for Ansible

### DIFF
--- a/app/models/foreman_ansible/ansible_provider.rb
+++ b/app/models/foreman_ansible/ansible_provider.rb
@@ -114,6 +114,10 @@ if defined? ForemanRemoteExecution
           'Proxy::Ansible::TaskLauncher::Playbook::PlaybookRunnerAction'
         end
 
+        def proxy_batch_size
+          Setting['foreman_ansible_proxy_batch_size']
+        end
+
         private
 
         def ansible_command?(template)

--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -75,6 +75,13 @@ Foreman::Plugin.register :foreman_ansible do
                 'For example: foo*, *b*,*bar'),
               default: [],
               full_name: N_('Ansible roles to ignore')
+      setting 'foreman_ansible_proxy_batch_size',
+              type: :integer,
+              description: N_('Number of tasks which should be sent to the smart proxy in one request, '\
+                              'if foreman_tasks_proxy_batch_trigger is enabled. '\
+                              'If set, overrides foreman_tasks_proxy_batch_size setting for Ansible jobs.'),
+              default: nil,
+              full_name: N_('Proxy tasks batch size for Ansible')
     end
   end
 


### PR DESCRIPTION
This follows REX#32032 and uses it to tweak batch sizes for Ansible.

- [ ] Needs  https://github.com/theforeman/foreman_remote_execution/pull/566 and bump REX dependency accordingly.