### PR TITLE
fix concurrency group

### DIFF
--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -9,7 +9,7 @@ on:
       - '*-stable'
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.ref_name }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
head_ref doesn't exist on push triggered workflows