### PR TITLE
Fixes #34094 - use report importer registry

### DIFF
--- a/app/services/foreman_ansible/ansible_report_importer.rb
+++ b/app/services/foreman_ansible/ansible_report_importer.rb
@@ -18,10 +18,6 @@ module ForemanAnsible
         partial_hostname_match(hostname)
       end
 
-      def self.authorized_smart_proxy_features
-        super + ['Ansible']
-      end
-
       def partial_hostname_match(hostname)
         return @host unless @host.new_record?
         hosts = Host.where(Host.arel_table[:name].matches("#{hostname}.%"))

--- a/lib/foreman_ansible/engine.rb
+++ b/lib/foreman_ansible/engine.rb
@@ -75,6 +75,7 @@ module ForemanAnsible
       ::Api::V2::HostgroupsController.include ForemanAnsible::Api::V2::HostgroupsControllerExtensions
       ::Api::V2::HostgroupsController.include ForemanAnsible::Api::V2::HostgroupsParamGroupExtensions
       ::ConfigReportImporter.include ForemanAnsible::AnsibleReportImporter
+      ReportImporter.register_smart_proxy_feature('Ansible')
     rescue StandardError => e
       Rails.logger.warn "Foreman Ansible: skipping engine hook (#{e})"
     end


### PR DESCRIPTION
See https://github.com/theforeman/foreman/pull/8958#issuecomment-986732271

Do not merge until the core PR is in.

Also minimum foreman version will be 3.2 now, I cannot find this in `engine.rb`?