### PR TITLE
Host Ansible jobs - Readable cron line

### DIFF
--- a/webpack/components/AnsibleHostDetail/components/JobsTab/JobsTabHelper.js
+++ b/webpack/components/AnsibleHostDetail/components/JobsTab/JobsTabHelper.js
@@ -79,6 +79,10 @@ export const useCancelMutation = (resourceName, resourceId) =>
   });
 
 export const readableCron = (cron = '') => {
+  if (cron.match(/(\d+ \* \* \* \*)/)) {
+    return 'hourly';
+  }
+
   if (cron.match(/(\d+ \d+ \* \* \*)/)) {
     return 'daily';
   }
@@ -91,5 +95,5 @@ export const readableCron = (cron = '') => {
     return 'monthly';
   }
 
-  return 'hourly';
+  return 'custom';
 };

--- a/webpack/components/AnsibleHostDetail/components/JobsTab/JobsTabHelper.js
+++ b/webpack/components/AnsibleHostDetail/components/JobsTab/JobsTabHelper.js
@@ -77,3 +77,19 @@ export const useCancelMutation = (resourceName, resourceId) =>
       },
     ],
   });
+
+export const readableCron = (cron = '') => {
+  if (cron.match(/(\d+ \d+ \* \* \*)/)) {
+    return 'daily';
+  }
+
+  if (cron.match(/(\d+ \d+ \* \* \d+)/)) {
+    return 'weekly';
+  }
+
+  if (cron.match(/(\d+ \d+ \d+ \* \*)/)) {
+    return 'monthly';
+  }
+
+  return 'hourly';
+};

--- a/webpack/components/AnsibleHostDetail/components/JobsTab/PreviousJobsTable.js
+++ b/webpack/components/AnsibleHostDetail/components/JobsTab/PreviousJobsTable.js
@@ -16,6 +16,7 @@ import Pagination from 'foremanReact/components/Pagination';
 
 import { decodeId } from '../../../../globalIdHelper';
 import withLoading from '../../../withLoading';
+import { readableCron } from './JobsTabHelper';
 
 const PreviousJobsTable = ({ history, totalCount, jobs, pagination }) => {
   const columns = [
@@ -61,7 +62,7 @@ const PreviousJobsTable = ({ history, totalCount, jobs, pagination }) => {
                   <Td>
                     <RelativeDateTime date={job.startAt} />
                   </Td>
-                  <Td>{job.recurringLogic.cronLine}</Td>
+                  <Td>{readableCron(job.recurringLogic.cronLine)}</Td>
                 </Tr>
               ))}
             </Tbody>

--- a/webpack/components/AnsibleHostDetail/components/JobsTab/RecurringJobsTable.js
+++ b/webpack/components/AnsibleHostDetail/components/JobsTab/RecurringJobsTable.js
@@ -14,7 +14,7 @@ import {
   Td,
 } from '@patternfly/react-table';
 
-import { useCancelMutation } from './JobsTabHelper';
+import { useCancelMutation, readableCron } from './JobsTabHelper';
 import withLoading from '../../../withLoading';
 import { decodeId } from '../../../../globalIdHelper';
 
