### PR TITLE
[SAT-24015] Remove telemetry option from conversion templates

### DIFF
--- a/app/views/foreman_ansible/job_templates/convert_to_rhel.erb
+++ b/app/views/foreman_ansible/job_templates/convert_to_rhel.erb
@@ -21,21 +21,6 @@ template_inputs:
   value_type: plain
   resource_type: Katello::ActivationKey
   hidden_value: false
-- name: Data telemetry
-  required: true
-  input_type: user
-  description: "The convert2rhel utility uploads the following data about the system
-    conversion to Red Hat servers for the purpose of the utility usage analysis:<br>\r\n-
-    The convert2rhel command as executed<br>\r\n- The convert2rhel RPM version and
-    GPG signature<br>\r\n- Success or failure status of the conversion<br>\r\n- Conversion
-    start and end timestamps<br>\r\n- Source OS vendor and version<br>\r\n- Target
-    RHEL version<br>\r\n- convert2rhel related environment variables<br>"
-  options: "yes\r\nno"
-  advanced: false
-  value_type: plain
-  resource_type: Katello::ActivationKey
-  default: 'yes'
-  hidden_value: false
 model: JobTemplate
 job_category: Convert 2 RHEL
 provider_type: Ansible
@@ -43,10 +28,6 @@ kind: job_template
 %>
 ---
 - hosts: all
-<%- if input('Data telemetry') != "yes" -%>
-  environment:
-    CONVERT2RHEL_DISABLE_TELEMETRY: 1
-<%- end -%>
   tasks:
     - name: Install convert2rhel
       ansible.builtin.package:


### PR DESCRIPTION
Remove the telemetry opt out since it's not being used by Convert2RHEL anymore.

https://issues.redhat.com/browse/SAT-24015