### PR TITLE
Refs #36021 - disable Ansible actions if hostgroup is empty

### DIFF
--- a/app/helpers/foreman_ansible/ansible_hostgroups_helper.rb
+++ b/app/helpers/foreman_ansible/ansible_hostgroups_helper.rb
@@ -4,18 +4,38 @@ module ForemanAnsible
   module AnsibleHostgroupsHelper
     def ansible_hostgroups_actions(hostgroup)
       actions = []
-      play_roles = if hostgroup.all_ansible_roles.empty?
-                     { action: { content: (link_to _('Run all Ansible roles'), 'javascript:void(0);', disabled: true, title: 'No roles assigned', class: 'disabled'), options: { class: 'disabled' } }, priority: 31 }
-                   else
-                     { action: display_link_if_authorized(_('Run all Ansible roles'), hash_for_play_roles_hostgroup_path(id: hostgroup), 'data-no-turbolink': true, title: _('Run all Ansible roles on hosts belonging to this host group')), priority: 31 }
-                   end
+      is_hostgroup_empty = hostgroup.all_ansible_roles.empty? || hostgroup.hosts_count.zero?
 
-      assign_jobs = { action: { content: (link_to _('Configure Ansible Job'), "/ansible/hostgroups/#{hostgroup.id}", class: 'la') }, priority: 32 }
+      if User.current.can?(:create_job_invocations)
+        actions << {
+          action: if is_hostgroup_empty
+                    disabled_action_link(_('Run all Ansible roles'))
+                  else
+                    display_link_if_authorized(_('Run all Ansible roles'), hash_for_play_roles_hostgroup_path(id: hostgroup), 'data-no-turbolink': true, title: _('Run all Ansible roles on hosts belonging to this host group'))
+                  end,
+          priority: 31
+        }
+      end
 
-      actions.push play_roles if User.current.can?(:create_job_invocations)
-      actions.push assign_jobs if User.current.can?(:view_job_invocations) && User.current.can?(:view_recurring_logics)
+      if User.current.can?(:view_job_invocations) && User.current.can?(:view_recurring_logics)
+        actions << {
+          action: if is_hostgroup_empty
+                    disabled_action_link(_('Configure Ansible Job'))
+                  else
+                    link_to(_('Configure Ansible Job'), "/ansible/hostgroups/#{hostgroup.id}", class: 'la')
+                  end,
+          priority: 32
+        }
+      end
 
       actions
+    end
+
+    def disabled_action_link(text)
+      {
+        content: link_to(text, 'javascript:void(0);', disabled: true, title: _('No roles/hosts assigned'), class: 'disabled'),
+        options: { class: 'disabled' }
+      }
     end
   end
 end

--- a/test/integration/hostgroup_js_test.rb
+++ b/test/integration/hostgroup_js_test.rb
@@ -10,21 +10,23 @@ class HostgroupJsTest < IntegrationTestWithJavascript
     FactoryBot.create(:host, :hostgroup_id => hostgroup_with_roles.id)
   end
 
-  test 'hostgroup without roles should have disabled link' do
+  test 'hostgroup without roles should have disabled links' do
     visit hostgroups_path(search: hostgroup.name)
 
     first_row = page.find('table > tbody > tr:nth-child(1)')
     first_row.find('td:nth-child(4) > div > a').click
 
     assert_includes first(:link, 'Run all Ansible roles')[:class], 'disabled'
+    assert_includes first(:link, 'Configure Ansible Job')[:class], 'disabled'
   end
 
-  test 'hostgroup with roles should have clickable link' do
+  test 'hostgroup with roles should have clickable links' do
     visit hostgroups_path(search: hostgroup_with_roles.name)
 
     first_row = page.find('table > tbody > tr:nth-child(1)')
     first_row.find('td:nth-child(4) > div > a').click
 
     assert_not first(:link, 'Run all Ansible roles')[:class].include?('disabled')
+    assert_not first(:link, 'Configure Ansible Job')[:class].include?('disabled')
   end
 end


### PR DESCRIPTION
Disable Ansible actions links for hostgroups with no roles or hosts