### PR TITLE
Fixes #35799 - fix ansible report returns 500 error code

### DIFF
--- a/app/helpers/foreman_ansible/ansible_reports_helper.rb
+++ b/app/helpers/foreman_ansible/ansible_reports_helper.rb
@@ -27,6 +27,8 @@ module ForemanAnsible
 
     def ansible_module_message(log)
       msg_json = parsed_message_json(log)
+      return _("Execution error: #{msg_json['msg']}") if msg_json['failed'].present?
+
       module_action = msg_json['module']
       case module_action
       when 'package'
@@ -65,6 +67,17 @@ module ForemanAnsible
       module_name(log).present?
     rescue StandardError
       false
+    end
+
+    def show_full_error_message_value(message_value)
+      tag.div class: 'replace-hidden-value' do
+        link_to_function(icon_text('plus', '', class: 'small'), 'replace_value_control(this, "div")',
+                         title: _('Show full value'),
+                         class: 'replace-hidden-value pull-right') +
+          (tag.span class: 'full-value' do
+            message_value
+          end)
+      end
     end
 
     private

--- a/app/views/foreman_ansible/config_reports/_ansible.html.erb
+++ b/app/views/foreman_ansible/config_reports/_ansible.html.erb
@@ -29,8 +29,12 @@
                 <% end %>
               </ul>
             <% else %>
-              <%= log_message %>
-          <% end %>
+              <% allowed_length = 150 %>
+              <div class='pull-left'>
+                <%= truncate(log_message, length: allowed_length) %>
+              </div>
+              <%= show_full_error_message_value(log_message) if log_message.length > allowed_length %>
+            <% end %>
           </td>
         </tr>
       <% end %>

--- a/foreman_ansible.gemspec
+++ b/foreman_ansible.gemspec
@@ -20,8 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'acts_as_list', '~> 1.0.3'
   s.add_dependency 'deface', '< 2.0'
-  # foreman_remote_execution 9.0 requires Foreman 3.6+, while
-  # foreman_ansible still works with 3.5+, so we allow 8.x and 9.x
-  s.add_dependency 'foreman_remote_execution', '>= 8.0', '< 10'
+  s.add_dependency 'foreman_remote_execution', '~> 9.0'
   s.add_dependency 'foreman-tasks', '~> 7.0'
 end

--- a/lib/foreman_ansible/version.rb
+++ b/lib/foreman_ansible/version.rb
@@ -4,5 +4,5 @@
 # This way other parts of Foreman can just call ForemanAnsible::VERSION
 # and detect what version the plugin is running.
 module ForemanAnsible
-  VERSION = '10.2.0'
+  VERSION = '11.0.0'
 end

--- a/test/unit/helpers/ansible_reports_helper_test.rb
+++ b/test/unit/helpers/ansible_reports_helper_test.rb
@@ -19,4 +19,18 @@ ANSIBLELOG
       ansible_module_message(log).to_s
     )
   end
+
+  test 'module message extraction with error' do
+    log_value = <<-ANSIBLELOG.strip_heredoc
+    {"msg": "AnsibleUndefinedVariable", "changed": false, "_ansible_no_log": false, "failed": true, "module": "template", "exception": "raise AnsibleUndefinedVariable"}
+ANSIBLELOG
+    message = FactoryBot.build(:message, value: log_value)
+    log = FactoryBot.build(:log, message: message)
+    log.message = message
+
+    assert_match(
+      'Execution error: AnsibleUndefinedVariable',
+      ansible_module_message(log).to_s
+    )
+  end
 end


### PR DESCRIPTION
Handle the case when job execution failed, and display the error message in the UI.

Requires:
- https://github.com/theforeman/foreman/pull/9561

[show full error message on config_reports page](https://user-images.githubusercontent.com/38184193/207911268-acfc516d-f58e-437b-afe6-12e7d0bd0b60.webm)