### PR TITLE
Fixes #36136 - make sure validatorRule is a string

### DIFF
--- a/foreman_ansible.gemspec
+++ b/foreman_ansible.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'acts_as_list', '~> 1.0.3'
   s.add_dependency 'deface', '< 2.0'
-  s.add_dependency 'foreman_remote_execution', '>= 4.4.0'
-  s.add_dependency 'foreman-tasks', '>= 5.2.0'
+  s.add_dependency 'foreman_remote_execution', '~> 7.2.2'
+  s.add_dependency 'foreman-tasks', '~> 6.0.3'
 end

--- a/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/AnsibleVariableOverridesTableHelper.js
+++ b/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/AnsibleVariableOverridesTableHelper.js
@@ -85,12 +85,16 @@ const validateRegexp = (variable, value) => {
 };
 
 const validateList = (variable, value) => {
-  if (variable.validatorRule.split(',').find(item => item.trim() === value)) {
+  let { validatorRule } = variable;
+  if (typeof validatorRule !== 'string') {
+    validatorRule = validatorRule.toString();
+  }
+  if (validatorRule.split(',').find(item => item.trim() === value)) {
     return validationSuccess;
   }
   return {
     key: 'error',
-    msg: sprintf(__('Invalid, expected one of: %s'), variable.validatorRule),
+    msg: sprintf(__('Invalid, expected one of: %s'), validatorRule),
   };
 };
 


### PR DESCRIPTION
variable.validatorRule.split was raising a TypeError: string.split is not a function

(cherry picked from commit bba4f31e6955b0833973cda768461a9521aca6a6)