### PR TITLE
Fixes #37250 - Ensure js tests are executed on default branch

### DIFF
--- a/.github/workflows/js_tests.yml
+++ b/.github/workflows/js_tests.yml
@@ -1,10 +1,9 @@
 name: JavaScript Testing
 on:
   pull_request:
-    paths:
-      - 'webpack/**'
-      - 'package.json'
-      - '.github/workflows/js_tests.yml'
+  push:
+    branches:
+      - "master"
 
 jobs:
   test_js:


### PR DESCRIPTION
I would like to address the situation that a change in foreman was breaking this plugin and it went unnoticed for nearly two months.

The best way to fix this integration problem would probably be nightly test runs.

This PR suggests to at least run the js tests when a branch is merged into (pushed to) master. This way possible errors are recognized by a failing default branch and development on PRs is not blocked by 'slow' js tests.

What do you think @nofaralfasi @evgeni ?

Obviously this requires https://github.com/theforeman/foreman_ansible/pull/698 to work.