### PR TITLE
Fixes #35354 - always display the link to view all assigned roles

### DIFF
--- a/webpack/components/AnsibleHostDetail/components/RolesTab/__test__/EditRoles.test.js
+++ b/webpack/components/AnsibleHostDetail/components/RolesTab/__test__/EditRoles.test.js
@@ -21,7 +21,8 @@ import {
   assignRolesErrorMock,
 } from './RolesTab.fixtures';
 
-const TestComponent = withReactRouter(withRedux(withMockedProvider(RolesTab)));
+jest.mock('axios');
+const TestComponent = withRedux(withReactRouter(withMockedProvider(RolesTab)));
 
 describe('assigning Ansible roles', () => {
   it('should assign Ansible roles', async () => {

--- a/webpack/components/AnsibleHostDetail/components/RolesTab/__test__/RolesTab.test.js
+++ b/webpack/components/AnsibleHostDetail/components/RolesTab/__test__/RolesTab.test.js
@@ -6,6 +6,7 @@ import {
   tick,
   withMockedProvider,
   withReactRouter,
+  withRedux,
 } from '../../../../../testHelper';
 
 import {
@@ -18,7 +19,8 @@ import {
 
 import RolesTab from '../';
 
-const TestComponent = withReactRouter(withMockedProvider(RolesTab));
+jest.mock('axios');
+const TestComponent = withRedux(withReactRouter(withMockedProvider(RolesTab)));
 
 describe('RolesTab', () => {
   it('should load Ansible Roles as admin', async () => {

--- a/webpack/components/AnsibleHostDetail/components/RolesTab/index.js
+++ b/webpack/components/AnsibleHostDetail/components/RolesTab/index.js
@@ -2,7 +2,10 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/client';
 import { Button } from '@patternfly/react-core';
+import { Link, Route } from 'react-router-dom';
 import { translate as __ } from 'foremanReact/common/I18n';
+import { foremanUrl } from 'foremanReact/common/helpers';
+import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
 
 import ansibleRolesQuery from '../../../../graphql/queries/hostAnsibleRoles.gql';
 import { encodeId } from '../../../../globalIdHelper';
@@ -12,6 +15,7 @@ import {
   useCurrentPagination,
 } from '../../../../helpers/pageParamsHelper';
 import EditRolesModal from './EditRolesModal';
+import AllRolesModal from './AllRolesModal';
 
 const RolesTab = ({ hostId, history, canEditHost }) => {
   const hostGlobalId = encodeId('Host', hostId);
@@ -33,9 +37,28 @@ const RolesTab = ({ hostId, history, canEditHost }) => {
       onClick={() => setAssignModal(true)}
       aria-label="edit ansible roles"
     >
-      {__('Assign Ansible roles')}
+      {__('Assign roles directly to the host')}
     </Button>
   ) : null;
+
+  const url = hostId && foremanUrl(`/api/v2/hosts/${hostId}/ansible_roles`);
+  const { response: allAnsibleRoles } = useAPI('get', url, {
+    key: 'ANSIBLE_ROLES',
+  });
+  const emptyStateDescription = allAnsibleRoles.length > 0 && (
+    <>
+      <Route path="/Ansible/roles/all">
+        <AllRolesModal
+          onClose={() => history.push('/Ansible/roles')}
+          isOpen
+          hostGlobalId={hostGlobalId}
+          history={history}
+        />
+      </Route>
+      <Link to="/Ansible/roles/all">{__('View inherited roles')}</Link>
+    </>
+  );
+
   return (
     <>
       <RolesTable
@@ -46,8 +69,9 @@ const RolesTab = ({ hostId, history, canEditHost }) => {
         history={history}
         hostGlobalId={hostGlobalId}
         emptyStateProps={{
-          header: __('No Ansible roles assigned'),
+          header: __('No roles assigned directly to the host'),
           action: editBtn,
+          description: emptyStateDescription,
         }}
         pagination={pagination}
         canEditHost={canEditHost}

--- a/webpack/testHelper.js
+++ b/webpack/testHelper.js
@@ -1,15 +1,24 @@
 import React from 'react';
 import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
+import { applyMiddleware, createStore, compose, combineReducers } from 'redux';
 import { MockedProvider } from '@apollo/react-testing';
 import { Router, MemoryRouter } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 
-import store from 'foremanReact/redux';
-import ConfirmModal from 'foremanReact/components/ConfirmModal';
+import { reducers as apiReducer, APIMiddleware } from 'foremanReact/redux/API';
+import ConfirmModal, {
+  reducers as confirmModalReducers,
+} from 'foremanReact/components/ConfirmModal';
 import { getForemanContext } from 'foremanReact/Root/Context/ForemanContext';
 
+const reducers = combineReducers({ ...apiReducer, ...confirmModalReducers });
+
+export const generateStore = () =>
+  createStore(reducers, compose(applyMiddleware(thunk, APIMiddleware)));
+
 export const withRedux = Component => props => (
-  <Provider store={store}>
+  <Provider store={generateStore()}>
     <Component {...props} />
     <ConfirmModal />
   </Provider>


### PR DESCRIPTION
The link was hidden when there was no roles assigned directly to the host,
but there are cases when the roles are inherited from the host's hostgroup
and users would like to be able to view them.

The link was added in the EmptyState description.

https://user-images.githubusercontent.com/26363699/188623005-6e3d2d0d-2007-4589-8525-9e8e4aa86631.mp4

