### PR TITLE
Fixes #35669 - Fix Ansible Provider Test

### DIFF
--- a/test/unit/ansible_provider_test.rb
+++ b/test/unit/ansible_provider_test.rb
@@ -19,11 +19,8 @@ class AnsibleProviderTest < ActiveSupport::TestCase
     end
 
     context 'when it is using the ansible_run_host feature' do
-      let(:rex_feature) do
-        RemoteExecutionFeature.where(:label => 'ansible_run_host').first_or_create
-      end
-
       it 'has remote_execution_command false' do
+        rex_feature = RemoteExecutionFeature.where(:label => 'ansible_run_host', :name => 'Run Ansible roles').first_or_create
         template_invocation.template.remote_execution_features << rex_feature
         assert_not command_options[:remote_execution_command]
       end


### PR DESCRIPTION
Adding a name field to the RemoteExecutionFeature, to save it correctly in the DB. This is required for the `when it is using the ansible_run_host feature` test to succeed.