### PR TITLE
Refs #34327 - enable ansible_variables on inherited roles

### DIFF
--- a/app/graphql/presenters/ansible_role_presenter.rb
+++ b/app/graphql/presenters/ansible_role_presenter.rb
@@ -4,6 +4,10 @@ module Presenters
 
     delegate :id, :name, :association, :to => :ansible_role
 
+    def self.graphql_type
+      'Types::InheritedAnsibleRole'
+    end
+
     def initialize(ansible_role, inherited)
       @ansible_role = ansible_role
       @inherited = inherited

--- a/app/graphql/types/ansible_role.rb
+++ b/app/graphql/types/ansible_role.rb
@@ -6,5 +6,6 @@ module Types
 
     field :name, String, :null => false
     field :path, resolver: Resolvers::AnsibleRole::Path
+    has_many :ansible_variables, ::Types::AnsibleVariable
   end
 end

--- a/app/graphql/types/inherited_ansible_role.rb
+++ b/app/graphql/types/inherited_ansible_role.rb
@@ -2,6 +2,10 @@ module Types
   class InheritedAnsibleRole < ::Types::AnsibleRole
     field :inherited, Boolean, :null => false
 
+    def self.record_for(object)
+      object.ansible_role
+    end
+
     def object_class
       object.ansible_role.class
     end

--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Foreman::Plugin.register :foreman_ansible do
-  requires_foreman '>= 3.0'
+  requires_foreman '>= 3.3'
 
   settings do
     category :ansible, N_('Ansible') do

--- a/test/graphql/queries/host_ansible_roles_query_test.rb
+++ b/test/graphql/queries/host_ansible_roles_query_test.rb
@@ -1,0 +1,61 @@
+require 'test_plugin_helper'
+
+module Queries
+  class HostAnsibleRolesQueryTest < GraphQLQueryTestCase
+    let(:role1) { FactoryBot.create(:ansible_role) }
+    let(:role2) { FactoryBot.create(:ansible_role) }
+    let(:hostgroup) { FactoryBot.create(:hostgroup, ansible_roles: [role1]) }
+    let(:host) { FactoryBot.create(:host, hostgroup: hostgroup, ansible_roles: [role2]) }
+    let(:variables) { { id: Foreman::GlobalId.for(host) } }
+    let(:query) do
+      <<-GRAPHQL
+      query ($id: String!) {
+        host(id: $id) {
+          id
+          allAnsibleRoles {
+            totalCount
+            nodes {
+              id
+              name
+              inherited
+              ansibleVariables {
+                totalCount
+                nodes {
+                  key
+                  override
+                }
+              }
+            }
+          }
+        }
+      }
+      GRAPHQL
+    end
+
+    context 'with admin permissions' do
+      let(:context_user) { FactoryBot.create(:user, :admin) }
+      let(:data) { result['data']['host']['allAnsibleRoles'] }
+
+      it 'allows to fetch inherited roles' do
+        value(data['totalCount']).must_equal(2)
+        r1_data = data['nodes'].first
+        r2_data = data['nodes'].second
+        value(r1_data['name']).must_equal(role1.name)
+        value(r1_data['inherited']).must_equal(true)
+        value(r2_data['name']).must_equal(role2.name)
+        value(r2_data['inherited']).must_equal(false)
+      end
+
+      it 'allow fetching variables' do
+        var1 = FactoryBot.create(:ansible_variable, ansible_role: role1, override: true)
+        FactoryBot.create(:ansible_variable, ansible_role: role1)
+        FactoryBot.create(:ansible_variable, ansible_role: role2, override: true)
+        r1_vars = data['nodes'].first['ansibleVariables']
+        r2_vars = data['nodes'].second['ansibleVariables']
+        value(r1_vars['totalCount']).must_equal(2)
+        value(r2_vars['totalCount']).must_equal(1)
+        value(r1_vars['nodes'].first['key']).must_equal(var1.key)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This resolves issue of loading associations from Presenter types.
Needs fix in core introduced by https://github.com/theforeman/foreman/pull/9134.