### PR TITLE
Bump foreman_ansible version to 10.1.0

### DIFF
--- a/lib/foreman_ansible/version.rb
+++ b/lib/foreman_ansible/version.rb
@@ -4,5 +4,5 @@
 # This way other parts of Foreman can just call ForemanAnsible::VERSION
 # and detect what version the plugin is running.
 module ForemanAnsible
-  VERSION = '10.0.1'
+  VERSION = '10.1.0'
 end


### PR DESCRIPTION
Bump foreman_ansible major version to 10.1.0, to release a new version for foreman-packaging (for Foreman 3.5 release). 