### PR TITLE
Fixes #37136 - SSH User is ignored in advanced field of job invocation

### DIFF
--- a/app/services/foreman_ansible/inventory_creator.rb
+++ b/app/services/foreman_ansible/inventory_creator.rb
@@ -97,7 +97,7 @@ module ForemanAnsible
 
     def remote_execution_options(host)
       params = {
-        'ansible_user' => host_setting(host, 'remote_execution_ssh_user'),
+        'ansible_user' => @template_invocation.job_invocation&.ssh_user || host_setting(host, 'remote_execution_ssh_user'),
         'ansible_become_method' => host_setting(host, 'remote_execution_effective_user_method'),
         'ansible_ssh_private_key_file' => ansible_ssh_private_key(host),
         'ansible_port' => host_setting(host, 'remote_execution_ssh_port'),

--- a/app/services/foreman_ansible/inventory_creator.rb
+++ b/app/services/foreman_ansible/inventory_creator.rb
@@ -97,7 +97,7 @@ module ForemanAnsible
 
     def remote_execution_options(host)
       params = {
-        'ansible_user' => @template_invocation.job_invocation&.ssh_user || host_setting(host, 'remote_execution_ssh_user'),
+        'ansible_user' => @template_invocation&.job_invocation&.ssh_user || host_setting(host, 'remote_execution_ssh_user'),
         'ansible_become_method' => host_setting(host, 'remote_execution_effective_user_method'),
         'ansible_ssh_private_key_file' => ansible_ssh_private_key(host),
         'ansible_port' => host_setting(host, 'remote_execution_ssh_port'),


### PR DESCRIPTION
**Relevant Bug**

This pull request fixes Bug #37136 - SSH User is ignored in advanced field of job invocation .

**Details**
The advanced field for the SSH user in the job invocation is ignored by `foreman_ansible`.
I fixed it so that now the priority for the SSH user is:
1. Advanced field in job invocation
2. Host parameter
3. Global setting