### PR TITLE
update links in readme to use HTTPS and point at general support page

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,11 @@
 
 Reporting and facts import from Ansible to Foreman.
 
-* Main website: [theforeman.org](http://theforeman.org)
-* Plugin manual: [foreman_ansible manual](http://theforeman.org/plugins/foreman_ansible)
-* ServerFault tag: [Foreman](http://serverfault.com/questions/tagged/foreman)
-* Issues: [foreman ansible on Redmine](http://projects.theforeman.org/projects/ansible/issues)
-* Community and support: [#theforeman](https://kiwiirc.com/client/irc.freenode.net/?#theforeman) for general support, [#theforeman-dev](https://kiwiirc.com/client/irc.freenode.net/?#theforeman-dev) for development chat in [Freenode](irc.freenode.net)
-* Mailing lists:
-    * [foreman-users](https://groups.google.com/forum/?fromgroups#!forum/foreman-users)
-    * [foreman-dev](https://groups.google.com/forum/?fromgroups#!forum/foreman-dev)
+* Main website: [theforeman.org](https://theforeman.org)
+* Plugin manual: [foreman_ansible manual](https://theforeman.org/plugins/foreman_ansible)
+* ServerFault tag: [Foreman](https://serverfault.com/questions/tagged/foreman)
+* Issues: [foreman ansible on Redmine](https://projects.theforeman.org/projects/ansible/issues)
+* Chat and forum: [https://theforeman.org/support.html](https://theforeman.org/support.html)
 
 ## Features
 * Import facts


### PR DESCRIPTION
the mailing lists don't exist anymore and the chat is now on libera.chat, point at the main page for that so we don't have to update links in all the places in the future