### PR TITLE
Fixes #26065 - Import playbook as a Job Template

### DIFF
--- a/app/controllers/api/v2/ansible_playbooks_controller.rb
+++ b/app/controllers/api/v2/ansible_playbooks_controller.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    # API controller for Ansible Roles
+    class AnsiblePlaybooksController < ::Api::V2::BaseController
+      include ::Api::Version2
+      include ::ForemanAnsible::ProxyAPI
+
+      resource_description do
+        api_version 'v2'
+        api_base_url '/ansible/api'
+      end
+
+      api :PUT, '/ansible_playbooks/sync', N_('Sync Ansible playbooks')
+      param :proxy_id, :identifier, :required => true, :desc => N_('Smart Proxy to sync from')
+      param :playbooks_names, Array, N_('Ansible  playbooks names to be synced')
+      def sync
+        # importer.import_playbooks(playbooks_names)
+        @task = plan_ansible_sync(proxy.id, playbooks_names)
+      end
+
+      api :GET, '/ansible_playbooks/fetch', N_('Fetch Ansible playbooks available to be synced')
+      param :proxy_id, :identifier, N_('Smart Proxy to fetch from'),
+            :required => true
+      def fetch
+        fetched = fetch_playbooks_names
+        render :json => { :results => { :playbooks_names => fetched } }
+      end
+
+      def action_permission
+        case params[:action]
+        when 'sync'
+          :sync
+        when 'fetch'
+          :fetch
+        else
+          super
+        end
+      end
+
+      def plan_ansible_sync(proxy, playbooks_names)
+        ForemanTasks.async_task(ImportPlaybooksJob::Async::SyncPlaybooks, proxy, playbooks_names)
+      end
+
+      private
+
+      # rubocop:disable Layout/DotPosition
+      def find_proxy
+        unless params[:proxy_id]
+          msg = _('Smart proxy id is required')
+          return render_error('custom_error', :status => :unprocessable_entity, :locals => { :message => msg })
+        end
+        SmartProxy.authorized(:view_smart_proxies)
+                  .find(params[:proxy_id])
+      end
+      # rubocop:enable Layout/DotPosition
+
+      def fetch_playbooks_names
+        proxy_api = find_proxy_api(proxy)
+        proxy_api.playbooks_names if @proxy
+      end
+
+      def playbooks_names
+        params.fetch(:playbooks_names, [])
+      end
+
+      def proxy
+        @proxy ||= find_proxy
+      end
+
+      def importer
+        @importer ||= ForemanAnsible::PlaybooksImporter.new(proxy)
+      end
+    end
+  end
+end

--- a/app/jobs/sync_playbooks.rb
+++ b/app/jobs/sync_playbooks.rb
@@ -1,8 +1,8 @@
 module ImportPlaybooksJob
   module Async
     class SyncPlaybooks < ::Actions::EntryAction
-      def plan(proxy, playbooks_names)
-        plan_self(proxy: proxy, playbooks_names: playbooks_names)
+      def plan(proxy_id, playbooks_names)
+        plan_self(proxy_id: proxy_id, playbooks_names: playbooks_names)
       end
 
       def run
@@ -14,7 +14,7 @@ module ImportPlaybooksJob
       end
 
       def proxy
-        SmartProxy.find(input[:proxy])
+        SmartProxy.find(input[:proxy_id])
       end
 
       def playbooks_names

--- a/app/jobs/sync_playbooks.rb
+++ b/app/jobs/sync_playbooks.rb
@@ -1,0 +1,25 @@
+module ImportPlaybooksJob
+  module Async
+    class SyncPlaybooks < ::Actions::EntryAction
+      def plan(proxy, playbooks_names)
+        plan_self(proxy: proxy, playbooks_names: playbooks_names)
+      end
+
+      def run
+        playbooks_importer = ForemanAnsible::PlaybooksImporter.new(proxy)
+        output[:result] = playbooks_importer.import_playbooks(playbooks_names)
+        ForemanAnsible::ImportPlaybooksSuccessNotification.deliver!(task)
+      rescue StandardError => e
+        ForemanAnsible::ImportPlaybooksErrorNotification.new(e, task).deliver!
+      end
+
+      def proxy
+        SmartProxy.find(input[:proxy])
+      end
+
+      def playbooks_names
+        input[:playbooks_names]
+      end
+    end
+  end
+end

