### PR TITLE
Fixes #32920 - support conversion of offline systems

### DIFF
--- a/app/views/foreman_ansible/job_templates/convert_to_rhel.erb
+++ b/app/views/foreman_ansible/job_templates/convert_to_rhel.erb
@@ -34,7 +34,7 @@ kind: job_template
         url: <%= subscription_manager_configuration_url(@host) %>
         dest: /usr/share/convert2rhel/subscription-manager/katello-ca-consumer-latest.noarch.rpm
     - name: Start convert2rhel
-      command: convert2rhel -y --activationkey "<%= input('Activation Key') %>" --org "<%= @host.organization.label %>" > /root/convert2rhel.log
+      command: convert2rhel -y --activationkey "<%= input('Activation Key') %>" --org "<%= @host.organization.label %>" --keep-rhsm
 <%- if input('Restart') == "yes" -%>
     - name: Reboot the machine
       reboot:


### PR DESCRIPTION
Convert2rhel version 0.22 added a parameter to avoid installing
subscription-manager from online resources. In our case we should use
subscription-manager installed during the registration process, that way
we can perform the upgrade with repositories synced to local
repositories. So we enforce that by --keep-rhsm parameter.

Also the log is always stored at /var/log/convert2rhel/convert2rhel.log
so we don't need the redirection (which doesn't work anyway)