### PR TITLE
Updating bump version command for DEB branches

### DIFF
--- a/developer_docs/releasing.md
+++ b/developer_docs/releasing.md
@@ -35,7 +35,7 @@ For setup of Foreman packaging follow instructions here: [rpm/develop](https://g
 **DEB**
 * Pull latest `deb/develop` or `deb/X.X-stable`
 * Create new branch
-* Bump version: `scripts/update_package.rb -n foreman-ansible -v X.X.X`
-* git commit -am "Updated foreman-ansible to X.X.X"
+* Bump version: `scripts/update_package.rb -n ruby-foreman-ansible -v X.X.X`
+* git commit -am "Updated ruby-foreman-ansible to X.X.X"
 * Push a PR
 


### PR DESCRIPTION
I think we were missing the `ruby-` prefix before `foreman-ansible` in the bump version command for the `deb` branches in the releasing docs.
I updated the command to the command that I was using which worked for me. 