### PR TITLE
Fixes #37342 - Update foreman docs and fix specify matcher documentation

### DIFF
--- a/app/views/ansible_roles/index.html.erb
+++ b/app/views/ansible_roles/index.html.erb
@@ -1,7 +1,7 @@
 <% title _("Ansible Roles") %>
 
 <% title_actions ansible_proxy_import(hash_for_import_ansible_roles_path),
-  documentation_button('#4.1ImportingRoles', :root_url => ansible_doc_url) %>
+  documentation_button('Managing_Configurations_Ansible', type: 'docs', chapter: 'Importing_Ansible_Roles_and_Variables_ansible') %>
 
 <table class="<%= table_css_classes 'table-fixed' %>">
   <thead>

--- a/app/views/ansible_roles/welcome.html.erb
+++ b/app/views/ansible_roles/welcome.html.erb
@@ -7,7 +7,7 @@
   <p><%= _('No Ansible Roles were found in Foreman. If you want to assign roles to your hosts,
              you have to import them first.').html_safe %>
   </p>
-  <p><%= link_to(_('Learn more about this in the documentation.'), documentation_url('#4.1ImportingRoles', :root_url => ansible_doc_url), target: '_blank') %></p>
+  <p><%= link_to(_('Learn more about this in the documentation.'), documentation_url('Managing_Configurations_Ansible', type: 'docs',  chapter: 'Importing_Ansible_Roles_and_Variables_ansible'), target: '_blank') %></p>
   <div class="blank-slate-pf-secondary-action">
     <%= ansible_proxy_import(hash_for_import_ansible_roles_path) %>
   </div>

--- a/app/views/ansible_variables/_fields.erb
+++ b/app/views/ansible_variables/_fields.erb
@@ -65,7 +65,7 @@
     </fieldset>
     </br>
     <fieldset>
-      <h2><%= _("Specify Matchers") %>  <%= documentation_button('4.2.6SmartMatchers') %></h2>
+      <h2><%= _("Specify Matchers") %>  <%= documentation_button('Managing_Configurations_Ansible', type: 'docs', chapter: 'Overriding_Ansible_Variables_in_foreman_ansible') %></h2>
       <div class="children_fields lookup_values">
         <%= render 'lookup_keys/values', :f => f, :is_param => false %>
       </div>

--- a/app/views/ansible_variables/index.html.erb
+++ b/app/views/ansible_variables/index.html.erb
@@ -2,8 +2,7 @@
 <%= stylesheet 'foreman_ansible/foreman-ansible' %>
 
 <%= title_actions display_link_if_authorized(_('New Ansible Variable'), hash_for_new_ansible_variable_path, :class => "btn btn-default no-float"),
-      documentation_button('#4.3Variables', :root_url => ansible_doc_url)
-       %>
+      documentation_button('Managing_Configurations_Ansible', type: 'docs', chapter: 'Importing_Ansible_Roles_and_Variables_ansible') %>
 
 <table class="<%= table_css_classes 'table-fixed' %>">
   <thead>


### PR DESCRIPTION
Foreman documentation was outdated and using theforeman.org. This PR updates the doc links according to 'https://docs.theforeman.org/nightly/Managing_Configurations_Ansible/index-foreman-el.html'

It also fixes the misdirected redirect for SpecifyMatchers as reported in https://issues.redhat.com/browse/SAT-24111

Note: This Pr is blocked by https://github.com/RedHatSatellite/foreman_theme_satellite/pull/45