### PR TITLE
Remove ipaddress dependency

### DIFF
--- a/app/models/concerns/foreman_ansible/host_managed_extensions.rb
+++ b/app/models/concerns/foreman_ansible/host_managed_extensions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'ipaddress'
+require 'resolv'
 module ForemanAnsible
   # Relations to make Host::Managed 'have' ansible roles
   module HostManagedExtensions
@@ -58,7 +58,7 @@ module ForemanAnsible
       def import_host(*args)
         host = super(*args)
         hostname = args[0]
-        if IPAddress.valid?(hostname) &&
+        if (Resolv::IPv4::Regex.match?(hostname) || Resolv::IPv6::Regex.match?(hostname)) &&
            (host_nic = Nic::Interface.find_by(:ip => hostname))
           host = host_nic.host
         end

--- a/app/services/foreman_ansible/ansible_report_importer.rb
+++ b/app/services/foreman_ansible/ansible_report_importer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'ipaddress'
+require 'resolv'
 module ForemanAnsible
   # Ensures Ansible reports from hosts where the IP was used, are assigned
   # to the right hostname in Foreman
@@ -10,7 +10,7 @@ module ForemanAnsible
       def host
         hostname = name.downcase
         if AnsibleReportScanner.ansible_report?(raw) &&
-           IPAddress.valid?(hostname) &&
+           (Resolv::IPv4::Regex.match?(hostname) || Resolv::IPv6::Regex.match?(hostname)) &&
            Nic::Interface.find_by(:ip => hostname)
           @host = Nic::Interface.find_by(:ip => hostname).host
         end

--- a/foreman_ansible.gemspec
+++ b/foreman_ansible.gemspec
@@ -21,5 +21,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'acts_as_list', '~> 1.0.3'
   s.add_dependency 'deface', '< 2.0'
   s.add_dependency 'foreman_remote_execution', '>= 4.4.0'
-  s.add_dependency 'ipaddress', '>= 0.8.0', '< 1.0'
 end


### PR DESCRIPTION
This uses the built in resolv module to see if it's an IP address instead of an unmaintained gem.