### PR TITLE
Fixes #36984 - Exclude all subdirectories for vendor in .rubocop.yaml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ AllCops:
     - 'extras/**/*'
     - 'locale/**/*'
     - 'node_modules/**/*'
-    - 'vendor/bundle/**/*'
+    - 'vendor/**/*'
 
 # Just so it looks like core Foreman
 Layout/DotPosition:


### PR DESCRIPTION
default config: https://github.com/rubocop/rubocop/blob/master/config/default.yml#L68