### PR TITLE
Fixes #33877 - Improve styling for roles tab

### DIFF
--- a/webpack/components/AnsibleHostDetail/components/RolesTab/RolesTable.js
+++ b/webpack/components/AnsibleHostDetail/components/RolesTab/RolesTable.js
@@ -56,14 +56,17 @@ const RolesTable = ({
 
   return (
     <React.Fragment>
-      <h3>{__('Assigned Ansible Roles')}</h3>
-      <Flex className="pf-u-pt-md">
-        {editBtn}
+      <Flex>
         <FlexItem>
-          <Link to="/Ansible/roles/all">
-            <Button variant="link">{__('View all assigned roles')}</Button>
-          </Link>
+          <h3>
+            <span>{__('Ansible roles assigned directly to host')}</span>
+            <span>{' - '}</span>
+            <Link to="/Ansible/roles/all">{__('view all assigned roles')}</Link>
+          </h3>
         </FlexItem>
+      </Flex>
+      <Flex>
+        <FlexItem>{editBtn}</FlexItem>
         <FlexItem align={{ default: 'alignRight' }}>
           <Pagination
             itemCount={totalCount}

--- a/webpack/components/AnsibleHostDetail/components/RolesTab/__test__/RolesTab.test.js
+++ b/webpack/components/AnsibleHostDetail/components/RolesTab/__test__/RolesTab.test.js
@@ -37,9 +37,9 @@ describe('RolesTab', () => {
       />
     );
     await waitFor(tick);
-    expect(screen.getByText('View all assigned roles')).toBeInTheDocument();
+    expect(screen.getByText('view all assigned roles')).toBeInTheDocument();
     expect(screen.queryByText('All Ansible Roles')).not.toBeInTheDocument();
-    userEvent.click(screen.getByText('View all assigned roles'));
+    userEvent.click(screen.getByText('view all assigned roles'));
     await waitFor(tick);
     expect(screen.getByText('All Ansible Roles')).toBeInTheDocument();
     expect(screen.getByText('Inherited from Hostgroup')).toBeInTheDocument();


### PR DESCRIPTION
Before: 
![roles-before](https://user-images.githubusercontent.com/2664090/140933287-bf27bb56-1b0a-4906-a05c-141e52395776.png)

After:
![roles-after](https://user-images.githubusercontent.com/2664090/140933298-2ef5b7bf-164b-4e30-819d-65924f970d00.png)


