### PR TITLE
Fixes #35585 - add an option to enable the callback plugin for job templates

### DIFF
--- a/app/controllers/concerns/foreman/controller/parameters/job_template_extensions.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/job_template_extensions.rb
@@ -1,0 +1,17 @@
+module Foreman
+  module Controller
+    module Parameters
+      module JobTemplateExtensions
+        extend ActiveSupport::Concern
+
+        class_methods do
+          def job_template_params_filter
+            super.tap do |filter|
+              filter.permit :ansible_callback_enabled
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/foreman_ansible/api/v2/job_templates_controller_extensions.rb
+++ b/app/controllers/foreman_ansible/api/v2/job_templates_controller_extensions.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module ForemanAnsible
+  module Api
+    module V2
+      # Extends the job_templates api controller to support creating/updating with ansible callback plugin
+      module JobTemplatesControllerExtensions
+        extend Apipie::DSL::Concern
+
+        update_api(:create, :update) do
+          param :job_template, Hash do
+            param :ansible_callback_enabled, :bool, :desc => N_('Enable the callback plugin for this template')
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/foreman_ansible/ansible_provider.rb
+++ b/app/models/foreman_ansible/ansible_provider.rb
@@ -123,7 +123,7 @@ if defined? ForemanRemoteExecution
 
         def ansible_command?(template)
           template.remote_execution_features.
-            where(:label => 'ansible_run_host').empty?
+            where(:label => 'ansible_run_host').empty? && !template.ansible_callback_enabled
         end
       end
     end

--- a/app/views/api/v2/job_templates/job_templates.json.rabl
+++ b/app/views/api/v2/job_templates/job_templates.json.rabl
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+attributes :ansible_callback_enabled

--- a/app/views/job_templates/_job_template_callback_tab_content.html.erb
+++ b/app/views/job_templates/_job_template_callback_tab_content.html.erb
@@ -1,0 +1,3 @@
+<div class="tab-pane" id="ansible_callback_enabled">
+  <%= checkbox_f f, :ansible_callback_enabled, :label => _('Enable Ansible Callback'), :disabled => @template.locked? %>
+</div>

--- a/app/views/job_templates/_job_template_callback_tab_headers.html.erb
+++ b/app/views/job_templates/_job_template_callback_tab_headers.html.erb
@@ -1,0 +1,13 @@
+<li><a id="ansible_tab_header" href="#ansible_callback_enabled" data-toggle="tab"><%= _("Ansible") %></a></li>
+<script type="text/javascript">
+    $(document).ready(function () {
+        var provider_type = $('#job_template_provider_type');
+        provider_type.change(setAnsibleTabVisibilityByProvider);
+        provider_type.change();
+
+        function setAnsibleTabVisibilityByProvider() {
+            var tab_header = $("#ansible_tab_header");
+            this.value === 'Ansible' ? tab_header.show() : tab_header.hide();
+        }
+    });
+</script>

--- a/db/migrate/20221003153000_add_ansible_callback_enabled_to_templates.rb
+++ b/db/migrate/20221003153000_add_ansible_callback_enabled_to_templates.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddAnsibleCallbackEnabledToTemplates < ActiveRecord::Migration[6.0]
+  def change
+    add_column :templates, :ansible_callback_enabled, :boolean, default: false
+    RemoteExecutionFeature.where(label: 'ansible_run_host').each do |rex_feature|
+      Template.find(rex_feature.job_template_id).update(ansible_callback_enabled: true)
+    end
+  end
+end

--- a/lib/foreman_ansible/engine.rb
+++ b/lib/foreman_ansible/engine.rb
@@ -74,6 +74,9 @@ module ForemanAnsible
       ::Api::V2::HostgroupsController.include ForemanAnsible::Api::V2::HostgroupsControllerExtensions
       ::Api::V2::HostgroupsController.include ForemanAnsible::Api::V2::HostgroupsParamGroupExtensions
       ::ConfigReportImporter.include ForemanAnsible::AnsibleReportImporter
+      ::Api::V2::JobTemplatesController.include ForemanAnsible::Api::V2::JobTemplatesControllerExtensions
+      ::Api::V2::JobTemplatesController.include Foreman::Controller::Parameters::JobTemplateExtensions
+      ::JobTemplatesController.include Foreman::Controller::Parameters::JobTemplateExtensions
       ReportImporter.register_smart_proxy_feature('Ansible')
     rescue StandardError => e
       Rails.logger.warn "Foreman Ansible: skipping engine hook (#{e})"

--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -237,6 +237,8 @@ Foreman::Plugin.register :foreman_ansible do
     register_report_origin 'Ansible', 'ConfigReport'
   end
 
+  extend_rabl_template 'api/v2/job_templates/show', 'api/v2/job_templates/job_templates'
+
   describe_host do
     multiple_actions_provider :ansible_hosts_multiple_actions
   end
@@ -256,5 +258,17 @@ Foreman::Plugin.register :foreman_ansible do
                         :name => _('Update Smart Proxy'),
                         :partial => 'foreman/smart_proxies/update_smart_proxy',
                         :onlyif => ->(proxy, view) { view.can_update_proxy?(proxy) }
+  end
+  extend_page('templates/_form') do |context|
+    context.add_pagelet :tab_headers,
+                        :name => _('Ansible'),
+                        :partial => 'job_templates/job_template_callback_tab_headers',
+                        :onlyif => ->(subject, _view) { subject.is_a? JobTemplate }
+  end
+  extend_page('templates/_form') do |context|
+    context.add_pagelet :tab_content,
+                        :name => _('Ansible'),
+                        :partial => 'job_templates/job_template_callback_tab_content',
+                        :onlyif => ->(subject, _view) { subject.is_a? JobTemplate }
   end
 end

--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Foreman::Plugin.register :foreman_ansible do
-  requires_foreman '>= 3.5'
+  requires_foreman '>= 3.6'
 
   settings do
     category :ansible, N_('Ansible') do

--- a/test/unit/ansible_provider_test.rb
+++ b/test/unit/ansible_provider_test.rb
@@ -12,16 +12,15 @@ class AnsibleProviderTest < ActiveSupport::TestCase
       assert command_options['ansible_inventory']
     end
 
-    context 'when it is not using the ansible_run_host feature' do
+    context 'when ansible_callback_enabled is set to false' do
       it 'sets enables :remote_execution_command to true' do
         assert command_options[:remote_execution_command]
       end
     end
 
-    context 'when it is using the ansible_run_host feature' do
+    context 'when ansible_callback_enabled is set to true' do
       it 'has remote_execution_command false' do
-        rex_feature = RemoteExecutionFeature.where(:label => 'ansible_run_host', :name => 'Run Ansible roles').first_or_create
-        template_invocation.template.remote_execution_features << rex_feature
+        template_invocation.template.ansible_callback_enabled = true
         assert_not command_options[:remote_execution_command]
       end
     end


### PR DESCRIPTION
Added the property ansible_callback_enabled to the templates table. Created a Pagelet on the template's form to add the callback option to the UI.

Requires:
- https://github.com/theforeman/foreman/pull/9503

A few questions regarding these changes:
1. Do we want to allow to change the callback-plugin value if the template is locked?
2. Should we add a check for the `Job Category` type (if it is for Ansible), to decide whether to display the new ansible-callback tab? 
3. Is this change requires updating the plugin's version? 

A screenshot with the new tab in the UI:
![image](https://user-images.githubusercontent.com/38184193/200330487-8f70b6d4-c8b9-493d-96d9-b9ed5ccff94c.png)
