### PR TITLE
Cherry-pick pagination changes to 7.0-stable

### DIFF
--- a/.github/workflows/js_tests.yml
+++ b/.github/workflows/js_tests.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: theforeman/foreman
-          ref: 3.1-stable
+          ref: 3.2-stable
           path: foreman
       - name: Setup Node
         uses: actions/setup-node@v1

--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        foreman-core-branch: [3.1-stable]
+        foreman-core-branch: [3.2-stable]
         ruby-version: [2.5, 2.6]
         node-version: [12]
     steps:

--- a/test/functional/hosts_controller_test.rb
+++ b/test/functional/hosts_controller_test.rb
@@ -20,7 +20,7 @@ class HostsControllerExtensionsTest < ActionController::TestCase
                  0 => { :ansible_role_id => @role.id, :position => 0 }
                } }
       post :create, :params => { :host => host }, :session => set_session_user
-      assert_redirected_to host_url(assigns('host'))
+      assert_redirected_to host_details_page_url(assigns('host'))
       assert assigns('host').ansible_roles, [@role]
     end
 
@@ -34,7 +34,7 @@ class HostsControllerExtensionsTest < ActionController::TestCase
              } }
            },
            :session => set_session_user
-      assert_redirected_to host_url(assigns('host'))
+      assert_redirected_to host_details_page_url(assigns('host'))
       assert_equal assigns('host').ansible_roles, [@role]
     end
 

