### PR TITLE
Fixes #36451 - AnsibleVariableOverrides.js test failures

### DIFF
--- a/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/__test__/AnsibleVariableOverrides.test.js
+++ b/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/__test__/AnsibleVariableOverrides.test.js
@@ -19,7 +19,7 @@ import {
 const TestComponent = withRedux(withMockedProvider(AnsibleVariableOverrides));
 
 describe('AnsibleVariableOverrides', () => {
-  it('should show skeleton when page is loading', () => {
+  it('should show skeleton when page is loading', async () => {
     const { container } = render(
       <TestComponent
         hostId={hostId}
@@ -31,6 +31,8 @@ describe('AnsibleVariableOverrides', () => {
     expect(
       container.getElementsByClassName('react-loading-skeleton')
     ).toHaveLength(5);
+
+    await waitFor(tick);
   });
   it('should load', async () => {
     render(


### PR DESCRIPTION
`'should show skeleton when page is loading'` was not unmounting something and breaking the tests after it (`'should load'`, `'should not allow editing when user does not have permissions'`)