### PR TITLE
Fixes #33142 - Add missing template for variable overrides

### DIFF
--- a/app/views/api/v2/ansible_override_values/index.json.rabl
+++ b/app/views/api/v2/ansible_override_values/index.json.rabl
@@ -1,0 +1,3 @@
+collection @override_values
+
+extends 'api/v2/ansible_override_values/show'

--- a/app/views/api/v2/ansible_variables/show.json.rabl
+++ b/app/views/api/v2/ansible_variables/show.json.rabl
@@ -10,7 +10,7 @@ attributes :id, :variable, :ansible_role, :ansible_role_id, :description, :overr
 node do |ansible_variable|
   {
     :override_values => partial(
-      'api/v2/override_values/index',
+      'api/v2/ansible_override_values/index',
       :object => ansible_variable.lookup_values
     )
   }


### PR DESCRIPTION
A follow-up fix after Puppet extraction.