### PR TITLE
Fixes #27181 - add link to hostgroup count for ansible roles

### DIFF
--- a/app/views/ansible_roles/index.html.erb
+++ b/app/views/ansible_roles/index.html.erb
@@ -18,7 +18,7 @@
     <% @ansible_roles.each do |role| %>
       <tr>
         <td class="ellipsis"><%= role.name %></td>
-        <td class="ellipsis"><%= role.hostgroups.count %></td>
+        <td class="ellipsis"><%= link_to role.hostgroups.count, hostgroups_path(:search => "ansible_role = #{role.name}") %></td>
         <td class="ellipsis"><%= link_to role.hosts.count, hosts_path(:search => "ansible_role = #{role.name}")%></td>
         <td class="ellipsis"><%= link_to(role.ansible_variables.count, ansible_variables_path(:search => "ansible_role = #{role}")) %></td>
         <td class="ellipsis"><%= import_time role %></td>

--- a/test/unit/concerns/hostgroup_extensions_test.rb
+++ b/test/unit/concerns/hostgroup_extensions_test.rb
@@ -61,4 +61,9 @@ class HostgroupExtensionsTest < ActiveSupport::TestCase
       @hostgroup_parent.clone.all_ansible_roles.must_equal @hostgroup_parent.all_ansible_roles
     end
   end
+
+  test 'should find hostgroup with role' do
+    result = ::Hostgroup.search_for("ansible_role = #{@role1.name}").pluck(:id)
+    assert_include result, @hostgroup.id
+  end
 end


### PR DESCRIPTION
On the Ansible Roles page, added a link to the hostgroups' counts for the ansible roles. 
This also required adding an additional searchable field of the `ansible role` for the hostgroup.