--- a/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/AnsibleVariableOverridesTable.js
+++ b/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/AnsibleVariableOverridesTable.js
@@ -146,59 +146,68 @@ const AnsibleVariableOverridesTable = ({
 
   return (
     <React.Fragment>
-      <Flex>
+      <Flex direction={{ default: 'column' }}>
         <FlexItem align={{ default: 'alignRight' }}>
           <Pagination updateParamsByUrl itemCount={totalCount} variant="top" />
         </FlexItem>
+        <FlexItem>
+          <TableComposable variant="compact">
+            <Thead>
+              <Tr>
+                {columns.map(col => (
+                  <Th key={col}>{col}</Th>
+                ))}
+                <Th />
+              </Tr>
+            </Thead>
+            <Tbody>
+              {variables.map((variable, idx) => (
+                <Tr key={idx}>
+                  <Td>
+                    <a href={variable.path}>{variable.key}</a>
+                  </Td>
+                  <Td>{variable.ansibleRoleName}</Td>
+                  <Td>{variable.parameterType}</Td>
+                  <Td>
+                    <EditableValue
+                      variable={variable}
+                      editing={editableState[idx].open}
+                      onChange={onValueChange(idx, variable)}
+                      value={editableState[idx].value}
+                      validation={editableState[idx].validation}
+                      working={editableState[idx].working}
+                    />
+                  </Td>
+                  <Td>{formatSourceAttr(variable)}</Td>
+                  <Td>
+                    <EditableAction
+                      open={editableState[idx].open}
+                      onClose={setEditable(idx, false)}
+                      onOpen={setEditable(idx, true)}
+                      toggleWorking={toggleWorking(idx)}
+                      variable={variable}
+                      state={editableState[idx]}
+                      hostId={hostId}
+                      hostName={hostAttrs.name}
+                      hostGlobalId={hostGlobalId}
+                      onSubmitSuccess={onSubmitSuccess(idx, variable)}
+                      onValidationError={onValidationError(idx)}
+                    />
+                  </Td>
+                  <Td actions={{ items: actionsResolver(variable, idx) }} />
+                </Tr>
+              ))}
+            </Tbody>
+          </TableComposable>
+        </FlexItem>
+        <FlexItem align={{ default: 'alignRight' }}>
+          <Pagination
+            updateParamsByUrl
+            itemCount={totalCount}
+            variant="bottom"
+          />
+        </FlexItem>
       </Flex>
-      <TableComposable variant="compact">
-        <Thead>
-          <Tr>
-            {columns.map(col => (
-              <Th key={col}>{col}</Th>
-            ))}
-            <Th />
-          </Tr>
-        </Thead>
-        <Tbody>
-          {variables.map((variable, idx) => (
-            <Tr key={idx}>
-              <Td>
-                <a href={variable.path}>{variable.key}</a>
-              </Td>
-              <Td>{variable.ansibleRoleName}</Td>
-              <Td>{variable.parameterType}</Td>
-              <Td>
-                <EditableValue
-                  variable={variable}
-                  editing={editableState[idx].open}
-                  onChange={onValueChange(idx, variable)}
-                  value={editableState[idx].value}
-                  validation={editableState[idx].validation}
-                  working={editableState[idx].working}
-                />
-              </Td>
-              <Td>{formatSourceAttr(variable)}</Td>
-              <Td>
-                <EditableAction
-                  open={editableState[idx].open}
-                  onClose={setEditable(idx, false)}
-                  onOpen={setEditable(idx, true)}
-                  toggleWorking={toggleWorking(idx)}
-                  variable={variable}
-                  state={editableState[idx]}
-                  hostId={hostId}
-                  hostName={hostAttrs.name}
-                  hostGlobalId={hostGlobalId}
-                  onSubmitSuccess={onSubmitSuccess(idx, variable)}
-                  onValidationError={onValidationError(idx)}
-                />
-              </Td>
-              <Td actions={{ items: actionsResolver(variable, idx) }} />
-            </Tr>
-          ))}
-        </Tbody>
-      </TableComposable>
     </React.Fragment>
   );
 };

--- a/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/AnsibleVariableOverridesTable.js
+++ b/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/AnsibleVariableOverridesTable.js
@@ -4,7 +4,6 @@ import { useDispatch } from 'react-redux';
 import { useMutation } from '@apollo/client';
 
 import { sprintf, translate as __ } from 'foremanReact/common/I18n';
-import { usePaginationOptions } from 'foremanReact/components/Pagination/PaginationHooks';
 import { openConfirmModal } from 'foremanReact/components/ConfirmModal';
 import {
   TableComposable,
@@ -14,8 +13,9 @@ import {
   Th,
   Td,
 } from '@patternfly/react-table';
-import { Flex, FlexItem, Pagination } from '@patternfly/react-core';
+import { Flex, FlexItem } from '@patternfly/react-core';
 
+import Pagination from 'foremanReact/components/Pagination';
 import deleteAnsibleVariableOverride from '../../../../graphql/mutations/deleteAnsibleVariableOverride.gql';
 import EditableAction from './EditableAction';
 import EditableValue from './EditableValue';
@@ -29,10 +29,6 @@ import {
 } from './AnsibleVariableOverridesTableHelper';
 
 import withLoading from '../../../withLoading';
-import {
-  preparePerPageOptions,
-  refreshPage,
-} from '../../../../helpers/paginationHelper';
 
 const reducer = (state, action) =>
   state.map((item, index) => {
@@ -58,8 +54,6 @@ const AnsibleVariableOverridesTable = ({
   hostId,
   hostGlobalId,
   totalCount,
-  pagination,
-  history,
 }) => {
   const columns = [
     __('Name'),
@@ -68,16 +62,6 @@ const AnsibleVariableOverridesTable = ({
     __('Value'),
     __('Source attribute'),
   ];
-
-  const handlePerPageSelected = (event, perPage) => {
-    refreshPage(history, { page: 1, perPage });
-  };
-
-  const handlePageSelected = (event, page) => {
-    refreshPage(history, { ...pagination, page });
-  };
-
-  const perPageOptions = preparePerPageOptions(usePaginationOptions());
 
   const [editableState, innerDispatch] = useReducer(
     reducer,
@@ -164,15 +148,7 @@ const AnsibleVariableOverridesTable = ({
     <React.Fragment>
       <Flex>
         <FlexItem align={{ default: 'alignRight' }}>
-          <Pagination
-            itemCount={totalCount}
-            page={pagination.page}
-            perPage={pagination.perPage}
-            onSetPage={handlePageSelected}
-            onPerPageSelect={handlePerPageSelected}
-            perPageOptions={perPageOptions}
-            variant="top"
-          />
+          <Pagination updateParamsByUrl itemCount={totalCount} variant="top" />
         </FlexItem>
       </Flex>
       <TableComposable variant="compact">
@@ -233,8 +209,6 @@ AnsibleVariableOverridesTable.propTypes = {
   hostId: PropTypes.number.isRequired,
   hostGlobalId: PropTypes.string.isRequired,
   totalCount: PropTypes.number.isRequired,
-  pagination: PropTypes.object.isRequired,
-  history: PropTypes.object.isRequired,
 };
 
 export default withLoading(AnsibleVariableOverridesTable);

--- a/webpack/components/AnsibleHostDetail/components/JobsTab/PreviousJobsTable.js
+++ b/webpack/components/AnsibleHostDetail/components/JobsTab/PreviousJobsTable.js
@@ -30,45 +30,54 @@ const PreviousJobsTable = ({ history, totalCount, jobs, pagination }) => {
   return (
     <React.Fragment>
       <h3>{__('Previously executed jobs')}</h3>
-      <Flex className="pf-u-pt-md">
+      <Flex direction={{ default: 'column' }} className="pf-u-pt-md">
         <FlexItem align={{ default: 'alignRight' }}>
           <Pagination updateParamsByUrl itemCount={totalCount} variant="top" />
         </FlexItem>
+        <FlexItem>
+          <TableComposable variant="compact">
+            <Thead>
+              <Tr>
+                {columns.map(col => (
+                  <Th key={col}>{col}</Th>
+                ))}
+              </Tr>
+            </Thead>
+            <Tbody>
+              {jobs.map(job => (
+                <Tr key={job.id}>
+                  <Td>
+                    <a
+                      onClick={() =>
+                        window.tfm.nav.pushUrl(
+                          `/job_invocations/${decodeId(job.id)}`
+                        )
+                      }
+                    >
+                      {job.description}
+                    </a>
+                    &nbsp;
+                    {readablePurpose(job.recurringLogic.purpose)}
+                  </Td>
+                  <Td>{job.task.result}</Td>
+                  <Td>{job.task.state}</Td>
+                  <Td>
+                    <RelativeDateTime date={job.startAt} />
+                  </Td>
+                  <Td>{readableCron(job.recurringLogic.cronLine)}</Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </TableComposable>
+        </FlexItem>
+        <FlexItem align={{ default: 'alignRight' }}>
+          <Pagination
+            updateParamsByUrl
+            itemCount={totalCount}
+            variant="bottom"
+          />
+        </FlexItem>
       </Flex>
-      <TableComposable variant="compact">
-        <Thead>
-          <Tr>
-            {columns.map(col => (
-              <Th key={col}>{col}</Th>
-            ))}
-          </Tr>
-        </Thead>
-        <Tbody>
-          {jobs.map(job => (
-            <Tr key={job.id}>
-              <Td>
-                <a
-                  onClick={() =>
-                    window.tfm.nav.pushUrl(
-                      `/job_invocations/${decodeId(job.id)}`
-                    )
-                  }
-                >
-                  {job.description}
-                </a>
-                &nbsp;
-                {readablePurpose(job.recurringLogic.purpose)}
-              </Td>
-              <Td>{job.task.result}</Td>
-              <Td>{job.task.state}</Td>
-              <Td>
-                <RelativeDateTime date={job.startAt} />
-              </Td>
-              <Td>{readableCron(job.recurringLogic.cronLine)}</Td>
-            </Tr>
-          ))}
-        </Tbody>
-      </TableComposable>
     </React.Fragment>
   );
 };

--- a/webpack/components/AnsibleHostDetail/components/JobsTab/PreviousJobsTable.js
+++ b/webpack/components/AnsibleHostDetail/components/JobsTab/PreviousJobsTable.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { usePaginationOptions } from 'foremanReact/components/Pagination/PaginationHooks';
-
 import RelativeDateTime from 'foremanReact/components/common/dates/RelativeDateTime';
 
 import {
@@ -13,15 +11,12 @@ import {
   Th,
   Td,
 } from '@patternfly/react-table';
-import { Flex, FlexItem, Pagination } from '@patternfly/react-core';
+import { Flex, FlexItem } from '@patternfly/react-core';
+import Pagination from 'foremanReact/components/Pagination';
 
 import { decodeId } from '../../../../globalIdHelper';
 import withLoading from '../../../withLoading';
 import { readableCron, readablePurpose } from './JobsTabHelper';
-import {
-  preparePerPageOptions,
-  refreshPage,
-} from '../../../../helpers/paginationHelper';
 
 const PreviousJobsTable = ({ history, totalCount, jobs, pagination }) => {
   const columns = [
@@ -32,30 +27,12 @@ const PreviousJobsTable = ({ history, totalCount, jobs, pagination }) => {
     __('Schedule'),
   ];
 
-  const handlePerPageSelected = (event, perPage) => {
-    refreshPage(history, { page: 1, perPage });
-  };
-
-  const handlePageSelected = (event, page) => {
-    refreshPage(history, { ...pagination, page });
-  };
-
-  const perPageOptions = preparePerPageOptions(usePaginationOptions());
-
   return (
     <React.Fragment>
       <h3>{__('Previously executed jobs')}</h3>
       <Flex className="pf-u-pt-md">
         <FlexItem align={{ default: 'alignRight' }}>
-          <Pagination
-            itemCount={totalCount}
-            page={pagination.page}
-            perPage={pagination.perPage}
-            onSetPage={handlePageSelected}
-            onPerPageSelect={handlePerPageSelected}
-            perPageOptions={perPageOptions}
-            variant="top"
-          />
+          <Pagination updateParamsByUrl itemCount={totalCount} variant="top" />
         </FlexItem>
       </Flex>
       <TableComposable variant="compact">

--- a/webpack/components/AnsibleHostDetail/components/RolesTab/AllRolesModal/AllRolesTable.js
+++ b/webpack/components/AnsibleHostDetail/components/RolesTab/AllRolesModal/AllRolesTable.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { usePaginationOptions } from 'foremanReact/components/Pagination/PaginationHooks';
 
 import {
   TableComposable,
@@ -11,45 +10,18 @@ import {
   Th,
   Td,
 } from '@patternfly/react-table';
-
-import { Flex, FlexItem, Pagination } from '@patternfly/react-core';
+import { Flex, FlexItem } from '@patternfly/react-core';
+import Pagination from 'foremanReact/components/Pagination';
 import withLoading from '../../../../withLoading';
-import {
-  preparePerPageOptions,
-  refreshPage,
-} from '../../../../../helpers/paginationHelper';
 
-const AllRolesTable = ({
-  allAnsibleRoles,
-  totalCount,
-  pagination,
-  history,
-}) => {
+const AllRolesTable = ({ allAnsibleRoles, totalCount }) => {
   const columns = [__('Name'), __('Source')];
-
-  const handlePerPageSelected = (event, allPerPage) => {
-    refreshPage(history, { allPage: 1, allPerPage });
-  };
-
-  const handlePageSelected = (event, allPage) => {
-    refreshPage(history, { ...pagination, allPage });
-  };
-
-  const perPageOptions = preparePerPageOptions(usePaginationOptions());
 
   return (
     <React.Fragment>
       <Flex className="pf-u-pt-md">
         <FlexItem align={{ default: 'alignRight' }}>
-          <Pagination
-            itemCount={totalCount}
-            page={pagination.allPage}
-            perPage={pagination.allPerPage}
-            onSetPage={handlePageSelected}
-            onPerPageSelect={handlePerPageSelected}
-            perPageOptions={perPageOptions}
-            variant="top"
-          />
+          <Pagination updateParamsByUrl itemCount={totalCount} variant="top" />
         </FlexItem>
       </Flex>
       <TableComposable variant="compact">
@@ -82,8 +54,6 @@ const AllRolesTable = ({
 AllRolesTable.propTypes = {
   allAnsibleRoles: PropTypes.array.isRequired,
   totalCount: PropTypes.number.isRequired,
-  pagination: PropTypes.object.isRequired,
-  history: PropTypes.object.isRequired,
 };
 
 export default withLoading(AllRolesTable);

--- a/webpack/components/AnsibleHostDetail/components/RolesTab/AllRolesModal/AllRolesTable.js
+++ b/webpack/components/AnsibleHostDetail/components/RolesTab/AllRolesModal/AllRolesTable.js
@@ -19,34 +19,41 @@ const AllRolesTable = ({ allAnsibleRoles, totalCount }) => {
 
   return (
     <React.Fragment>
-      <Flex className="pf-u-pt-md">
+      <Flex direction={{ default: 'column' }} className="pf-u-pt-md">
         <FlexItem align={{ default: 'alignRight' }}>
           <Pagination updateParamsByUrl itemCount={totalCount} variant="top" />
         </FlexItem>
-      </Flex>
-      <TableComposable variant="compact">
-        <Thead>
-          <Tr>
-            <Th />
-            {columns.map(col => (
-              <Th key={`${col}-all`}>{col}</Th>
-            ))}
-          </Tr>
-        </Thead>
-        <Tbody>
-          {allAnsibleRoles.map(role => (
-            <Tr key={`${role.id}-all`} id={role.id}>
-              <Td />
-              <Td>{role.name}</Td>
-              <Td>
-                {role.inherited
-                  ? __('Inherited from Hostgroup')
-                  : __('Directly assigned to Host')}
-              </Td>
+        <TableComposable variant="compact">
+          <Thead>
+            <Tr>
+              <Th />
+              {columns.map(col => (
+                <Th key={`${col}-all`}>{col}</Th>
+              ))}
             </Tr>
-          ))}
-        </Tbody>
-      </TableComposable>
+          </Thead>
+          <Tbody>
+            {allAnsibleRoles.map(role => (
+              <Tr key={`${role.id}-all`} id={role.id}>
+                <Td />
+                <Td>{role.name}</Td>
+                <Td>
+                  {role.inherited
+                    ? __('Inherited from Hostgroup')
+                    : __('Directly assigned to Host')}
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </TableComposable>
+        <FlexItem align={{ default: 'alignRight' }}>
+          <Pagination
+            updateParamsByUrl
+            itemCount={totalCount}
+            variant="bottom"
+          />
+        </FlexItem>
+      </Flex>
     </React.Fragment>
   );
 };

--- a/webpack/components/AnsibleHostDetail/components/RolesTab/AllRolesModal/index.js
+++ b/webpack/components/AnsibleHostDetail/components/RolesTab/AllRolesModal/index.js
@@ -27,7 +27,7 @@ const AllRolesModal = ({ hostGlobalId, onClose, history }) => {
     ),
   };
 
-  const paginationKeys = { page: 'allPage', perPage: 'allPerPage' };
+  const paginationKeys = { page: 'page', perPage: 'per_page' };
 
   const wrapper = child => <Modal {...baseModalProps}>{child}</Modal>;
 

--- a/webpack/components/AnsibleHostDetail/components/RolesTab/RolesTable.js
+++ b/webpack/components/AnsibleHostDetail/components/RolesTab/RolesTable.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { Route, Link } from 'react-router-dom';
-import { usePaginationOptions } from 'foremanReact/components/Pagination/PaginationHooks';
+import Pagination from 'foremanReact/components/Pagination';
 
 import {
   TableComposable,
@@ -12,20 +12,15 @@ import {
   Th,
   Td,
 } from '@patternfly/react-table';
-import { Flex, FlexItem, Button, Pagination } from '@patternfly/react-core';
+import { Flex, FlexItem, Button } from '@patternfly/react-core';
 
 import EditRolesModal from './EditRolesModal';
 
 import withLoading from '../../../withLoading';
 import AllRolesModal from './AllRolesModal';
-import {
-  preparePerPageOptions,
-  refreshPage,
-} from '../../../../helpers/paginationHelper';
 
 const RolesTable = ({
   totalCount,
-  pagination,
   history,
   ansibleRoles,
   hostId,
@@ -33,16 +28,6 @@ const RolesTable = ({
   canEditHost,
 }) => {
   const columns = [__('Name')];
-
-  const handlePerPageSelected = (event, perPage) => {
-    refreshPage(history, { page: 1, perPage });
-  };
-
-  const handlePageSelected = (event, page) => {
-    refreshPage(history, { ...pagination, page });
-  };
-
-  const perPageOptions = preparePerPageOptions(usePaginationOptions());
 
   const editBtn = canEditHost ? (
     <FlexItem>
@@ -68,15 +53,7 @@ const RolesTable = ({
       <Flex>
         <FlexItem>{editBtn}</FlexItem>
         <FlexItem align={{ default: 'alignRight' }}>
-          <Pagination
-            itemCount={totalCount}
-            page={pagination.page}
-            perPage={pagination.perPage}
-            onSetPage={handlePageSelected}
-            onPerPageSelect={handlePerPageSelected}
-            perPageOptions={perPageOptions}
-            variant="top"
-          />
+          <Pagination updateParamsByUrl itemCount={totalCount} variant="top" />
         </FlexItem>
       </Flex>
       <TableComposable variant="compact">
@@ -123,7 +100,6 @@ RolesTable.propTypes = {
   hostId: PropTypes.number.isRequired,
   hostGlobalId: PropTypes.string.isRequired,
   history: PropTypes.object.isRequired,
-  pagination: PropTypes.object.isRequired,
   totalCount: PropTypes.number.isRequired,
   canEditHost: PropTypes.bool.isRequired,
 };

--- a/webpack/components/AnsibleHostDetail/components/RolesTab/RolesTable.js
+++ b/webpack/components/AnsibleHostDetail/components/RolesTab/RolesTable.js
@@ -56,24 +56,35 @@ const RolesTable = ({
           <Pagination updateParamsByUrl itemCount={totalCount} variant="top" />
         </FlexItem>
       </Flex>
-      <TableComposable variant="compact">
-        <Thead>
-          <Tr>
-            {columns.map(col => (
-              <Th key={col}>{col}</Th>
-            ))}
-          </Tr>
-        </Thead>
-        <Tbody>
-          {ansibleRoles.map(role => (
-            <Tr key={role.id}>
-              <Td>
-                <a href={role.path}>{role.name}</a>
-              </Td>
-            </Tr>
-          ))}
-        </Tbody>
-      </TableComposable>
+      <Flex direction={{ default: 'column' }}>
+        <FlexItem>
+          <TableComposable variant="compact">
+            <Thead>
+              <Tr>
+                {columns.map(col => (
+                  <Th key={col}>{col}</Th>
+                ))}
+              </Tr>
+            </Thead>
+            <Tbody>
+              {ansibleRoles.map(role => (
+                <Tr key={role.id}>
+                  <Td>
+                    <a href={role.path}>{role.name}</a>
+                  </Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </TableComposable>
+        </FlexItem>
+        <FlexItem align={{ default: 'alignRight' }}>
+          <Pagination
+            updateParamsByUrl
+            itemCount={totalCount}
+            variant="bottom"
+          />
+        </FlexItem>
+      </Flex>
       <Route path="/Ansible/roles/edit">
         <EditRolesModal
           closeModal={() => history.goBack()}

--- a/webpack/components/AnsibleRolesAndVariables/AnsibleRolesAndVariables.js
+++ b/webpack/components/AnsibleRolesAndVariables/AnsibleRolesAndVariables.js
@@ -33,10 +33,13 @@ const ImportRolesAndVariablesTable = ({
 
   const [isChecked, setIsChecked] = useState(false);
   const [selectedRowsCount, setSelectRowsCount] = useState(0);
-
-  const [page, setPage] = useState();
-  const [perPage, setPerPage] = useState(DEFAULT_PER_PAGE);
-  const [paginatedRows, setPaginatedRows] = useState(rows.slice(0, perPage));
+  const [pagination, setPagination] = useState({
+    page: 1,
+    per_page: DEFAULT_PER_PAGE,
+  });
+  const [paginatedRows, setPaginatedRows] = useState(
+    rows.slice(0, pagination.per_page)
+  );
 
   const onSelect = (event, isSelected, rowId, row) => {
     const selectableRowLength = rows.filter(
@@ -67,43 +70,22 @@ const ImportRolesAndVariablesTable = ({
     onSelect(null, checked, -1);
   };
 
-  const handleSetPage = (event, newPage) => {
-    const startIdx = (newPage - 1) * perPage;
+  const handleSetPage = args => {
+    const startIdx = (args.page - 1) * args.per_page;
     const endIdx =
-      rows.length < newPage * perPage ? rows.length : newPage * perPage;
-    setPage(newPage);
+      rows.length < args.page * args.per_page
+        ? rows.length
+        : args.page * args.per_page;
+    setPagination(args);
     setPaginatedRows(rows.slice(startIdx, endIdx));
   };
 
-  const handlePerPageSelect = (
-    event,
-    newPerPage,
-    newPage,
-    startIdx,
-    endIdx
-  ) => {
-    setPerPage(newPerPage);
-    setPage(newPage);
-    setPaginatedRows(rows.slice(startIdx, endIdx));
-  };
-
-  const renderPagination = (variant = 'top') => (
+  const renderPagination = () => (
     <Pagination
       isCompact
       itemCount={rows.length}
-      page={page}
-      perPage={perPage}
-      defaultToFullPage
-      onSetPage={handleSetPage}
-      onPerPageSelect={handlePerPageSelect}
-      perPageOptions={[
-        { title: '3', value: 3 },
-        { title: '5', value: 5 },
-        { title: '10', value: 10 },
-      ]}
-      titles={{
-        paginationTitle: `${variant} pagination`,
-      }}
+      perPage={pagination.per_page}
+      onChange={args => handleSetPage(args)}
     />
   );
 

--- a/webpack/components/AnsibleRolesAndVariables/AnsibleRolesAndVariables.js
+++ b/webpack/components/AnsibleRolesAndVariables/AnsibleRolesAndVariables.js
@@ -12,9 +12,8 @@ import {
   ToolbarContent,
   ToolbarItem,
   Checkbox,
-  Pagination,
 } from '@patternfly/react-core';
-
+import Pagination from 'foremanReact/components/Pagination';
 import PropTypes from 'prop-types';
 import { DEFAULT_PER_PAGE } from './AnsibleRolesAndVariablesConstants';
 import './AnsibleRolesAndVariables.scss';

--- a/webpack/components/AnsibleRolesSwitcher/components/AvailableRolesList.js
+++ b/webpack/components/AnsibleRolesSwitcher/components/AvailableRolesList.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { ListView, LoadingState } from 'patternfly-react';
-import PaginationWrapper from 'foremanReact/components/Pagination/PaginationWrapper';
+import Pagination from 'foremanReact/components/Pagination';
 
 import AnsibleRole from './AnsibleRole';
 
@@ -16,7 +16,7 @@ const AvailableRolesList = ({
 }) => (
   <ListView>
     <div className="sticky-pagination">
-      <PaginationWrapper
+      <Pagination
         viewType="list"
         itemCount={itemCount}
         pagination={pagination}

--- a/webpack/components/AnsibleRolesSwitcher/components/__snapshots__/AvailableRolesList.test.js.snap
+++ b/webpack/components/AnsibleRolesSwitcher/components/__snapshots__/AvailableRolesList.test.js.snap
@@ -7,21 +7,24 @@ exports[`AvailableRolesList should render 1`] = `
   <div
     className="sticky-pagination"
   >
-    <PaginationWrapper
-      className=""
-      disableNext={false}
-      disablePrev={false}
+    <Pagination
+      className={null}
       dropdownButtonId="available-ansible-roles-pagination-row-dropdown"
       itemCount={2}
+      noSidePadding={false}
       onChange={[Function]}
-      onPageSet={[Function]}
-      onPerPageSelect={[Function]}
+      onPerPageSelect={null}
+      onSetPage={null}
+      page={1}
       pagination={
         Object {
           "page": 1,
           "perPage": 25,
         }
       }
+      perPage={null}
+      updateParamsByUrl={true}
+      variant="bottom"
       viewType="list"
     />
   </div>

--- a/webpack/helpers/pageParamsHelper.js
+++ b/webpack/helpers/pageParamsHelper.js
@@ -14,7 +14,7 @@ export const addSearch = (basePath, params) => {
 
 export const useCurrentPagination = (
   history,
-  keys = { page: 'page', perPage: 'perPage' }
+  keys = { page: 'page', perPage: 'per_page' }
 ) => {
   const pageParams = parsePageParams(history);
   const uiSettings = useForemanSettings();
@@ -28,7 +28,7 @@ export const useCurrentPagination = (
 
 export const pageToVars = (
   pagination,
-  keys = { page: 'page', perPage: 'perPage' }
+  keys = { page: 'page', perPage: 'per_page' }
 ) => ({
   first: pagination[keys.page] * pagination[keys.perPage],
   last: pagination[keys.perPage],
@@ -36,5 +36,5 @@ export const pageToVars = (
 
 export const useParamsToVars = (
   history,
-  keys = { page: 'page', perPage: 'perPage' }
+  keys = { page: 'page', perPage: 'per_page' }
 ) => pageToVars(useCurrentPagination(history, keys), keys);

--- a/webpack/helpers/paginationHelper.js
+++ b/webpack/helpers/paginationHelper.js
@@ -1,9 +1,0 @@
-import { addSearch } from './pageParamsHelper';
-
-export const preparePerPageOptions = opts =>
-  opts.map(item => ({ title: item.toString(), value: item }));
-
-export const refreshPage = (history, params = {}) => {
-  const url = addSearch(history.location.pathname, params);
-  history.push(url);
-};


### PR DESCRIPTION
- Fixes #34190 - consume pagination from core: https://github.com/theforeman/foreman_ansible/commit/b4ebc729193b826a96a4befb26e750f07a9ada0d
- Fixes #34286 - add bottom pagination in all new host page tables - https://github.com/theforeman/foreman_ansible/commit/24620c64dea8922af456a5304aace85f05a21b85
- Fixes #34334 - Import roles - Fix pagination - https://github.com/theforeman/foreman_ansible/commit/67ddad2c67cec49f2e38691eac39c03abfd44ae1

Not sure if I missed any other commit from `master`.
If you could look carefully on the `PreviousJobsTable.js` file as it was quite hard to cherry-pick into it - newer commits were merged before the older commits which are introduced here.