### PR TITLE
Fixes #36004 - Migration error 'column settings.category does not exist'

### DIFF
--- a/db/migrate/20210818083407_fix_ansible_setting_category_to_dsl.rb
+++ b/db/migrate/20210818083407_fix_ansible_setting_category_to_dsl.rb
@@ -1,5 +1,5 @@
 class FixAnsibleSettingCategoryToDsl < ActiveRecord::Migration[6.0]
   def up
-    Setting.where(category: 'Setting::Ansible').update_all(category: 'Setting')
+    Setting.where(category: 'Setting::Ansible').update_all(category: 'Setting') if column_exists?(:settings, :category)
   end
 end


### PR DESCRIPTION
See:

https://github.com/theforeman/foreman/pull/9524
https://github.com/theforeman/foreman/pull/9524#issuecomment-1404661119