### PR TITLE
Refs #36956 - Fetch configured ansible tags on rerun

### DIFF
--- a/app/models/foreman_ansible/ansible_provider.rb
+++ b/app/models/foreman_ansible/ansible_provider.rb
@@ -61,19 +61,23 @@ if defined? ForemanRemoteExecution
           true
         end
 
-        def provider_inputs
+        def provider_inputs(provider_input_values = [])
+          tags = provider_input_values&.find { |input| input[:name] == 'tags' }&.fetch(:value) || ''
+          tags_flag = provider_input_values&.find { |input| input[:name] == 'tags_flag' }&.fetch(:value) || ''
           [
             ForemanRemoteExecution::ProviderInput.new(
               name: 'tags',
               label: _('Tags'),
-              value: '',
+              value: tags,
               value_type: 'plain',
+              default: '',
               description: 'Tags used for Ansible execution'
             ),
             ForemanRemoteExecution::ProviderInput.new(
               name: 'tags_flag',
               label: _('Include/Exclude Tags'),
-              value: 'include',
+              value: tags_flag,
+              default: 'include',
               description: 'Option whether to include or exclude tags',
               options: "include\nexclude"
             )


### PR DESCRIPTION
Currently in progress,
fixed: fetching the tags,
needs update: setting the default tags value.

This PR is blocked by
`Fixes: https://github.com/theforeman/foreman_remote_execution/pull/852