### PR TITLE
Fixes #37245 - 25 tests failing with "TypeError: Cannot read property 'perPage' of undefined"

### DIFF
--- a/webpack/testHelper.js
+++ b/webpack/testHelper.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import { applyMiddleware, createStore, compose, combineReducers } from 'redux';
@@ -42,20 +42,21 @@ export const withReactRouter = Component => props => {
 };
 
 export const withMockedProvider = Component => props => {
-  const ForemanContext = getForemanContext(ctx);
-  // eslint-disable-next-line react/prop-types
-  const { mocks, ...rest } = props;
-
-  const ctx = {
+  const [context, setContext] = useState({
     metadata: {
       UISettings: {
         perPage: 20,
       },
     },
-  };
+  });
+  const contextData = { context, setContext };
+  const ForemanContext = getForemanContext(contextData);
+
+  // eslint-disable-next-line react/prop-types
+  const { mocks, ...rest } = props;
 
   return (
-    <ForemanContext.Provider value={ctx}>
+    <ForemanContext.Provider value={contextData}>
       <MockedProvider mocks={mocks}>
         <Component {...rest} />
       </MockedProvider>


### PR DESCRIPTION
[Bug #37245](https://projects.theforeman.org/issues/37245)

This pull-request fixes #37245 by wrapping the mocked context in a React state.

**Detailed problem description**

This bug was introduced, when `useForemanContext` of _ForemanContext.js_ was changed in theforeman/foreman@0b40a64be53fb54843bccf2aa193cab0632c83b3

In the commit, `useForemanContext` was split into `useForemanContext` and `useForemanSetContext`, which return `getForemanContext.context`  and `getForemanContext.setContext` respectively. `context` and `setContext` were provided by wrapping the original context object in `React.useState()`. 
In foreman_ansible, this change is not yet reflected. `getForemanContext` still returns the raw context object. Since the context object does not have the fields `context` and `setContext`, `useForemanContext` and `useForemanSetContext` would return `undefined`, causing the tests to fail.

This is fixed, by wrapping the context object given to `getForemanContext` in `withMockedProvider` of _testHelper.js_ in `React.useState()` similar to [ReactApp.js](https://github.com/theforeman/foreman/blob/develop/webpack/assets/javascripts/react_app/Root/ReactApp.js) of Foreman.