### PR TITLE
Pin @adobe/css-tools to ~4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react-json-tree": "^0.11.0"
   },
   "devDependencies": {
+    "@adobe/css-tools": "~4.2.0",
     "@babel/core": "^7.7.0",
     "@testing-library/user-event": "^13.2.1",
     "@theforeman/builder": "^10.0",


### PR DESCRIPTION
This commit was copied from https://github.com/theforeman/foreman_remote_execution commit 911be4e.

The changes were necessary to resolve a similar issue in our repository.