### PR TITLE
Fixes #35883 - don't fail if data is missing due to no_log

### DIFF
--- a/app/helpers/foreman_ansible/ansible_reports_helper.rb
+++ b/app/helpers/foreman_ansible/ansible_reports_helper.rb
@@ -30,11 +30,11 @@ module ForemanAnsible
       return _("Execution error: #{msg_json['msg']}") if msg_json['failed'].present?
 
       module_action = msg_json['module']
+      module_args = msg_json.fetch('invocation', {}).fetch('module_args', {})
       case module_action
       when 'package'
         msg_json['results'].empty? ? msg_json['msg'] : msg_json['results']
       when 'template'
-        module_args = msg_json['invocation']['module_args']
         _("Rendered template #{module_args['_original_basename']} to #{msg_json['dest']}")
       when 'service'
         _("Service #{msg_json['name']} #{msg_json['state']} (enabled: #{msg_json['enabled']})")
@@ -43,10 +43,8 @@ module ForemanAnsible
       when 'user'
         _("User #{msg_json['name']} #{msg_json['state']}, uid: #{msg_json['uid']}")
       when 'cron'
-        module_args = msg_json['invocation']['module_args']
         _("Cron job: #{module_args['minute']} #{module_args['hour']} #{module_args['day']} #{module_args['month']} #{module_args['weekday']} #{module_args['job']} (disabled: #{module_args['disabled']})")
       when 'copy'
-        module_args = msg_json['invocation']['module_args']
         _("Copy #{module_args['_original_basename']} to #{msg_json['dest']}")
       when 'command', 'shell'
         msg_json['stdout_lines']

--- a/test/unit/helpers/ansible_reports_helper_test.rb
+++ b/test/unit/helpers/ansible_reports_helper_test.rb
@@ -33,4 +33,17 @@ ANSIBLELOG
       ansible_module_message(log).to_s
     )
   end
+
+  test 'accepting a censored message' do
+    log_value = <<-ANSIBLELOG.strip_heredoc
+    {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": true, "failed": false, "module": "copy"}
+ANSIBLELOG
+    message = FactoryBot.build(:message, value: log_value)
+    log = FactoryBot.build(:log)
+    log.message = message
+    assert_match(
+      /Copy/,
+      ansible_module_message(log).to_s
+    )
+  end
 end


### PR DESCRIPTION
When you run an Ansible module with `no_log: true`, the report does not contain any `invocation` data and thus also no `module_args`.