### PR TITLE
Fixes #34512 - coerce batch size to integer

### DIFF
--- a/app/models/foreman_ansible/ansible_provider.rb
+++ b/app/models/foreman_ansible/ansible_provider.rb
@@ -115,7 +115,8 @@ if defined? ForemanRemoteExecution
         end
 
         def proxy_batch_size
-          Setting['foreman_ansible_proxy_batch_size']
+          value = Setting['foreman_ansible_proxy_batch_size']
+          value.presence && value.to_i
         end
 
         private

--- a/test/unit/ansible_provider_test.rb
+++ b/test/unit/ansible_provider_test.rb
@@ -47,4 +47,16 @@ class AnsibleProviderTest < ActiveSupport::TestCase
         proxy_command_options(template_invocation, dummyhost)
     end
   end
+
+  describe '#proxy_batch_size' do
+    it 'returns integer if setting is string' do
+      Setting.expects(:[]).with('foreman_ansible_proxy_batch_size').returns('10')
+      _(ForemanAnsible::AnsibleProvider.proxy_batch_size).must_equal(10)
+    end
+
+    it 'returns nil if setting is empty' do
+      Setting.expects(:[]).with('foreman_ansible_proxy_batch_size').returns('')
+      _(ForemanAnsible::AnsibleProvider.proxy_batch_size).must_equal(nil)
+    end
+  end
 end


### PR DESCRIPTION
The setting is not coerced properly, we need to make sure it is coerced properly.