@@ -74,7 +74,7 @@ const RecurringJobsTable = ({ jobs, resourceName, resourceId }) => {
                   {job.description}
                 </a>
               </Td>
-              <Td>{job.recurringLogic.cronLine}</Td>
+              <Td>{readableCron(job.recurringLogic.cronLine)}</Td>
               <Td>
                 <RelativeDateTime date={job.startAt} />
               </Td>

--- a/webpack/components/AnsibleHostDetail/components/JobsTab/__test__/JobsTab.test.js
+++ b/webpack/components/AnsibleHostDetail/components/JobsTab/__test__/JobsTab.test.js
@@ -18,6 +18,7 @@ import {
 import * as toasts from '../../../../../toastHelper';
 
 import { toCron } from '../NewRecurringJobHelper';
+import { readableCron } from '../JobsTabHelper';
 
 import {
   tick,
@@ -49,8 +50,10 @@ describe('JobsTab', () => {
       .map(element => expect(element).toBeInTheDocument());
     expect(screen.getByText('Scheduled recurring jobs')).toBeInTheDocument();
     expect(screen.getByText('Previously executed jobs')).toBeInTheDocument();
-    expect(screen.getByText(toCron(futureDate, 'weekly'))).toBeInTheDocument();
-    expect(screen.getByText('54 10 15 * *')).toBeInTheDocument();
+    expect(
+      screen.getByText(readableCron(toCron(futureDate, 'weekly')))
+    ).toBeInTheDocument();
+    expect(screen.getByText('monthly')).toBeInTheDocument();
   });
   it('should show empty state', async () => {
     render(
@@ -129,7 +132,9 @@ describe('JobsTab', () => {
       message: 'Ansible job was successfully created.',
     });
     await waitFor(tick);
-    expect(screen.getByText(toCron(futureDate, 'weekly'))).toBeInTheDocument();
+    expect(
+      screen.getByText(readableCron(toCron(futureDate, 'weekly')))
+    ).toBeInTheDocument();
     expect(screen.getByText('in 3 days')).toBeInTheDocument();
     expect(
       screen.queryByText('No config job for Ansible roles scheduled')

--- a/webpack/components/AnsibleHostDetail/components/JobsTab/__test__/JobsTabHelper.test.js
+++ b/webpack/components/AnsibleHostDetail/components/JobsTab/__test__/JobsTabHelper.test.js
@@ -1,0 +1,11 @@
+import { readableCron } from '../JobsTabHelper';
+
+describe('JobTabsHelper', () => {
+  it('readableCron', () => {
+    expect(readableCron('01 * * * *')).toBe('hourly');
+    expect(readableCron('01 01 * * *')).toBe('daily');
+    expect(readableCron('01 01 * * 01')).toBe('weekly');
+    expect(readableCron('01 01 01 * *')).toBe('monthly');
+    expect(readableCron()).toBe('hourly');
+  });
+});

--- a/webpack/components/AnsibleHostDetail/components/JobsTab/__test__/JobsTabHelper.test.js
+++ b/webpack/components/AnsibleHostDetail/components/JobsTab/__test__/JobsTabHelper.test.js
@@ -6,6 +6,6 @@ describe('JobTabsHelper', () => {
     expect(readableCron('01 01 * * *')).toBe('daily');
     expect(readableCron('01 01 * * 01')).toBe('weekly');
     expect(readableCron('01 01 01 * *')).toBe('monthly');
-    expect(readableCron()).toBe('hourly');
+    expect(readableCron()).toBe('custom');
   });
 });

--- a/webpack/routes/HostgroupJobs/__test__/HostgroupJobs.test.js
+++ b/webpack/routes/HostgroupJobs/__test__/HostgroupJobs.test.js
@@ -24,6 +24,7 @@ import {
 } from '../../../testHelper';
 
 import { toCron } from '../../../components/AnsibleHostDetail/components/JobsTab/NewRecurringJobHelper';
+import { readableCron } from '../../../components/AnsibleHostDetail/components/JobsTab/JobsTabHelper';
 
 const TestComponent = withRedux(withRouter(withMockedProvider(HostgroupJobs)));
 
@@ -46,7 +47,7 @@ describe('HostgroupJobs', () => {
       .map(element => expect(element).toBeInTheDocument());
     expect(screen.getByText('Scheduled recurring jobs')).toBeInTheDocument();
     expect(screen.getByText('Previously executed jobs')).toBeInTheDocument();
-    expect(screen.getByText('54 10 15 * *')).toBeInTheDocument();
+    expect(screen.getByText(readableCron('54 10 15 * *'))).toBeInTheDocument();
   });
   it('should show empty state', async () => {
     render(
@@ -103,7 +104,9 @@ describe('HostgroupJobs', () => {
       type: 'success',
       message: 'Ansible job was successfully created.',
     });
-    expect(screen.getByText(toCron(futureDate, 'weekly'))).toBeInTheDocument();
+    expect(
+      screen.getByText(readableCron(toCron(futureDate, 'weekly')))
+    ).toBeInTheDocument();
     expect(screen.getByText('in 3 days')).toBeInTheDocument();
     expect(
       screen.queryByText('No config job for Ansible roles scheduled')


### PR DESCRIPTION
Simple `readableCron` helper for parsing cron line into human readable format: `hourly`, `daily`, `weekly` and `monthly`.