### PR TITLE
Fixes #36469 - Fix ansible roles and variables pagination

### DIFF
--- a/webpack/components/AnsibleHostDetail/components/RolesTab/index.js
+++ b/webpack/components/AnsibleHostDetail/components/RolesTab/index.js
@@ -23,7 +23,7 @@ const RolesTab = ({ hostId, history, canEditHost }) => {
   const [assignModal, setAssignModal] = useState(false);
   const renameData = data => ({
     ansibleRoles: data.host.ownAnsibleRoles.nodes,
-    totalCount: data.host.ownAnsibleRoles.totalCount,
+    totalCount: allAnsibleRoles.length,
   });
 
   const useFetchFn = () =>


### PR DESCRIPTION
@MariaAga @nofaralfasi 
Fixed the pagination for the roles tab, for the variables tab however, we need total variables count. There is not get API to fetch the total overriden variables and their count. Do we create one?
