### PR TITLE
Fixes #30090 - fix the controller permission mapping

### DIFF
--- a/app/controllers/ansible_variables_controller.rb
+++ b/app/controllers/ansible_variables_controller.rb
@@ -104,4 +104,8 @@ class AnsibleVariablesController < ::LookupKeysController
     end
     @smart_proxy
   end
+
+  def controller_permission
+    'ansible_variables'
+  end
 end


### PR DESCRIPTION
The AnsibleVariables controller inherits from LookupKeys controller
which means it inherits it's permission name. We have separate
permission for ansible variables so we need to define that explicitly.

To reproduce the issue, just create non-admin user and try to list
ansible variables, no variable is displayed. With this patch, correct
permission name is constructed `view_ansible_variables` instead of
`view_external_variables` and all variables are correctly displayed.