### PR TITLE
Use reusable GitHub Actions for testing

### DIFF
--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -71,7 +71,6 @@ jobs:
       - name: Run plugin tests
         run: |
           bundle exec rake test:foreman_ansible -v --trace
-          bundle exec rake test TEST="test/unit/foreman/access_permissions_test.rb" -v --trace
       - name: 'Upload logs'
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -1,80 +1,25 @@
+---
 name: Ruby Testing
+
 on:
   pull_request:
-env:
-  BUNDLE_WITHOUT: journald:development:console:libvirt
-  RAILS_ENV: test
-  DATABASE_URL: postgresql://postgres:@localhost/test
-  DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: true
+  push:
+    branches:
+      - 'master'
+      - '*-stable'
+
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   rubocop:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.7
-          bundler-cache: true
-      - name: Run rubocop
-        run: bundle exec rubocop
+    name: Rubocop
+    uses: theforeman/actions/.github/workflows/rubocop.yml@v0
+
   test_ruby:
-    runs-on: ubuntu-latest
+    name: Ruby
     needs: rubocop
-    services:
-      postgres:
-        image: postgres:12.1
-        ports: ['5432:5432']
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-    strategy:
-      fail-fast: false
-      matrix:
-        foreman-core-branch: [develop]
-        ruby-version: [2.7]
-        node-version: [12]
-    steps:
-      - name: Install build packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install build-essential libcurl4-openssl-dev zlib1g-dev libpq-dev
-      - uses: actions/checkout@v2
-        with:
-          repository: theforeman/foreman
-          ref: ${{ matrix.foreman-core-branch }}
-      - uses: actions/checkout@v2
-        with:
-          path: foreman_ansible
-      - name: Setup Bundler
-        run: |
-          echo "gem 'foreman_ansible', path: './foreman_ansible'" > bundler.d/foreman_ansible.local.rb
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby-version }}
-          bundler-cache: true
-      - name: Setup Node
-        uses: actions/setup-node@v1
-        with:
-          node-version:  ${{ matrix.node-version }}
-      - name: Install npm dependencies
-        run: npm install
-      - name: Install plugin's npm dependencies
-        run: npm install --omit=dev
-        working-directory: ${{ github.workspace }}/foreman_ansible
-      - name: Prepare test env
-        run: |
-          bundle exec rake db:create
-          bundle exec rake db:migrate
-          bundle exec rake db:test:prepare
-      - name: Prepare webpack
-        run: bundle exec rake webpack:compile
-      - name: Run plugin tests
-        run: |
-          bundle exec rake test:foreman_ansible -v --trace
-      - name: 'Upload logs'
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: logs
-          path: log/*.log
-          retention-days: 5
+    uses: theforeman/actions/.github/workflows/foreman_plugin.yml@v0
+    with:
+      plugin: foreman_ansible

--- a/lib/tasks/foreman_ansible_tasks.rake
+++ b/lib/tasks/foreman_ansible_tasks.rake
@@ -7,6 +7,7 @@ namespace :test do
     test_dir = File.join(__dir__, '..', '..', 'test')
     t.libs << ['test', test_dir]
     t.pattern = "#{test_dir}/**/*_test.rb"
+    t.test_files = [Rails.root.join('test/unit/foreman/access_permissions_test.rb')]
     t.verbose = false
     t.warning = false
   end


### PR DESCRIPTION
This reduces the duplication between projects. For example, this ensures testing on Ruby 2.7 which previously didn't happen.

There are various preparation PRs, see the commits for details.

Right now this is incomplete because it loses the caching step that happens on a push to master. It also still uses the repository in my own namespace. This is just to see if it works.