### PR TITLE
Fix typo in convert2rhel job description

### DIFF
--- a/app/views/foreman_ansible/job_templates/convert_to_rhel.erb
+++ b/app/views/foreman_ansible/job_templates/convert_to_rhel.erb
@@ -26,7 +26,7 @@ template_inputs:
   input_type: user
   description: "The convert2rhel utility uploads the following data about the system
     conversion to Red Hat servers for the purpose of the utility usage analysis:<br>\r\n-
-    The conver2rhel command as executed<br>\r\n- The convert2rhel RPM version and
+    The convert2rhel command as executed<br>\r\n- The convert2rhel RPM version and
     GPG signature<br>\r\n- Success or failure status of the conversion<br>\r\n- Conversion
     start and end timestamps<br>\r\n- Source OS vendor and version<br>\r\n- Target
     RHEL version<br>\r\n- convert2rhel related environment variables<br>"


### PR DESCRIPTION
I also noticed that the line break tags will show up literally in the UI. I think they should be removed. The current UI doesn't appear to convert line breaks to newlines either.