### PR TITLE
Fixes #35579 - Pass parameters as keyword arguments

### DIFF
--- a/test/functional/api/v2/ansible_inventories_controller_test.rb
+++ b/test/functional/api/v2/ansible_inventories_controller_test.rb
@@ -37,7 +37,7 @@ module Api
         Setting['ansible_inventory_template'] = report.name
         user = FactoryBot.create(:user)
         user.roles << Role.find_by(:name => 'Ansible Tower Inventory Reader')
-        post :schedule, { :session => set_session_user(user) }
+        post :schedule, session: set_session_user(user)
         assert_response :success
       end
 


### PR DESCRIPTION
This raises a deprecation warning in Ruby 2.7 and breaks in Ruby 3.