### PR TITLE
Fixes #33186 - New job template to run OpenSCAP scans via Ansible

### DIFF
--- a/app/views/foreman_ansible/job_templates/run_openscap_scans_-_ansible_default.erb
+++ b/app/views/foreman_ansible/job_templates/run_openscap_scans_-_ansible_default.erb
@@ -1,0 +1,20 @@
+<%#
+name: Run OpenSCAP scans - Ansible Default
+job_category: OpenSCAP Ansible Commands
+description_format: Run scan for all OpenSCAP policies on given hosts
+snippet: false
+provider_type: Ansible
+kind: job_template
+model: JobTemplate
+%>
+
+<% raise "Create and assign a policy to this host before proceeding" if @host.policies_enc_raw.empty? -%>
+---
+- hosts: all
+  tasks:
+<% @host.policies_enc_raw.each do |policy| -%>
+    - shell: /usr/bin/foreman_scap_client <%= policy['id'] %>
+      register: out
+    - debug: var=out
+<% end -%>
+


### PR DESCRIPTION
Just like Remote Execution commands can be run with an SSH-based template as well as with an Ansible-based template, I'd like to be able to run OpenSCAP scans via Ansible in addition to the existing SSH-based method.