### PR TITLE
Fixes #36136 - make sure validatorRule is a string

### DIFF
--- a/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/AnsibleVariableOverridesTableHelper.js
+++ b/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/AnsibleVariableOverridesTableHelper.js
@@ -86,12 +86,16 @@ const validateRegexp = (variable, value) => {
 };
 
 const validateList = (variable, value) => {
-  if (variable.validatorRule.split(',').find(item => item.trim() === value)) {
+  let { validatorRule } = variable;
+  if (typeof validatorRule !== 'string') {
+    validatorRule = validatorRule.toString();
+  }
+  if (validatorRule.split(',').find(item => item.trim() === value)) {
     return validationSuccess;
   }
   return {
     key: 'error',
-    msg: sprintf(__('Invalid, expected one of: %s'), variable.validatorRule),
+    msg: sprintf(__('Invalid, expected one of: %s'), validatorRule),
   };
 };
 


### PR DESCRIPTION
variable.validatorRule.split was raising a TypeError: string.split is not a function