### PR TITLE
open up @theforeman dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "peerDependencies": {
-    "@theforeman/vendor": "^12.0.1"
+    "@theforeman/vendor": ">= 12.0.1"
   },
   "dependencies": {
     "react-json-tree": "^0.11.0"
@@ -15,12 +15,12 @@
   "devDependencies": {
     "@babel/core": "^7.7.0",
     "@testing-library/user-event": "^13.2.1",
-    "@theforeman/builder": "^12.0.1",
-    "@theforeman/eslint-plugin-foreman": "^12.0.1",
-    "@theforeman/find-foreman": "^12.0.1",
-    "@theforeman/stories": "^12.0.1",
-    "@theforeman/test": "^12.0.1",
-    "@theforeman/vendor-dev": "^12.0.1",
+    "@theforeman/builder": ">= 12.0.1",
+    "@theforeman/eslint-plugin-foreman": ">= 12.0.1",
+    "@theforeman/find-foreman": ">= 12.0.1",
+    "@theforeman/stories": ">= 12.0.1",
+    "@theforeman/test": ">= 12.0.1",
+    "@theforeman/vendor-dev": ">= 12.0.1",
     "babel-eslint": "^10.0.3",
     "eslint": "^6.7.2",
     "prettier": "^1.13.5"


### PR DESCRIPTION
this makes packaging easier by dropping the upper bound on the dependencies

See also
- https://github.com/theforeman/foreman_rh_cloud/commit/65660aaa793d8c64d331095d7b825db06bfd6d3b
- https://github.com/theforeman/foreman_discovery/commit/c83a075bd382e4f818b3beb80da4a59716b2cf00
- https://github.com/theforeman/foreman_bootdisk/commit/c05a5ecfc377154cebdeef0c959764c9d0d93631