### PR TITLE
Fixes #32796 - Return the correct exit code for the rescued task

### DIFF
--- a/lib/foreman_ansible_core/runner/ansible_runner.rb
+++ b/lib/foreman_ansible_core/runner/ansible_runner.rb
@@ -80,10 +80,16 @@ module ForemanAnsibleCore
       def handle_broadcast_data(event)
         log_event("broadcast", event)
         if event['event'] == 'playbook_on_stats'
+          failures = event.dig('event_data', 'failures') || {}
           header, *rows = event['stdout'].strip.lines.map(&:chomp)
           @outputs.keys.select { |key| key.is_a? String }.each do |host|
             line = rows.find { |row| row =~ /#{host}/ }
             publish_data_for(host, [header, line].join("\n"), 'stdout')
+
+            # If the task has been rescued, it won't consider a failure
+            if @exit_statuses[host].to_i != 0 && failures[host].to_i <= 0
+              publish_exit_status_for(host, 0)
+            end
           end
         else
           broadcast_data(event['stdout'] + "\n", 'stdout')

--- a/lib/foreman_ansible_core/runner/ansible_runner.rb
+++ b/lib/foreman_ansible_core/runner/ansible_runner.rb
@@ -87,9 +87,11 @@ module ForemanAnsibleCore
             publish_data_for(host, [header, line].join("\n"), 'stdout')
 
             # If the task has been rescued, it won't consider a failure
+            # rubocop:disable Style/IfUnlessModifier
             if @exit_statuses[host].to_i != 0 && failures[host].to_i <= 0
               publish_exit_status_for(host, 0)
             end
+            # rubocop:enable Style/IfUnlessModifier
           end
         else
           broadcast_data(event['stdout'] + "\n", 'stdout')


### PR DESCRIPTION
Backport of https://github.com/theforeman/smart_proxy_ansible/pull/38

Backported from theforeman/smart_proxy_ansible@79ea7d7d72f05a74ecd400d8dfd39b8505bcc009

