### PR TITLE
Fixes #31991 - API for importing roles & variables

### DIFF
--- a/app/controllers/api/v2/ansible_roles_controller.rb
+++ b/app/controllers/api/v2/ansible_roles_controller.rb
@@ -5,6 +5,7 @@ module Api
     # API controller for Ansible Roles
     class AnsibleRolesController < ::Api::V2::BaseController
       include ::Api::Version2
+      include ::ForemanAnsible::AnsibleRolesDataPreparations
 
       resource_description do
         api_version 'v2'
@@ -12,8 +13,8 @@ module Api
       end
 
       before_action :find_resource, :only => [:show, :destroy]
-      before_action :find_proxy, :only => [:import, :obsolete, :fetch]
-      before_action :create_importer, :only => [:import, :obsolete, :fetch]
+      before_action :find_proxy, :only => [:import, :obsolete, :fetch, :sync]
+      before_action :create_importer, :only => [:import, :obsolete, :fetch, :sync]
 
       api :GET, '/ansible_roles/:id', N_('Show role')
       param :id, :identifier, :required => true
@@ -32,28 +33,46 @@ module Api
         process_response @ansible_role.destroy
       end
 
-      api :PUT, '/ansible_roles/import', N_('Import Ansible roles')
+      api :PUT, '/ansible_roles/import', N_('DEPRECATED: Import Ansible roles'), deprecated: true
       param :proxy_id, :identifier, :required => true, :desc => N_('Smart Proxy to import from')
-      param :role_names, Array, N_('Ansible role names to import')
+      param :role_names, Array, N_('Ansible role names to be imported')
       def import
-        @imported = @importer.import!(role_names)
+        Foreman::Deprecation.api_deprecation_warning(_('Use sync instead, to sync roles from Smart Proxy with Ansible feature enabled'))
+        new_roles = @roles_importer.import_role_names['new']
+        if role_names.present?
+          new_roles.select! do |role|
+            role_names.include?(role.name)
+          end
+        end
+        new_roles.map(&:save)
+        @imported = new_roles
       end
 
-      api :PUT, '/ansible_roles/obsolete', N_('Obsolete Ansible roles')
+      api :PUT, '/ansible_roles/sync', N_('Sync Ansible roles')
+      param :proxy_id, :identifier, :required => true, :desc => N_('Smart Proxy to sync from')
+      param :role_names, Array, N_('Ansible role names to be synced')
+      def sync
+        params = @importer.import!(role_names)
+        if params['changed'].present?
+          @task = @importer.confirm_sync(params)
+        else
+          process_resource_error({ :message => _('Roles could not be synced') })
+        end
+      end
+
+      api :PUT, '/ansible_roles/obsolete', N_('DEPRECATED: Obsolete Ansible roles'), deprecated: true
       param :proxy_id, :identifier, N_('Smart Proxy to import from')
       def obsolete
+        Foreman::Deprecation.api_deprecation_warning(_('Use sync instead, to sync roles from Smart Proxy with Ansible feature enabled'))
         @obsoleted = @importer.obsolete!
       end
 
       api :GET, '/ansible_roles/fetch',
-          N_('Fetch Ansible roles available to be imported')
+          N_('Fetch Ansible roles available to be synced')
       param :proxy_id, :identifier, N_('Smart Proxy to fetch from'),
             :required => true
       def fetch
-        fetched = []
-        @importer.fetch!.each do |role_name|
-          fetched << { :name => role_name }
-        end
+        fetched =  prepare_ansible_import_rows(@roles_importer.import!, @variables_importer, false)
         respond_to do |format|
           format.json do
             render :json => { :results => { :ansible_roles => fetched } }
@@ -79,6 +98,8 @@ module Api
       # rubocop:enable Layout/DotPosition
 
       def create_importer
+        @roles_importer = ForemanAnsible::UiRolesImporter.new(@proxy)
+        @variables_importer = ForemanAnsible::VariablesImporter.new(@proxy)
         @importer = ForemanAnsible::ApiRolesImporter.new(@proxy)
       end
     end

--- a/app/controllers/api/v2/ansible_variables_controller.rb
+++ b/app/controllers/api/v2/ansible_variables_controller.rb
@@ -69,20 +69,22 @@ module Api
       end
 
       api :PUT, '/ansible_variables/import',
-          N_('Import Ansible variables. This will only import variables '\
-             'for already existing roles, it will not import any new roles')
+          N_('DEPRECATED: Import Ansible variables. This will only import variables '\
+             'for already existing roles, it will not import any new roles'), deprecated: true
       param :proxy_id, :identifier, N_('Smart Proxy to import from'), :required => true
       def import
