### PR TITLE
Fixes #32399 - Add Ansible tab to host detail page

### DIFF
--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -96,6 +96,8 @@ Foreman::Plugin.register :foreman_ansible do
   parameter_filter Host::Managed, base_role_assignment_params.merge(:host_ansible_roles_attributes => {})
   parameter_filter Hostgroup, base_role_assignment_params.merge(:hostgroup_ansible_roles_attributes => {})
 
+  register_global_js_file 'global'
+
   divider :top_menu, :caption => N_('Ansible'), :parent => :configure_menu
   menu :top_menu, :ansible_roles,
        :caption => N_('Roles'),

--- a/webpack/components/AnsibleHostDetail/AnsibleHostDetail.js
+++ b/webpack/components/AnsibleHostDetail/AnsibleHostDetail.js
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import { Tabs, Tab, TabTitleText, Label } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
+
+import { translate as __ } from 'foremanReact/common/I18n';
+
+import './AnsibleHostDetail.scss';
+
+const AnsibleHostDetail = props => {
+  // https://projects.theforeman.org/issues/32398
+  const [activeTab] = useState('variables');
+
+  return (
+    <div className="ansible-host-detail">
+      <Tabs activeKey={activeTab} isSecondary>
+        <Tab
+          eventKey="variables"
+          title={<TabTitleText>{__('Variables')}</TabTitleText>}
+        >
+          <Label
+            color="blue"
+            icon={<InfoCircleIcon />}
+            style={{ marginTop: '1.5rem' }}
+          >
+            Ansible Variables coming soon!
+          </Label>
+        </Tab>
+      </Tabs>
+    </div>
+  );
+};
+
+export default AnsibleHostDetail;

--- a/webpack/components/AnsibleHostDetail/AnsibleHostDetail.scss
+++ b/webpack/components/AnsibleHostDetail/AnsibleHostDetail.scss
@@ -1,0 +1,6 @@
+@import '~@patternfly/patternfly/base/patternfly-variables';
+
+.ansible-host-detail {
+  background-color: $pf-color-white;
+  padding: 1.8rem;
+}

--- a/webpack/components/AnsibleHostDetail/AnsibleHostDetail.test.js
+++ b/webpack/components/AnsibleHostDetail/AnsibleHostDetail.test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import AnsibleHostDetail from './';
+
+describe('AnsibleHostDetail', () => {
+  it('should show content', () => {
+    render(<AnsibleHostDetail />);
+    expect(
+      screen.getByText('Ansible Variables coming soon!')
+    ).toBeInTheDocument();
+  });
+});

--- a/webpack/components/AnsibleHostDetail/index.js
+++ b/webpack/components/AnsibleHostDetail/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import AnsibleHostDetail from './AnsibleHostDetail';
+
+const WrappedAnsibleHostDetail = props => <AnsibleHostDetail {...props} />;
+
+export default WrappedAnsibleHostDetail;

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import { addGlobalFill } from 'foremanReact/components/common/Fill/GlobalFill';
+
+import AnsibleHostDetail from './components/AnsibleHostDetail';
+
+addGlobalFill(
+  'host-details-page-tabs',
+  'Ansible',
+  <AnsibleHostDetail key="ansible-host-detail" />,
+  500
+);


### PR DESCRIPTION
Registeres a new tab on host detail page for Ansible
content.