### PR TITLE
Fixes #37091 - Pretty print long YAML list

### DIFF
--- a/app/views/foreman_ansible/job_templates/package_action_-_ansible_default.erb
+++ b/app/views/foreman_ansible/job_templates/package_action_-_ansible_default.erb
@@ -30,8 +30,7 @@ template_inputs:
 provider_type: Ansible
 kind: job_template
 model: JobTemplate
-%>
-
+-%>
 # For Windows targets use the win_package module instead.
 ---
 - hosts: all
@@ -41,7 +40,7 @@ model: JobTemplate
   <%- end -%>
   tasks:
     - package:
-        name: <%= input('name') %>
+<%= indent(8) { to_yaml({"name" => input('name')}).gsub(/---\n/, '') } -%>
         state: <%= input('state') %>
   <%- if input('post_script').present? -%>
   post_tasks:


### PR DESCRIPTION
Hello,

I come after https://github.com/Katello/katello/pull/10850. During testing a long list was printed for packages_name.

1) It was hard to read
2) Ruby print list in the same format than YAML compact form. It doesn't seems the original author was aware (I think it expected a String because it called it name and not names)
