### PR TITLE
Fixes #34575 - Fix table roles pagination failure

### DIFF
--- a/webpack/components/AnsibleHostDetail/components/RolesTab/RolesTable.js
+++ b/webpack/components/AnsibleHostDetail/components/RolesTab/RolesTable.js
@@ -42,7 +42,8 @@ const RolesTable = ({
     refreshPage(history, { ...pagination, page });
   };
 
-  const perPageOptions = preparePerPageOptions(usePaginationOptions());
+  const options = usePaginationOptions();
+  const perPageOptions = preparePerPageOptions(options);
 
   const editBtn = canEditHost ? (
     <FlexItem>


### PR DESCRIPTION
as described in https://community.theforeman.org/t/foreman-ansible-roles-import/27467

```
foreman-vendor.bundle-v10.0.2-production-b143521739869caa8de3.js:292 TypeError: Cannot read properties of undefined (reading 'map')
at t.preparePerPageOptions (paginationHelper.js:4)
at v (RolesTable.js:45)
at Ka (foreman-vendor.bundle-v10.0.2-production-b143521739869caa8de3.js:292)
```