### PR TITLE
Fixes #36368 - fix ansible roles pagination on host edit page

### DIFF
--- a/webpack/components/AnsibleRolesSwitcher/AnsibleRolesSwitcher.js
+++ b/webpack/components/AnsibleRolesSwitcher/AnsibleRolesSwitcher.js
@@ -26,7 +26,6 @@ class AnsibleRolesSwitcher extends React.Component {
       inheritedRoleIds,
       resourceId,
       resourceName,
-      { page: 1, perPage: 10 },
       excludeAssignedRolesSearch(initialAssignedRoles)
     );
   }

--- a/webpack/components/AnsibleRolesSwitcher/components/AvailableRolesList.js
+++ b/webpack/components/AnsibleRolesSwitcher/components/AvailableRolesList.js
@@ -19,7 +19,9 @@ const AvailableRolesList = ({
       <Pagination
         viewType="list"
         itemCount={itemCount}
-        pagination={pagination}
+        updateParamsByUrl={false}
+        page={pagination.page}
+        perPage={pagination.perPage}
         onChange={onListingChange}
         dropdownButtonId="available-ansible-roles-pagination-row-dropdown"
       />

--- a/webpack/components/AnsibleRolesSwitcher/components/__snapshots__/AvailableRolesList.test.js.snap
+++ b/webpack/components/AnsibleRolesSwitcher/components/__snapshots__/AvailableRolesList.test.js.snap
@@ -16,14 +16,8 @@ exports[`AvailableRolesList should render 1`] = `
       onPerPageSelect={null}
       onSetPage={null}
       page={1}
-      pagination={
-        Object {
-          "page": 1,
-          "perPage": 25,
-        }
-      }
-      perPage={null}
-      updateParamsByUrl={true}
+      perPage={25}
+      updateParamsByUrl={false}
       variant="bottom"
       viewType="list"
     />


### PR DESCRIPTION
This PR fixes the pagination issues we have with Ansible roles on the host edit page. 