--- a/app/lib/proxy_api/ansible.rb
+++ b/app/lib/proxy_api/ansible.rb
@@ -40,5 +40,18 @@ module ProxyAPI
       raise ProxyException.new(url, e,
                                N_('Unable to get roles/variables from Ansible'))
     end
+
+    def playbooks_names
+      parse(get('playbooks_names'))
+    rescue *PROXY_ERRORS => e
+      raise ProxyException.new(url, e, N_('Unable to get playbook\'s names from Ansible'))
+    end
+
+    def playbooks(playbooks_names = [])
+      playbooks_names = playbooks_names.join(',')
+      parse(get("playbooks/#{playbooks_names}"))
+    rescue *PROXY_ERRORS => e
+      raise ProxyException.new(url, e, N_('Unable to get playbooks from Ansible'))
+    end
   end
 end

--- a/app/services/foreman_ansible/import_playbooks_error_notification.rb
+++ b/app/services/foreman_ansible/import_playbooks_error_notification.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module ForemanAnsible
+  class ImportPlaybooksErrorNotification < ::UINotifications::Base
+    private
+
+    def initialize(error, task)
+      @job_error = error
+      @subject = task
+    end
+
+    def create
+      ::Notification.create!(
+        :audience => Notification::AUDIENCE_ADMIN,
+        :notification_blueprint => blueprint,
+        :initiator => initiator,
+        :message => message,
+        :subject => subject,
+        :actions => {
+          :links => links
+        }
+      )
+    end
+
+    def blueprint
+      name = 'Sync_playbooks_failed'
+      @blueprint ||= NotificationBlueprint.unscoped.find_by(:name => name)
+    end
+
+    def message
+      _("Failed to import playbooks Due to: #{@job_error}")
+    end
+
+    def links
+      [{ :href => Rails.application.routes.url_helpers.foreman_tasks_task_path(:id => subject.id), :title => N_('Task Details') }]
+    end
+  end
+end

