### PR TITLE
Fixes #34886 - Github actions - remove NodeJS 10 and add NodeJS 14

### DIFF
--- a/.github/workflows/js_tests.yml
+++ b/.github/workflows/js_tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10, 12]
+        node-version: [12, 14]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/checkout@v2


### PR DESCRIPTION
Fix for:
```
npm ERR! code ENOTSUP
npm ERR! notsup Unsupported engine for node-sass@6.0.1: wanted: {"node":">=12"} (current: {"node":"10.24.1","npm":"6.14.12"})
npm ERR! notsup Not compatible with your version of node/npm: node-sass@6.0.1
npm ERR! notsup Not compatible with your version of node/npm: node-sass@6.0.1
npm ERR! notsup Required: {"node":">=12"}
npm ERR! notsup Actual:   {"npm":"6.14.12","node":"10.24.1"}

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2022-05-10T11_43_06_469Z-debug.log
Error: Process completed with exit code 1.

```