### PR TITLE
Fixes #36136 - make sure validatorRule is a string

### DIFF
--- a/foreman_ansible.gemspec
+++ b/foreman_ansible.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'acts_as_list', '~> 1.0.3'
   s.add_dependency 'deface', '< 2.0'
   # foreman_remote_execution 9.0 requires Foreman 3.6+, while
-  # foreman_ansible still works with 3.5+, so we allow 8.x and 9.x
-  s.add_dependency 'foreman_remote_execution', '>= 8.0', '< 10'
-  s.add_dependency 'foreman-tasks', '~> 7.0'
+  # foreman_ansible still works with 3.5+, so we allow 8.2.x
+  s.add_dependency 'foreman_remote_execution', '~> 8.2'
+  s.add_dependency 'foreman-tasks', '~> 7.1.1'
 end

--- a/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/AnsibleVariableOverridesTableHelper.js
+++ b/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/AnsibleVariableOverridesTableHelper.js
@@ -86,12 +86,16 @@ const validateRegexp = (variable, value) => {
 };
 
 const validateList = (variable, value) => {
-  if (variable.validatorRule.split(',').find(item => item.trim() === value)) {
+  let { validatorRule } = variable;
+  if (typeof validatorRule !== 'string') {
+    validatorRule = validatorRule.toString();
+  }
+  if (validatorRule.split(',').find(item => item.trim() === value)) {
     return validationSuccess;
   }
   return {
     key: 'error',
-    msg: sprintf(__('Invalid, expected one of: %s'), variable.validatorRule),
+    msg: sprintf(__('Invalid, expected one of: %s'), validatorRule),
   };
 };
 


### PR DESCRIPTION
variable.validatorRule.split was raising a TypeError: string.split is not a function

(cherry picked from commit bba4f31e6955b0833973cda768461a9521aca6a6)