### PR TITLE
Fixes #32041 - set API default params

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  namespace :api do
+  namespace :api, defaults: { format: 'json' } do
     scope '(:apiv)',
           :module => :v2,
-          :defaults => { :apiv => 'v2' },
-          :apiv => /v1|v2/,
-          :constraints => ApiConstraints.new(:version => 2) do
+          :defaults => { apiv: 'v2' },
+          :apiv => /v2/,
+          :constraints => ApiConstraints.new(version: 2, default: true) do
       constraints(:id => %r{[^\/]+}) do
         resources :hosts, :only => [] do
           member do


### PR DESCRIPTION
Add defaults for format and apiv params. Before this default format was
HTML in API and the version part of URL is required for API urls,
what is mismatch from Foreman core.