### PR TITLE
Bump foreman dependency to 3.4 and foreman_ansible to 9.0.0

### DIFF
--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Foreman::Plugin.register :foreman_ansible do
-  requires_foreman '>= 3.3'
+  requires_foreman '>= 3.4'
 
   settings do
     category :ansible, N_('Ansible') do

--- a/lib/foreman_ansible/version.rb
+++ b/lib/foreman_ansible/version.rb
@@ -4,5 +4,5 @@
 # This way other parts of Foreman can just call ForemanAnsible::VERSION
 # and detect what version the plugin is running.
 module ForemanAnsible
-  VERSION = '8.0.1'
+  VERSION = '9.0.0'
 end


### PR DESCRIPTION
Since this previous [PR](https://github.com/theforeman/foreman_ansible/pull/541) requires some Foreman core functionality, we needed to bump the minimal Foreman version to 3.4 as well as the foreman_ansible major version to 9.0.0.

