### PR TITLE
Refs #32399: Reference theforeman/vendor variables and not patternfly…

### DIFF
--- a/webpack/components/AnsibleHostDetail/AnsibleHostDetail.scss
+++ b/webpack/components/AnsibleHostDetail/AnsibleHostDetail.scss
@@ -1,4 +1,4 @@
-@import '~@patternfly/patternfly/base/patternfly-variables';
+@import '~@theforeman/vendor/scss/variables';
 
 .ansible-host-detail {
   background-color: $pf-color-white;


### PR DESCRIPTION
… directly

The theforeman/vendor package when built does not include the
patternfly variables. Therefore they are not available at production
build time causing a failure to import.