### PR TITLE
Fixes #35317 - The icon is part of foreman core now.

### DIFF
--- a/app/helpers/foreman_ansible/ansible_reports_helper.rb
+++ b/app/helpers/foreman_ansible/ansible_reports_helper.rb
@@ -57,10 +57,6 @@ module ForemanAnsible
       _('No additional data')
     end
 
-    def ansible_report_origin_icon
-      'foreman_ansible/Ansible.png'
-    end
-
     def ansible_report_origin_partial
       'foreman_ansible/config_reports/ansible'
     end


### PR DESCRIPTION
The icon on the config management reports page is not shown because it tries to show the icon in foreman_ansible plugin directory. The icon was moved to foreman core month ago.

(cherry picked from commit f70eef5ba24d57b604940f01781034189f7287c8)