### PR TITLE
Fixes #36298 - Add migration to enable Ansible callback for Rex feature

### DIFF
--- a/db/migrate/20230416170000_enable_ansible_callback_for_rex_feature.rb
+++ b/db/migrate/20230416170000_enable_ansible_callback_for_rex_feature.rb
@@ -1,0 +1,5 @@
+class EnableAnsibleCallbackForRexFeature < ActiveRecord::Migration[6.0]
+  def change
+    Template.where(id: RemoteExecutionFeature.select(:job_template_id).where(label: 'ansible_run_host')).update_all(ansible_callback_enabled: true)
+  end
+end


### PR DESCRIPTION
This migration updates the 'ansible_callback_enabled' attribute for templates associated with the Remote Execution feature where the 'label' is 'ansible_run_host'.