### PR TITLE
Fixes #36568 - Hostgroup API controller also returns roles assigned to hosts in a host group

### DIFF
--- a/app/controllers/foreman_ansible/api/v2/hostgroups_controller_extensions.rb
+++ b/app/controllers/foreman_ansible/api/v2/hostgroups_controller_extensions.rb
@@ -50,7 +50,7 @@ module ForemanAnsible
             @inherited_ansible_roles = @hostgroup.inherited_ansible_roles
             @directly_assigned_roles = @hostgroup.ansible_roles
             @ansible_roles = (
-              @directly_assigned_roles + @inherited_ansible_roles + @hostgroup.host_ansible_roles
+              @directly_assigned_roles + @inherited_ansible_roles
             ).uniq
           end
 


### PR DESCRIPTION
I believe the API call shouldn't return the list of roles assigned to hosts in a hostgroup directly. Just a list of assigned and inherited roles is enough. 