--- a/app/services/foreman_ansible/import_playbooks_error_notification.rb
+++ b/app/services/foreman_ansible/import_playbooks_error_notification.rb
@@ -11,7 +11,7 @@ module ForemanAnsible
 
     def create
       ::Notification.create!(
-        :audience => Notification::AUDIENCE_ADMIN,
+        :audience => Notification::AUDIENCE_USER,
         :notification_blueprint => blueprint,
         :initiator => initiator,
         :message => message,

--- a/app/services/foreman_ansible/import_playbooks_success_notification.rb
+++ b/app/services/foreman_ansible/import_playbooks_success_notification.rb
@@ -6,7 +6,7 @@ module ForemanAnsible
 
     def create
       ::Notification.create!(
-        :audience => Notification::AUDIENCE_ADMIN,
+        :audience => Notification::AUDIENCE_USER,
         :notification_blueprint => blueprint,
         :initiator => initiator,
         :message => message,

--- a/app/services/foreman_ansible/import_playbooks_success_notification.rb
+++ b/app/services/foreman_ansible/import_playbooks_success_notification.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module ForemanAnsible
+  class ImportPlaybooksSuccessNotification < ::UINotifications::Base
+    private
+
+    def create
+      ::Notification.create!(
+        :audience => Notification::AUDIENCE_ADMIN,
+        :notification_blueprint => blueprint,
+        :initiator => initiator,
+        :message => message,
+        :subject => subject,
+        :actions => {
+          :links => links
+        }
+      )
+    end
+
+    def blueprint
+      name = 'Sync_playbooks_successfully'
+      @blueprint ||= NotificationBlueprint.unscoped.find_by(:name => name)
+    end
+
+    def message
+      blueprint.message
+    end
+
+    def links
+      [{ :href => Rails.application.routes.url_helpers.foreman_tasks_task_path(:id => subject.id), :title => N_('Task Details') }]
+    end
+  end
+end

--- a/app/services/foreman_ansible/playbooks_importer.rb
+++ b/app/services/foreman_ansible/playbooks_importer.rb
@@ -55,6 +55,8 @@ module ForemanAnsible
     def create_job_template(playbook)
       job_template = JobTemplate.create(name: playbook[:name], template: playbook[:playbook_content], job_category: 'Ansible Playbook - Imported', provider_type: 'Ansible')
       # TODO: Add support for creating template inputs
+      job_template.organizations = Organization.unscoped.all
+      job_template.locations = Location.unscoped.all
       job_template.save
       { job_template.id => job_template.name }
     end

--- a/app/services/foreman_ansible/proxy_api.rb
+++ b/app/services/foreman_ansible/proxy_api.rb
@@ -8,16 +8,15 @@ module ForemanAnsible
     included do
       attr_reader :ansible_proxy
 
-      def find_proxy_api
+      def find_proxy_api(ansible_proxy)
         if ansible_proxy.blank?
           raise ::Foreman::Exception.new(N_('Proxy not found'))
         end
-        @proxy_api = ::ProxyAPI::Ansible.new(:url => ansible_proxy.url)
+        ::ProxyAPI::Ansible.new(:url => ansible_proxy.url)
       end
 
       def proxy_api
-        return @proxy_api if @proxy_api
-        find_proxy_api
+        @proxy_api ||= find_proxy_api(ansible_proxy)
       end
     end
   end

--- a/app/views/api/v2/ansible_playbooks/sync.json.rabl
+++ b/app/views/api/v2/ansible_playbooks/sync.json.rabl
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+object @task
+
+attributes :id, :action, :state, :result, :start_at

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,13 @@ Rails.application.routes.draw do
           end
         end
 
+        resources :ansible_playbooks, :only => [] do
+          collection do
+            get :fetch
+            put :sync
+          end
+        end
+
         resources :ansible_variables, :only => [:show, :index, :destroy, :update, :create] do
           collection do
             put :import

--- a/db/seeds.d/90_notification_blueprints.rb
+++ b/db/seeds.d/90_notification_blueprints.rb
@@ -31,7 +31,21 @@ blueprints = [
     :name => 'Sync_roles_and_variables_failed',
     :message => 'DYNAMIC',
     :level => 'error'
+  },
+  {
+    :group => N_('Playbooks'),
+    :name => 'Sync_playbooks_successfully',
+    :message => N_('Import playbooks has finished successfully'),
+    :level => 'success'
+
+  },
+  {
+    :group => N_('Playbooks'),
+    :name => 'Sync_playbooks_failed',
+    :message => 'DYNAMIC',
+    :level => 'error'
   }
 
 ]
+
 blueprints.each { |blueprint| UINotifications::Seed.new(blueprint).configure }

--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -158,6 +158,10 @@ Foreman::Plugin.register :foreman_ansible do
                :resource_type => 'Hostgroup'
     permission :generate_ansible_inventory,
                { :'api/v2/ansible_inventories' => [:schedule] }
+    permission :import_ansible_playbooks,
+               { :'api/v2/ansible_playbooks' => [:sync] }
+    permission :fetch_ansible_playbooks,
+               { :'api/v2/ansible_playbooks' => [:fetch] }
   end
 
   role 'Ansible Roles Manager',
@@ -167,7 +171,7 @@ Foreman::Plugin.register :foreman_ansible do
         :view_ansible_roles, :destroy_ansible_roles,
         :import_ansible_roles, :view_ansible_variables,
         :create_ansible_variables, :import_ansible_variables,
-        :edit_ansible_variables, :destroy_ansible_variables]
+        :edit_ansible_variables, :destroy_ansible_variables, :import_ansible_playbooks, :fetch_ansible_playbooks]
 
   role 'Ansible Tower Inventory Reader',
        [:view_hosts, :view_hostgroups, :view_facts, :generate_report_templates, :generate_ansible_inventory,

--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -159,9 +159,7 @@ Foreman::Plugin.register :foreman_ansible do
     permission :generate_ansible_inventory,
                { :'api/v2/ansible_inventories' => [:schedule] }
     permission :import_ansible_playbooks,
-               { :'api/v2/ansible_playbooks' => [:sync] }
-    permission :fetch_ansible_playbooks,
-               { :'api/v2/ansible_playbooks' => [:fetch] }
+               { :'api/v2/ansible_playbooks' => [:sync, :fetch] }
   end
 
   role 'Ansible Roles Manager',
@@ -171,7 +169,7 @@ Foreman::Plugin.register :foreman_ansible do
         :view_ansible_roles, :destroy_ansible_roles,
         :import_ansible_roles, :view_ansible_variables,
         :create_ansible_variables, :import_ansible_variables,
-        :edit_ansible_variables, :destroy_ansible_variables, :import_ansible_playbooks, :fetch_ansible_playbooks]
+        :edit_ansible_variables, :destroy_ansible_variables, :import_ansible_playbooks]
 
   role 'Ansible Tower Inventory Reader',
        [:view_hosts, :view_hostgroups, :view_facts, :generate_report_templates, :generate_ansible_inventory,

--- a/test/functional/api/v2/ansible_playbooks_controller_test.rb
+++ b/test/functional/api/v2/ansible_playbooks_controller_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'test_plugin_helper'
+
+module Api
+  module V2
+    # Tests for the ansible playbooks controller
+    class AnsiblePlaybooksControllerTest < ActionController::TestCase
+      let(:ansible_proxy) { FactoryBot.create(:smart_proxy, :with_ansible) }
+      let(:proxy_api) { ::ProxyAPI::Ansible.new(url: ansible_proxy.url) }
+      let(:playbooks_names) { %w[xprazak2.forklift_collection.foreman_provisioning.yml xprazak2.forklift_collection.collect_debug_draft.yml] }
+      let(:importer_test) { mock('PlaybooksImporter') }
+
+      test 'should fetch with nil' do
+        AnsiblePlaybooksController.any_instance.stubs(:fetch_playbooks_names).returns(nil)
+
+        get :fetch, :params => {
+          :proxy_id => ansible_proxy.id
+        }, :session => set_session_user
+        response = JSON.parse(@response.body)
+        assert_empty response['results']['playbooks_names']
+        assert_response :success
+      end
+
+      test 'should fetch playbooks names' do
+        AnsiblePlaybooksController.any_instance.stubs(:fetch_playbooks_names).returns(playbooks_names)
+
+        get :fetch, :params => {
+          :proxy_id => ansible_proxy.id
+        }, :session => set_session_user
+        response = JSON.parse(@response.body)
+        assert_not_empty response['results']
+        assert_equal response['results']['playbooks_names'], playbooks_names
+      end
+
+      test 'should use correct proxy' do
+        AnsiblePlaybooksController.any_instance.expects(:find_proxy_api).with(ansible_proxy).returns(proxy_api)
+        proxy_api.expects(:playbooks_names).returns(playbooks_names)
+
+        get :fetch, :params => {
+          :proxy_id => ansible_proxy.id
+        }, :session => set_session_user
+        response = JSON.parse(@response.body)
+        assert_not_empty response['results']
+        assert_not_empty playbooks_names = response['results']['playbooks_names']
+        assert_equal 2, playbooks_names.count
+      end
+
+      test 'check plan and sync' do
+        task = mock('Foreman Task')
+        AnsiblePlaybooksController.any_instance.expects(:plan_ansible_sync).with(ansible_proxy.id, playbooks_names).returns(task)
+        task.stubs(:id).returns('123')
+        task.stubs(:action).returns('Import Playbooks')
+
+        put :sync, :params => {
+          :proxy_id => ansible_proxy.id,
+          :playbooks_names => playbooks_names
+        }, :session => set_session_user
+        response = JSON.parse(@response.body)
+        assert_equal '123', response['id']
+        assert_equal 'Import Playbooks', response['action']
+      end
+    end
+  end
+end

--- a/test/unit/lib/proxy_api/ansible_test.rb
+++ b/test/unit/lib/proxy_api/ansible_test.rb
@@ -14,6 +14,12 @@ class AnsibleTest < ActiveSupport::TestCase
     assert_equal roles, @proxy_api.roles
   end
 
+  test 'should get ansible playbooks from proxy' do
+    playbooks = ['some_playbook.some_author', 'test_playbook.test_author']
+    @proxy_api.expects(:get).returns(fake_rest_client_response(playbooks))
+    assert_equal playbooks, @proxy_api.playbooks
+  end
+
   test 'should raise error with appropriate message' do
     message = 'Connection refused'
     @proxy_api.expects(:get).raises(Errno::ECONNREFUSED, message)


### PR DESCRIPTION
Add the option to Import ansible playbooks smart proxy,  while updating, creating, or deleting  them as job templates