### PR TITLE
Fixes #25579 - allow Ansible Manager to run jobs 

### DIFF
--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -76,9 +76,10 @@ Foreman::Plugin.register :foreman_ansible do
 
   role 'Ansible Roles Manager',
        [:play_roles_on_host, :play_roles_on_hostgroup,
+        :create_job_invocations, :view_job_templates,      # to allow the play_roles
+        :create_template_invocations, :view_smart_proxies, # ...
         :view_ansible_roles, :destroy_ansible_roles,
-        :import_ansible_roles,
-        :view_ansible_variables,
+        :import_ansible_roles, :view_ansible_variables,
         :create_ansible_variables, :import_ansible_variables,
         :edit_ansible_variables, :destroy_ansible_variables]
 


### PR DESCRIPTION
Ansible Roles Manager can play_roles_on_host, but can't run REX job,
which renders this funcionality useless from Host details page.