### PR TITLE
Fixes #25580 - allow import with only import perm

### DIFF
--- a/app/controllers/foreman_ansible/concerns/import_controller_helper.rb
+++ b/app/controllers/foreman_ansible/concerns/import_controller_helper.rb
@@ -17,7 +17,7 @@ module ForemanAnsible
 
       def find_proxy
         return nil unless params[:proxy]
-        @proxy = SmartProxy.authorized(:view_smart_proxies).find(params[:proxy])
+        @proxy = SmartProxy.find(params[:proxy])
       end
     end
   end


### PR DESCRIPTION
This fixes an issues where we require users to have `view_smart_proxies`
permission to be able to import from them, but we show the button
anyway. This was confusing users.

This just removes the requirement of having the `view_smart_proxies`
persmission, as user can do nothing else then import AnsibleRoles and variables on
that proxy, so it should not be required to have view permissions for
said proxy.