### PR TITLE
Extended type should be string

### DIFF
--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -187,7 +187,7 @@ Foreman::Plugin.register :foreman_ansible do
 
   register_global_js_file 'global'
 
-  extend_graphql_type :type => ::Types::Host do
+  extend_graphql_type :type => '::Types::Host' do
     field :all_ansible_roles, ::Types::InheritedAnsibleRole.connection_type, :null => true, :method => :present_all_ansible_roles
     field :own_ansible_roles, ::Types::AnsibleRole.connection_type, :null => true
     field :available_ansible_roles, ::Types::AnsibleRole.connection_type, :null => true


### PR DESCRIPTION
Do not autoload the constant prematurely.
It can cause world of trouble if we require the constant too early.
The graphql registration supports string types, we should leverage that.