### PR TITLE
Fixes #28374 - disable run ansible roles option from hostgroup dropdown if no roles are assigned

### DIFF
--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -60,12 +60,20 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version:  ${{ matrix.node-version }}
+      - name: Install npm dependencies
+        run: npm install
+      - name: Install plugin's npm dependencies
+        run: npm install --omit=dev
+        working-directory: ${{ github.workspace }}/foreman_ansible
       - name: Prepare test env
         if: github.event_name != 'push'
         run: |
           bundle exec rake db:create
           bundle exec rake db:migrate
           bundle exec rake db:test:prepare
+      - name: Prepare webpack
+        if: github.event_name != 'push'
+        run: bundle exec rake webpack:compile
       - name: Run plugin tests
         if: github.event_name != 'push'
         run: |

--- a/app/helpers/foreman_ansible/ansible_hostgroups_helper.rb
+++ b/app/helpers/foreman_ansible/ansible_hostgroups_helper.rb
@@ -4,7 +4,7 @@ module ForemanAnsible
   module AnsibleHostgroupsHelper
     def ansible_hostgroups_actions(hostgroup)
       play_roles = if hostgroup.all_ansible_roles.empty?
-                     { action: (link_to _('Run all Ansible roles'), 'javascript:void(0);', disabled: true, title: 'No Roles assigned'), priority: 31 }
+                     { action: { content: (link_to _('Run all Ansible roles'), 'javascript:void(0);', disabled: true, title: 'No roles assigned', class: 'disabled'), options: { class: 'disabled' } }, priority: 31 }
                    else
                      { action: display_link_if_authorized(_('Run all Ansible roles'), hash_for_play_roles_hostgroup_path(id: hostgroup), 'data-no-turbolink': true, title: _('Run all Ansible roles on hosts belonging to this host group')), priority: 31 }
                    end

--- a/foreman_ansible.gemspec
+++ b/foreman_ansible.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'acts_as_list', '~> 1.0.3'
   s.add_dependency 'deface', '< 2.0'
-  s.add_dependency 'foreman_remote_execution', '>= 4.4.0'
-  s.add_dependency 'foreman-tasks', '>= 5.2.0'
+  s.add_dependency 'foreman_remote_execution', '>= 8.0.0'
+  s.add_dependency 'foreman-tasks', '>= 7.0.0'
 end

--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Foreman::Plugin.register :foreman_ansible do
-  requires_foreman '>= 3.4'
+  requires_foreman '>= 3.5'
 
   settings do
     category :ansible, N_('Ansible') do

--- a/lib/foreman_ansible/version.rb
+++ b/lib/foreman_ansible/version.rb
@@ -4,5 +4,5 @@
 # This way other parts of Foreman can just call ForemanAnsible::VERSION
 # and detect what version the plugin is running.
 module ForemanAnsible
-  VERSION = '9.0.1'
+  VERSION = '10.0.0'
 end

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@theforeman/stories": "^10.0",
     "@theforeman/test": "^10.0",
     "@theforeman/vendor-dev": "^10.0",
-    "@testing-library/user-event": "^13.2.1",
     "babel-eslint": "^10.0.3",
     "eslint": "^6.7.2",
     "prettier": "^1.13.5"

--- a/test/integration/hostgroup_js_test.rb
+++ b/test/integration/hostgroup_js_test.rb
@@ -1,0 +1,30 @@
+require_relative '../test_plugin_helper'
+require 'integration_test_helper'
+
+class HostgroupJsTest < IntegrationTestWithJavascript
+  let(:hostgroup) { FactoryBot.create(:hostgroup, :name => 'HostgroupWithoutRoles') }
+  let(:hostgroup_with_roles) { FactoryBot.create(:hostgroup, :with_ansible_roles, :name => 'HostgroupWithRoles') }
+
+  setup do
+    FactoryBot.create(:host, :hostgroup_id => hostgroup.id)
+    FactoryBot.create(:host, :hostgroup_id => hostgroup_with_roles.id)
+  end
+
+  test 'hostgroup without roles should have disabled link' do
+    visit hostgroups_path(search: hostgroup.name)
+
+    first_row = page.find('table > tbody > tr:nth-child(1)')
+    first_row.find('td:nth-child(4) > div > a').click
+
+    assert_includes first(:link, 'Run all Ansible roles')[:class], 'disabled'
+  end
+
+  test 'hostgroup with roles should have clickable link' do
+    visit hostgroups_path(search: hostgroup_with_roles.name)
+
+    first_row = page.find('table > tbody > tr:nth-child(1)')
+    first_row.find('td:nth-child(4) > div > a').click
+
+    assert_not first(:link, 'Run all Ansible roles')[:class].include?('disabled')
+  end
+end


### PR DESCRIPTION
Remove `Run all Ansible roles` option from hostgroup dropdown if no roles are assigned.