### PR TITLE
Fixes #35654 - Host Details missing a dot in two modals

### DIFF
--- a/webpack/components/AnsibleHostDetail/components/RolesTab/AllRolesModal/index.js
+++ b/webpack/components/AnsibleHostDetail/components/RolesTab/AllRolesModal/index.js
@@ -24,7 +24,7 @@ const AllRolesModal = ({ hostGlobalId, onClose, history }) => {
     title: __('All assigned Ansible roles'),
     disableFocusTrap: true,
     description: __(
-      'This list consists of host assigned roles and group assigned roles. Group assigned roles will always be executed prior to host assigned roles'
+      'This list consists of host assigned roles and group assigned roles. Group assigned roles will always be executed prior to host assigned roles.'
     ),
   };
 

--- a/webpack/components/AnsibleHostDetail/components/RolesTab/EditRolesModal/index.js
+++ b/webpack/components/AnsibleHostDetail/components/RolesTab/EditRolesModal/index.js
@@ -28,7 +28,7 @@ const EditRolesModal = ({
     title: __('Edit Ansible Roles'),
     disableFocusTrap: true,
     description: __(
-      'Add, remove or reorder host assigned Ansible roles. This host has also group assigned roles that are not displayed here and will always be executed prior to host assigned roles'
+      'Add, remove or reorder host assigned Ansible roles. This host has also group assigned roles that are not displayed here and will always be executed prior to host assigned roles.'
     ),
   };
 


### PR DESCRIPTION
On the "All assigned Ansible roles"
And on the "Edit Ansible roles"
Both modals are missing a dot at the end of the sentence