### PR TITLE
Fixes #36011 - Split Capsule and Smart Proxy upgrades to separate tem…

### DIFF
--- a/app/helpers/foreman_ansible/smart_proxies_helper.rb
+++ b/app/helpers/foreman_ansible/smart_proxies_helper.rb
@@ -27,7 +27,13 @@ module ForemanAnsible
     end
 
     def proxy_update_button(proxy)
-      feature = RemoteExecutionFeature.feature(:ansible_run_capsule_upgrade)
+      name = if Foreman::Plugin.find('foreman_theme_satellite').present?
+               :ansible_run_capsule_upgrade
+             else
+               :ansible_run_smart_proxy_upgrade
+             end
+
+      feature = RemoteExecutionFeature.feature(name)
       return if feature.nil?
 
       path = new_job_invocation_path(:host_ids => proxy.infrastructure_host_facets.pluck(:host_id),

--- a/app/views/foreman_ansible/job_templates/capsule_upgrade_-_ansible_default.erb
+++ b/app/views/foreman_ansible/job_templates/capsule_upgrade_-_ansible_default.erb
@@ -1,5 +1,5 @@
 <%#
-name: Smart Proxy Upgrade Playbook
+name: Capsule Upgrade Playbook
 snippet: false
 template_inputs:
 - name: target_version
@@ -26,8 +26,8 @@ feature: ansible_run_capsule_upgrade
 - hosts: all
   vars:
     target_version: "<%= input('target_version').present? ? input('target_version') : product_short_version %>"
-<% if plugin_present?('foreman_theme_satellite') -%>
   tasks:
+<% if plugin_present?('foreman_theme_satellite') -%>
     - name: Gather the rpm package facts
       package_facts:
         manager: auto
@@ -75,35 +75,7 @@ feature: ansible_run_capsule_upgrade
           fail:
             msg: "Failed! Capsule server upgrade failed. See /var/log/foreman-installer/capsule.log in the Capsule server for more information"
 <% else -%>
-  tasks:
-    - name: Gather the rpm package facts
-      package_facts:
-        manager: auto
-
-    - name: Fail if the target server is a Foreman server
+    - name: Fail if foreman_theme_satellite is missing
       fail:
-        msg: "This playbook cannot be executed on a Foreman server. Use only on a Smart Proxy server."
-      when: "'foreman' in ansible_facts.packages"
-
-    - name: Install foreman release gpg key
-      rpm_key:
-        state: present
-        key: http://yum.theforeman.org/releases/{{ target_version }}/RPM-GPG-KEY-foreman
-      when: target_version != "nightly"
-
-    - name: Update foreman repositories
-      package:
-        name: https://yum.theforeman.org/releases/{{ target_version }}/el{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/foreman-release.rpm
-        state: installed
-
-    - name: Clean yum metadata
-      command: yum clean all
-
-    - name: Update all packages
-      package:
-        name: '*'
-        state: latest
-
-    - name: Run the installer
-      shell: foreman-installer
+        msg: "Failed! The plugin foreman_theme_satellite is not present. This playbook is only for use with Satellite."
 <% end -%>

--- a/app/views/foreman_ansible/job_templates/smart_proxy_upgrade_-_ansible_default.erb
+++ b/app/views/foreman_ansible/job_templates/smart_proxy_upgrade_-_ansible_default.erb
@@ -1,0 +1,59 @@
+<%#
+name: Smart Proxy Upgrade Playbook
+snippet: false
+template_inputs:
+- name: target_version
+  required: false
+  input_type: user
+  advanced: false
+  value_type: plain
+  hidden_value: false
+- name: whitelist_options
+  required: false
+  input_type: user
+  advanced: false
+  value_type: plain
+  hidden_value: false
+model: JobTemplate
+job_category: Maintenance Operations
+description_format: "%{template_name}"
+provider_type: Ansible
+kind: job_template
+feature: ansible_run_smart_proxy_upgrade
+%>
+
+---
+- hosts: all
+  vars:
+    target_version: "<%= input('target_version').present? ? input('target_version') : product_short_version %>"
+  tasks:
+    - name: Gather the rpm package facts
+      package_facts:
+        manager: auto
+
+    - name: Fail if the target server is a Foreman server
+      fail:
+        msg: "This playbook cannot be executed on a Foreman server. Use only on a Smart Proxy server."
+      when: "'foreman' in ansible_facts.packages"
+
+    - name: Install foreman release gpg key
+      rpm_key:
+        state: present
+        key: http://yum.theforeman.org/releases/{{ target_version }}/RPM-GPG-KEY-foreman
+      when: target_version != "nightly"
+
+    - name: Update foreman repositories
+      package:
+        name: https://yum.theforeman.org/releases/{{ target_version }}/el{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/foreman-release.rpm
+        state: installed
+
+    - name: Clean yum metadata
+      command: yum clean all
+
+    - name: Update all packages
+      package:
+        name: '*'
+        state: latest
+
+    - name: Run the installer
+      shell: foreman-installer


### PR DESCRIPTION
…plates

First, it is likely I am missing some aspect of a change like this. I am fine if someone else take sit over and polishes it.

The idea is that instead of mixing branding, and the differences in workflows, which are inconsistent to split them into dedicated templates that are chosen based on enabled plugin. I think this further helps with how smart-proxy and Capsules are similar but still treated fundamentally different between Foreman and Satellite ecosystems.