### PR TITLE
Send resource as keyword argument in resource_name

### DIFF
--- a/app/controllers/ui_ansible_roles_controller.rb
+++ b/app/controllers/ui_ansible_roles_controller.rb
@@ -8,7 +8,7 @@ class UiAnsibleRolesController < ::Api::V2::BaseController
   end
 
   # restore original method from find_common to ignore resource nesting
-  def resource_scope(options = {})
-    @resource_scope ||= scope_for(resource_class, options)
+  def resource_scope(**kwargs)
+    @resource_scope ||= scope_for(resource_class, **kwargs)
   end
 end

--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Foreman::Plugin.register :foreman_ansible do
-  requires_foreman '>= 3.8.1'
+  requires_foreman '>= 3.10.0'
   register_gettext
 
   settings do


### PR DESCRIPTION
This was always a better way, but in Foreman 3.10 the args and kwargs handling was made more explicit.