### PR TITLE
Refs #31991 - Do not respond with error on no changes

### DIFF
--- a/app/controllers/api/v2/ansible_roles_controller.rb
+++ b/app/controllers/api/v2/ansible_roles_controller.rb
@@ -56,7 +56,7 @@ module Api
         if params['changed'].present?
           @task = @importer.confirm_sync(params)
         else
-          process_resource_error({ :message => _('Roles could not be synced') })
+          render_message _('No changes detected in specified Ansible Roles and their variables')
         end
       end
 


### PR DESCRIPTION
When there are no changes in roles on proxy,
we currently respond with 500 - but there were
actually no errors and everything completed,
only no changes were detected.