### PR TITLE
Fixes #32126 - add support for additional reported data

### DIFF
--- a/app/services/foreman_ansible/fact_parser.rb
+++ b/app/services/foreman_ansible/fact_parser.rb
@@ -72,6 +72,22 @@ module ForemanAnsible
       Time.zone.now.to_i - facts['ansible_uptime_seconds'].to_i
     end
 
+    def virtual
+      facts['ansible_virtualization_role'] == 'guest'
+    end
+
+    def ram
+      facts['ansible_memtotal_mb'].to_i
+    end
+
+    def sockets
+      facts['ansible_processor_count'].to_i
+    end
+
+    def cores
+      facts['ansible_processor_cores'].to_i
+    end
+
     private
 
     def ansible_interfaces

--- a/test/unit/services/fact_parser_test.rb
+++ b/test/unit/services/fact_parser_test.rb
@@ -29,6 +29,22 @@ module ForemanAnsible
       refute @facts_parser.environment
     end
 
+    test 'calculates virtual reported data' do
+      refute @facts_parser.virtual
+    end
+
+    test 'calculates ram reported data' do
+      assert_equal 7899, @facts_parser.ram
+    end
+
+    test 'calculates sockets reported data' do
+      assert_equal 1, @facts_parser.sockets
+    end
+
+    test 'calculates cores reported data' do
+      assert_equal 2, @facts_parser.cores
+    end
+
     test 'creates operatingsystem from operating system options' do
       sample_mock = mock
       major_fact = @facts_parser.facts['ansible_distribution_major_version']


### PR DESCRIPTION
The Foreman core recognizes some facts and stores them as first class
citizen, normalized data in the reported data facet since 1.24. These
are the facts missing comparing to the current set in the core. The data
can be then used cross fact sources and be displayed consistently or
used in reports.