### PR TITLE
Pass parameters as keyword arguments in test

### DIFF
--- a/test/functional/api/v2/ansible_inventories_controller_test.rb
+++ b/test/functional/api/v2/ansible_inventories_controller_test.rb
@@ -37,7 +37,7 @@ module Api
         Setting['ansible_inventory_template'] = report.name
         user = FactoryBot.create(:user)
         user.roles << Role.find_by(:name => 'Ansible Tower Inventory Reader')
-        post :schedule, { :session => set_session_user(user) }
+        post :schedule, session: set_session_user(user)
         assert_response :success
       end
 


### PR DESCRIPTION
I noticed this in https://github.com/theforeman/foreman_ansible/pull/576 while looking at the failed test. This only solves the warning, not the actual test failure.