### PR TITLE
Fixes #32829 - align secondary tabs in host details to PF4

### DIFF
--- a/webpack/components/AnsibleHostDetail/AnsibleHostDetail.js
+++ b/webpack/components/AnsibleHostDetail/AnsibleHostDetail.js
@@ -11,22 +11,24 @@ const AnsibleHostDetail = props => {
   const [activeTab] = useState('variables');
 
   return (
-    <div className="ansible-host-detail">
-      <Tabs activeKey={activeTab} isSecondary>
-        <Tab
-          eventKey="variables"
-          title={<TabTitleText>{__('Variables')}</TabTitleText>}
-        >
-          <Label
-            color="blue"
-            icon={<InfoCircleIcon />}
-            style={{ marginTop: '1.5rem' }}
-          >
-            Ansible Variables coming soon!
-          </Label>
-        </Tab>
-      </Tabs>
-    </div>
+    <Tabs activeKey={activeTab} isSecondary>
+      <Tab
+        eventKey="variables"
+        title={<TabTitleText>{__('Variables')}</TabTitleText>}
+      >
+        <div className="host-details-tab-item">
+          <div className="ansible-host-detail">
+            <Label
+              color="blue"
+              icon={<InfoCircleIcon />}
+              style={{ marginTop: '1.5rem' }}
+            >
+              Ansible Variables coming soon!
+            </Label>
+          </div>
+        </div>
+      </Tab>
+    </Tabs>
   );
 };
 


### PR DESCRIPTION
<img width="1241" alt="Screen Shot 2021-06-17 at 20 56 05" src="https://user-images.githubusercontent.com/11807069/122451091-6fb10d00-cfb0-11eb-8c5b-ff3442d39750.png">

Blocked by https://github.com/theforeman/foreman/pull/8604