### PR TITLE
Fixes #34701 - Make running roles from hostgroup index work again

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  match '/ansible/hostgroups' => 'react#index', :via => [:get]
-  match '/ansible/hostgroups/*page' => 'react#index', :via => [:get]
-
   namespace :api, defaults: { format: 'json' } do
     scope '(:apiv)',
           :module => :v2,
@@ -113,4 +110,7 @@ Rails.application.routes.draw do
       end
     end
   end
+
+  match '/ansible/hostgroups' => 'react#index', :via => [:get]
+  match '/ansible/hostgroups/*page' => 'react#index', :via => [:get]
 end


### PR DESCRIPTION
The route to /ansible/hostgroups/$HG_ID/play_roles was shadowed by a
mapping to react controller. This way, the more specific routes are
matched first before the react controller which catches everything.