### PR TITLE
Refs #34121 - Add inherited Ansible role flag to host(group) API

### DIFF
--- a/app/controllers/foreman_ansible/api/v2/hostgroups_controller_extensions.rb
+++ b/app/controllers/foreman_ansible/api/v2/hostgroups_controller_extensions.rb
@@ -46,7 +46,10 @@ module ForemanAnsible
             find_resource
             return unless @hostgroup
 
-            @ansible_roles = @hostgroup.all_ansible_roles
+            @inherited_ansible_roles = @hostgroup.inherited_ansible_roles
+            @ansible_roles = (
+              @inherited_ansible_roles + @hostgroup.ansible_roles + @hostgroup.host_ansible_roles
+            ).uniq
           end
 
           api :POST, '/hostgroups/:id/assign_ansible_roles',

--- a/app/controllers/foreman_ansible/api/v2/hosts_controller_extensions.rb
+++ b/app/controllers/foreman_ansible/api/v2/hosts_controller_extensions.rb
@@ -49,7 +49,8 @@ module ForemanAnsible
           def ansible_roles
             return unless @host
 
-            @ansible_roles = @host.all_ansible_roles
+            @inherited_ansible_roles = @host.inherited_ansible_roles
+            @ansible_roles = (@inherited_ansible_roles + @host.ansible_roles).uniq
           end
 
           api :POST, '/hosts/:id/assign_ansible_roles',

--- a/app/views/api/v2/hostgroups/ansible_roles.json.rabl
+++ b/app/views/api/v2/hostgroups/ansible_roles.json.rabl
@@ -2,4 +2,8 @@
 
 collection @ansible_roles
 
-attributes :id, :name, :created_at, :updated_at
+extends 'api/v2/ansible_roles/show'
+
+node :inherited do |role|
+  @inherited_ansible_roles.include?(role)
+end

--- a/app/views/api/v2/hosts/ansible_roles.json.rabl
+++ b/app/views/api/v2/hosts/ansible_roles.json.rabl
@@ -2,4 +2,8 @@
 
 collection @ansible_roles
 
-attributes :id, :name, :created_at, :updated_at
+extends 'api/v2/ansible_roles/show'
+
+node :inherited do |role|
+  @inherited_ansible_roles.include?(role)
+end


### PR DESCRIPTION
Needed for https://github.com/theforeman/hammer-cli-foreman-ansible/pull/10.

Unfortunatelly, I needed to extract host(group)'s [all_ansible_roles](https://github.com/theforeman/foreman_ansible/blob/master/app/models/concerns/foreman_ansible/host_managed_extensions.rb#L60-L62) method logic into the controller to get inherited ones only to be used in the RABL template, so we don't need to call this for each role. I din't want to call `inherited_ansible_roles` method logic twice since it would call the DB twice. But please tell me if there is a better way since this looks quite ugly :/