### PR TITLE
Expand Ansible inventory by default on the new host page

### DIFF
--- a/webpack/components/ReportJsonViewer.js
+++ b/webpack/components/ReportJsonViewer.js
@@ -10,7 +10,17 @@ const theme = {
 
 const ReportJsonViewer = ({ data }) => (
   <div className="report-json-viewer">
-    <JSONTree data={data} hideRoot theme={theme} />
+    <JSONTree
+      data={data}
+      hideRoot
+      theme={theme}
+      shouldExpandNode={(keyPath, _myData, level) =>
+        keyPath[0] === '_meta' ||
+        keyPath[0] === 'hostvars' ||
+        level === 3 ||
+        keyPath[0] === 'foreman_ansible_roles'
+      }
+    />
   </div>
 );
 


### PR DESCRIPTION
Expand Ansible inventory by default to show Ansible roles.