### PR TITLE
Fixes #33424 - Remove gray margins from host details tab

### DIFF
--- a/webpack/components/AnsibleHostDetail/components/TabLayout.js
+++ b/webpack/components/AnsibleHostDetail/components/TabLayout.js
@@ -2,9 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const TabLayout = props => (
-  <div className="host-details-tab-item">
-    <div className="ansible-host-detail">{props.children}</div>
-  </div>
+  <div className="ansible-host-detail">{props.children}</div>
 );
 
 TabLayout.propTypes = {


### PR DESCRIPTION
Needs https://github.com/theforeman/foreman/pull/8764

Before:

![before](https://user-images.githubusercontent.com/2664090/132306869-78c451dc-c0ad-4d88-b1bd-b6954f093344.png)

Now:

![now](https://user-images.githubusercontent.com/2664090/132306876-f1243d3e-543c-41fb-88ef-4f062cbb49dd.png)

cc @amirfefer @MariSvirik 
