### PR TITLE
Fixes #32913 - Show correct roles order for hostgroup

### DIFF
--- a/app/models/concerns/foreman_ansible/hostgroup_extensions.rb
+++ b/app/models/concerns/foreman_ansible/hostgroup_extensions.rb
@@ -6,7 +6,7 @@ module ForemanAnsible
     extend ActiveSupport::Concern
 
     included do
-      has_many :hostgroup_ansible_roles, :foreign_key => :hostgroup_id
+      has_many :hostgroup_ansible_roles, -> { order('hostgroup_ansible_roles.position ASC') }, :foreign_key => :hostgroup_id
       has_many :ansible_roles,
                -> { order('hostgroup_ansible_roles.position ASC') },
                :through => :hostgroup_ansible_roles,

--- a/test/unit/hostgroup_ansible_role_test.rb
+++ b/test/unit/hostgroup_ansible_role_test.rb
@@ -19,4 +19,17 @@ class HostgroupAnsibleRoleTest < ActiveSupport::TestCase
     end
     should validate_uniqueness_of(:ansible_role_id).scoped_to(:hostgroup_id)
   end
+
+  describe 'ordering' do
+    test 'should list roles in correct order' do
+      hg = FactoryBot.create(:hostgroup)
+      5.times do |idx|
+        HostgroupAnsibleRole.create(:hostgroup => hg, :ansible_role => FactoryBot.create(:ansible_role), :position => idx)
+      end
+
+      hg.hostgroup_ansible_roles.each_with_index do |item, idx|
+        assert_equal(item.position, idx + 1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
(cherry picked from commit 5a950fe3f0ce8d8bd4e1f7ae9f434c4090b2eef0)

cp for 2.5