### PR TITLE
Fixes #36469 - Fix Ansible Roles and Variables sub-tabs pagination

### DIFF
--- a/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/index.js
+++ b/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/index.js
@@ -17,6 +17,11 @@ const AnsibleVariableOverrides = ({ hostId, hostAttrs, history }) => {
   const hostGlobalId = encodeId('Host', hostId);
   const pagination = useCurrentPagination(history);
   const [totalItems, setTotalItems] = useState(0);
+  const setTotalCount = data => {
+    if (!data) return;
+    const { totalCount } = data.host.ansibleVariablesWithOverrides;
+    if (totalItems === 0) setTotalItems(totalCount);
+  };
 
   const useFetchFn = () =>
     useQuery(variableOverrides, {
@@ -27,16 +32,13 @@ const AnsibleVariableOverrides = ({ hostId, hostAttrs, history }) => {
       },
       fetchPolicy: 'network-only',
       nextFetchPolicy: 'cache-first',
+      onCompleted: setTotalCount,
     });
 
-  const renameData = data => {
-    const { totalCount } = data.host.ansibleVariablesWithOverrides;
-    if (totalItems === 0) setTotalItems(totalCount);
-    return {
-      variables: data.host.ansibleVariablesWithOverrides.nodes,
-      totalCount,
-    };
-  };
+  const renameData = data => ({
+    variables: data.host.ansibleVariablesWithOverrides.nodes,
+    totalCount: data.host.ansibleVariablesWithOverrides.totalCount,
+  });
 
   return (
     <AnsibleVariableOverridesTable

--- a/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/index.js
+++ b/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
 
@@ -16,22 +16,27 @@ import './AnsibleVariableOverrides.scss';
 const AnsibleVariableOverrides = ({ hostId, hostAttrs, history }) => {
   const hostGlobalId = encodeId('Host', hostId);
   const pagination = useCurrentPagination(history);
+  const [totalItems, setTotalItems] = useState(0);
 
   const useFetchFn = () =>
     useQuery(variableOverrides, {
       variables: {
         id: hostGlobalId,
         match: `fqdn=${hostAttrs.name}`,
-        ...useParamsToVars(history),
+        ...useParamsToVars(history, totalItems),
       },
       fetchPolicy: 'network-only',
       nextFetchPolicy: 'cache-first',
     });
 
-  const renameData = data => ({
-    variables: data.host.ansibleVariablesWithOverrides.nodes,
-    totalCount: data.host.ansibleVariablesWithOverrides.totalCount,
-  });
+  const renameData = data => {
+    const totalCount = data.host.ansibleVariablesWithOverrides.totalCount;
+    if (totalItems === 0) setTotalItems(totalCount);
+    return ({
+      variables: data.host.ansibleVariablesWithOverrides.nodes,
+      totalCount,
+    })
+  };
 
   return (
     <AnsibleVariableOverridesTable

--- a/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/index.js
+++ b/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/index.js
@@ -30,12 +30,12 @@ const AnsibleVariableOverrides = ({ hostId, hostAttrs, history }) => {
     });
 
   const renameData = data => {
-    const totalCount = data.host.ansibleVariablesWithOverrides.totalCount;
+    const { totalCount } = data.host.ansibleVariablesWithOverrides;
     if (totalItems === 0) setTotalItems(totalCount);
-    return ({
+    return {
       variables: data.host.ansibleVariablesWithOverrides.nodes,
       totalCount,
-    })
+    };
   };
 
   return (

--- a/webpack/components/AnsibleHostDetail/components/RolesTab/AllRolesModal/index.js
+++ b/webpack/components/AnsibleHostDetail/components/RolesTab/AllRolesModal/index.js
@@ -28,8 +28,6 @@ const AllRolesModal = ({ hostGlobalId, onClose, history }) => {
     ),
   };
 
-  const paginationKeys = { page: 'page', perPage: 'per_page' };
-
   const wrapper = child => (
     <Modal ouiaId="modal-ansible-roles" {...baseModalProps}>
       {child}
@@ -46,7 +44,7 @@ const AllRolesModal = ({ hostGlobalId, onClose, history }) => {
     useQuery(allAnsibleRolesQuery, {
       variables: {
         id: hostGlobalId,
-        ...useParamsToVars(history, paginationKeys),
+        ...useParamsToVars(history),
       },
       fetchPolicy: 'network-only',
     });
@@ -56,7 +54,7 @@ const AllRolesModal = ({ hostGlobalId, onClose, history }) => {
     totalCount: data.host.allAnsibleRoles.totalCount,
   });
 
-  const pagination = useCurrentPagination(history, paginationKeys);
+  const pagination = useCurrentPagination(history);
 
   return (
     <AllRolesTable

--- a/webpack/components/AnsibleHostDetail/components/RolesTab/AllRolesModal/index.js
+++ b/webpack/components/AnsibleHostDetail/components/RolesTab/AllRolesModal/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/client';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -14,6 +14,12 @@ import {
 } from '../../../../../helpers/pageParamsHelper';
 
 const AllRolesModal = ({ hostGlobalId, onClose, history }) => {
+  const [totalItems, setTotalItems] = useState(0);
+  const setTotalCount = data => {
+    if (!data) return;
+    const { totalCount } = data.host.allAnsibleRoles;
+    if (totalItems === 0) setTotalItems(totalCount);
+  };
   const baseModalProps = {
     ouiaId: 'modal-ansible-roles',
     variant: ModalVariant.large,
@@ -44,9 +50,10 @@ const AllRolesModal = ({ hostGlobalId, onClose, history }) => {
     useQuery(allAnsibleRolesQuery, {
       variables: {
         id: hostGlobalId,
-        ...useParamsToVars(history),
+        ...useParamsToVars(history, totalItems),
       },
       fetchPolicy: 'network-only',
+      onCompleted: setTotalCount,
     });
 
   const renameData = data => ({

--- a/webpack/components/AnsibleHostDetail/components/RolesTab/index.js
+++ b/webpack/components/AnsibleHostDetail/components/RolesTab/index.js
@@ -21,6 +21,13 @@ const RolesTab = ({ hostId, history, canEditHost }) => {
   const hostGlobalId = encodeId('Host', hostId);
   const pagination = useCurrentPagination(history);
   const [assignModal, setAssignModal] = useState(false);
+  const [totalItems, setTotalItems] = useState(0);
+  const setTotalCount = data => {
+    if (!data) return;
+    const { totalCount } = data.host.ownAnsibleRoles;
+    if (totalItems === 0) setTotalItems(totalCount);
+  };
+
   const renameData = data => ({
     ansibleRoles: data.host.ownAnsibleRoles.nodes,
     totalCount: data.host.ownAnsibleRoles.totalCount,
@@ -28,8 +35,9 @@ const RolesTab = ({ hostId, history, canEditHost }) => {
 
   const useFetchFn = () =>
     useQuery(ansibleRolesQuery, {
-      variables: { id: hostGlobalId, ...useParamsToVars(history) },
+      variables: { id: hostGlobalId, ...useParamsToVars(history, totalItems) },
       fetchPolicy: 'network-only',
+      onCompleted: setTotalCount,
     });
 
   const editBtn = canEditHost ? (

--- a/webpack/helpers/pageParamsHelper.js
+++ b/webpack/helpers/pageParamsHelper.js
@@ -31,11 +31,11 @@ export const useCurrentPagination = history => {
  */
 export const pageToVars = ({ page, per_page }, totalCount = 0) => {
   totalCount = totalCount || per_page;
-  return ({
+  return {
     first: Math.min(page * per_page, totalCount),
     last: Math.min(per_page, totalCount - (page - 1) * per_page),
-  });
-}
+  };
+};
 
 export const useParamsToVars = (history, totalCount) =>
   pageToVars(useCurrentPagination(history), totalCount);

--- a/webpack/helpers/pageParamsHelper.js
+++ b/webpack/helpers/pageParamsHelper.js
@@ -12,33 +12,20 @@ export const addSearch = (basePath, params) => {
   return `${basePath}${stringyfied}`;
 };
 
-export const useCurrentPagination = (
-  history,
-  keys = { page: 'page', perPage: 'per_page' }
-) => {
+export const useCurrentPagination = (history) => {
   const pageParams = parsePageParams(history);
   const uiSettings = useForemanSettings();
 
   return {
-    [keys.page]: parseInt(pageParams[keys.page], 10) || 1,
-    [keys.perPage]:
-      parseInt(pageParams[keys.perPage], 10) || uiSettings.perPage,
+    page: parseInt(pageParams.page, 10) || 1,
+    per_page:
+      parseInt(pageParams.per_page, 10) || uiSettings.perPage,
   };
 };
 
-export const pageToVars = (
-  pagination,
-  totalCount = 0,
-  keys = { page: 'page', perPage: 'per_page' },
-) => {
-  return ({
-    first: pagination[keys.page] * pagination[keys.perPage],
-    last: pagination[keys.page] > 1 & totalCount > 0 ? totalCount - pagination[keys.perPage] : pagination[keys.perPage],
-  })
-};
+export const pageToVars = ({ page, per_page }, totalCount = 0) => ({
+  first: page * per_page,
+  last: page > 1 & totalCount > 0 ? totalCount - per_page : per_page,
+})
 
-export const useParamsToVars = (
-  history,
-  totalCount,
-  keys = { page: 'page', perPage: 'per_page' }
-) => pageToVars(useCurrentPagination(history, keys), totalCount, keys);
+export const useParamsToVars = (history, totalCount) => pageToVars(useCurrentPagination(history), totalCount);

--- a/webpack/helpers/pageParamsHelper.js
+++ b/webpack/helpers/pageParamsHelper.js
@@ -28,13 +28,17 @@ export const useCurrentPagination = (
 
 export const pageToVars = (
   pagination,
-  keys = { page: 'page', perPage: 'per_page' }
-) => ({
-  first: pagination[keys.page] * pagination[keys.perPage],
-  last: pagination[keys.perPage],
-});
+  totalCount = 0,
+  keys = { page: 'page', perPage: 'per_page' },
+) => {
+  return ({
+    first: pagination[keys.page] * pagination[keys.perPage],
+    last: pagination[keys.page] > 1 & totalCount > 0 ? totalCount - pagination[keys.perPage] : pagination[keys.perPage],
+  })
+};
 
 export const useParamsToVars = (
   history,
+  totalCount,
   keys = { page: 'page', perPage: 'per_page' }
-) => pageToVars(useCurrentPagination(history, keys), keys);
+) => pageToVars(useCurrentPagination(history, keys), totalCount, keys);

--- a/webpack/helpers/pageParamsHelper.js
+++ b/webpack/helpers/pageParamsHelper.js
@@ -29,10 +29,13 @@ export const useCurrentPagination = history => {
  * to make the pagination work on tables where `page * per_page > totalCount`,
  * we needed to add the following calculation for the `last` variable
  */
-export const pageToVars = ({ page, per_page }, totalCount = 0) => ({
-  first: page * per_page,
-  last: page > 1 && totalCount > 0 ? totalCount - per_page : per_page,
-});
+export const pageToVars = ({ page, per_page }, totalCount = 0) => {
+  totalCount = totalCount || per_page;
+  return ({
+    first: Math.min(page * per_page, totalCount),
+    last: Math.min(per_page, totalCount - (page - 1) * per_page),
+  });
+}
 
 export const useParamsToVars = (history, totalCount) =>
   pageToVars(useCurrentPagination(history), totalCount);

--- a/webpack/helpers/pageParamsHelper.js
+++ b/webpack/helpers/pageParamsHelper.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import URI from 'urijs';
 import { useForemanSettings } from 'foremanReact/Root/Context/ForemanContext';
 
@@ -12,14 +13,13 @@ export const addSearch = (basePath, params) => {
   return `${basePath}${stringyfied}`;
 };
 
-export const useCurrentPagination = (history) => {
+export const useCurrentPagination = history => {
   const pageParams = parsePageParams(history);
   const uiSettings = useForemanSettings();
 
   return {
     page: parseInt(pageParams.page, 10) || 1,
-    per_page:
-      parseInt(pageParams.per_page, 10) || uiSettings.perPage,
+    per_page: parseInt(pageParams.per_page, 10) || uiSettings.perPage,
   };
 };
 
@@ -31,7 +31,8 @@ export const useCurrentPagination = (history) => {
  */
 export const pageToVars = ({ page, per_page }, totalCount = 0) => ({
   first: page * per_page,
-  last: page > 1 & totalCount > 0 ? totalCount - per_page : per_page,
-})
+  last: page > 1 && totalCount > 0 ? totalCount - per_page : per_page,
+});
 
-export const useParamsToVars = (history, totalCount) => pageToVars(useCurrentPagination(history), totalCount);
+export const useParamsToVars = (history, totalCount) =>
+  pageToVars(useCurrentPagination(history), totalCount);

--- a/webpack/helpers/pageParamsHelper.js
+++ b/webpack/helpers/pageParamsHelper.js
@@ -23,6 +23,12 @@ export const useCurrentPagination = (history) => {
   };
 };
 
+/**
+ * Since there is no easy way to do pagination with Graphql at the moment,
+ * we are using `first` and `last` variables in the query.
+ * to make the pagination work on tables where `page * per_page > totalCount`,
+ * we needed to add the following calculation for the `last` variable
+ */
 export const pageToVars = ({ page, per_page }, totalCount = 0) => ({
   first: page * per_page,
   last: page > 1 & totalCount > 0 ? totalCount - per_page : per_page,


### PR DESCRIPTION
Since there is no easy way to do pagination with Graphql at the moment,
we are using `first` and `last` variables in the query.
to make the pagination work on tables where `page * per_page > totalCount`,
we needed to add the following calculation for the `last` variable