### PR TITLE
Fixes #34150 -  align secondary tabs in host page

### DIFF
--- a/webpack/components/AnsibleHostDetail/AnsibleHostDetail.js
+++ b/webpack/components/AnsibleHostDetail/AnsibleHostDetail.js
@@ -21,6 +21,7 @@ const AnsibleHostDetail = ({
       {response?.id && (
         <>
           <Tabs
+            className="ansible-host-details-tabs"
             onSelect={(evt, subTab) => hashHistory.push(subTab)}
             activeKey={pathname?.split('/')[2]}
             isSecondary

--- a/webpack/components/AnsibleHostDetail/AnsibleHostDetail.scss
+++ b/webpack/components/AnsibleHostDetail/AnsibleHostDetail.scss
@@ -4,3 +4,7 @@
   background-color: $pf-color-white;
   padding: 1.8rem;
 }
+
+.ansible-host-details-tabs {
+  margin: 0 24px;
+}


### PR DESCRIPTION
following https://github.com/theforeman/foreman/pull/8996

before:
![Screen Shot 2021-12-14 at 18 40 26](https://user-images.githubusercontent.com/11807069/146053220-d4b3da7e-f025-4ffd-a538-a8fe85832d11.png)

after:
![Screen Shot 2021-12-14 at 19 52 45](https://user-images.githubusercontent.com/11807069/146053249-c59a7370-5e09-4244-9adc-87770bdf31af.png)
