### PR TITLE
Fixes #33313 - Consider jobs on unreachable hosts failed

### DIFF
--- a/lib/foreman_ansible_core/runner/ansible_runner.rb
+++ b/lib/foreman_ansible_core/runner/ansible_runner.rb
@@ -81,6 +81,7 @@ module ForemanAnsibleCore
         log_event("broadcast", event)
         if event['event'] == 'playbook_on_stats'
           failures = event.dig('event_data', 'failures') || {}
+          unreachable = event.dig('event_data', 'dark') || {}
           header, *rows = event['stdout'].strip.lines.map(&:chomp)
           @outputs.keys.select { |key| key.is_a? String }.each do |host|
             line = rows.find { |row| row =~ /#{host}/ }
@@ -88,7 +89,7 @@ module ForemanAnsibleCore
 
             # If the task has been rescued, it won't consider a failure
             # rubocop:disable Style/IfUnlessModifier
-            if @exit_statuses[host].to_i != 0 && failures[host].to_i <= 0
+            if @exit_statuses[host].to_i != 0 && failures[host].to_i <= 0 && unreachable[host].to_i <= 0
               publish_exit_status_for(host, 0)
             end
             # rubocop:enable Style/IfUnlessModifier


### PR DESCRIPTION
In [1] we started treating jobs with non-zero exit code, but with no
failures as successful. However, if a host is unreachable, ansible
doesn't treat it as a failure so such jobs hit this condition and were
treated as successful.

[1] - https://github.com/theforeman/smart_proxy_ansible/pull/38