### PR TITLE
Fixes #35557 - host details variables page cant load json

### DIFF
--- a/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/AnsibleVariableOverridesTableHelper.js
+++ b/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/AnsibleVariableOverridesTableHelper.js
@@ -23,6 +23,7 @@ export const formatValue = variable => {
     case 'yaml':
     case 'hash':
     case 'array':
+    case 'json':
       return JSON.stringify(value);
     default:
       return value;

--- a/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/EditableValue.js
+++ b/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/EditableValue.js
@@ -17,11 +17,12 @@ const EditableValue = props => {
 
   const type = props.variable.parameterType;
 
-  if (type === 'array' || type === 'hash') {
+  if (['json', 'yaml', 'array', 'hash'].includes(type)) {
     return (
       <TextAreaField
+        aria-label="Edit override field"
         onChange={props.onChange}
-        value={props.value}
+        value={JSON.stringify(props.value)}
         validation={props.validation}
         isDisabled={props.working}
       />
@@ -31,6 +32,7 @@ const EditableValue = props => {
   if (type === 'boolean') {
     return (
       <SelectField
+        aria-label="Edit override field"
         selectItems={[
           { id: 'trueSelectOpt', value: true, name: __('true') },
           { id: 'falseSelectOpt', value: false, name: __('false') },


### PR DESCRIPTION
* to reproduce:
create an ansible variable with type json and default value {"test":1} and override true
open host details page, ansible, variables tab
result:
error page with this error:
```
uncaught Error: Objects are not valid as a React child (found: object with keys {test}). If you meant to render a collection of children, use an array instead.
in EditableValue (created by AnsibleVariableOverridesTable)
```

* after fixing that issue, when editing the value there was a console error saying:
```
TextArea: TextArea requires either an id or aria-label to be specified 
```
fixed that too

* and edit values were not parsed correctly when editing and that is also fixed -
json values turned into `[Object object]` array values were spread so `[1,2,3]` was `1,2,3`