+        Foreman::Deprecation.api_deprecation_warning(_('Use sync instead, to sync roles from Smart Proxy with Ansible feature enabled'))
         new_variables = @importer.import_variable_names([])[:new]
         new_variables.map(&:save)
         @imported = new_variables
       end
 
       api :PUT, '/ansible_variables/obsolete',
-          N_('Obsolete Ansible variables. This will only obsolete variables '\
-             'for already existing roles, it will not delete any old roles')
+          N_('DEPRECATED: Obsolete Ansible variables. This will only obsolete variables '\
+             'for already existing roles, it will not delete any old roles'), deprecated: true
       param :proxy_id, :identifier, N_('Smart Proxy to import from'), :required => true
       def obsolete
+        Foreman::Deprecation.api_deprecation_warning(_('Use sync instead, to sync roles from Smart Proxy with Ansible feature enabled'))
         old_variables = @importer.import_variable_names([])[:obsolete]
         old_variables.map(&:destroy)
         @obsoleted = old_variables

--- a/app/views/api/v2/ansible_roles/sync.json.rabl
+++ b/app/views/api/v2/ansible_roles/sync.json.rabl
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+object @task
+
+attributes :id, :action, :state, :result, :start_at

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,6 +77,7 @@ Rails.application.routes.draw do
         resources :ansible_roles, :only => [:show, :index, :destroy] do
           collection do
             put :import
+            put :sync
             put :obsolete
             get :fetch
           end

--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -25,7 +25,7 @@ Foreman::Plugin.register :foreman_ansible do
                :resource_type => 'AnsibleRole'
     permission :import_ansible_roles,
                { :ansible_roles => [:import, :confirm_import],
-                 :'api/v2/ansible_roles' => [:import] },
+                 :'api/v2/ansible_roles' => [:import, :sync] },
                :resource_type => 'AnsibleRole'
     permission :view_ansible_variables,
                {

--- a/test/functional/api/v2/ansible_roles_controller_test.rb
+++ b/test/functional/api/v2/ansible_roles_controller_test.rb
@@ -45,7 +45,30 @@ module Api
           }, :session => set_session_user
           assert_response :success
         end
+
         test 'should fetch' do
+          @controller = Api::V2::AnsibleRolesController.new
+          @controller.stubs(:prepare_ansible_import_rows).returns(
+            [{
+              :name => 'test_user.test_name',
+              :id => nil,
+              :role_action => 'Import Role',
+              :variables => 'Add: 7',
+              :hosts_count => '',
+              :hostgroup_count => '',
+              :kind => 'new'
+            },
+             {
+               :name => 'some_user.some_role',
+               :id => nil,
+               :role_action => 'Import Role',
+               :variables => 'Add: 3',
+               :hosts_count => '',
+               :hostgroup_count => '',
+               :kind => 'new'
+             }]
+          )
+
           get :fetch, :params => {
             :proxy_id => @proxy.id
           }, :session => set_session_user

--- a/test/unit/services/api_roles_importer_test.rb
+++ b/test/unit/services/api_roles_importer_test.rb
@@ -12,11 +12,28 @@ class ApiRolesImporterTest < ActiveSupport::TestCase
   end
 
   test 'should import roles' do
-    @importer.stubs(:import_role_names).returns(:new => @test_roles)
-    res = @importer.import!
-    assert_equal 2, res.count
-    assert AnsibleRole.find_by :name => @test_roles.first.name
-    assert AnsibleRole.find_by :name => @test_roles.last.name
+    @importer.stubs(:prepare_ansible_import_rows).returns(
+      [{
+        :name => 'test_user.test_name',
+        :id => nil,
+        :role_action => 'Import Role',
+        :variables => 'Add: 7',
+        :hosts_count => '',
+        :hostgroup_count => '',
+        :kind => 'new'
+      },
+       {
+         :name => 'some_user.some_role',
+         :id => nil,
+         :role_action => 'Import Role',
+         :variables => 'Add: 3',
+         :hosts_count => '',
+         :hostgroup_count => '',
+         :kind => 'new'
+       }]
+    )
+    res = @importer.import!([@test_roles.first.name, @test_roles.last.name])
+    assert_equal 2, res['changed']['new'].count
   end
 
   test 'should obsolete roles' do


### PR DESCRIPTION
- Change fetch roles to show all roles that needs a sync, with more data: the action of the roles, and the amount
  of variables to be synced and more
- Change import roles to sync the seleced roles and their variables
  togther
- Add deprecation warnnings for: obselte roles, obslete variables and
  import variables