### PR TITLE
Fixes SAT-24133 - 13-STABLE Convert2RHEL deprecated functionality 

### DIFF
--- a/app/views/foreman_ansible/job_templates/convert_to_rhel.erb
+++ b/app/views/foreman_ansible/job_templates/convert_to_rhel.erb
@@ -19,7 +19,6 @@ template_inputs:
   options: "yes\r\nno"
   advanced: false
   value_type: plain
-  resource_type: Katello::ActivationKey
   hidden_value: false
 - name: Data telemetry
   required: true
@@ -52,12 +51,27 @@ kind: job_template
       ansible.builtin.package:
         name: convert2rhel
         state: present
+
+    - name: Gather package facts
+      package_facts:
+        manager: auto
+
+    - name: Set fact for package version
+      set_fact:
+        convert2rhel_version: "{{ ansible_facts.packages['convert2rhel'][0].version }}"
+      when: "'convert2rhel' in ansible_facts.packages"
+      no_log: true
+
     - name: Prepopulate katello-ca-consumer
       get_url:
         url: <%= subscription_manager_configuration_url(@host) %>
         dest: /usr/share/convert2rhel/subscription-manager/katello-ca-consumer-latest.noarch.rpm
+      when:
+        - "convert2rhel_version is version('2.0.0', '<')"
+
     - name: Start convert2rhel
-      command: convert2rhel -y --activationkey "<%= input_resource('Activation Key').name %>" --org "<%= @host.organization.label %>" --keep-rhsm
+      command: convert2rhel -y --activationkey "<%= input_resource('Activation Key').name %>" --org "<%= @host.organization.label %>"
+
 <%- if input('Restart') == "yes" -%>
     - name: Reboot the machine
       reboot:

--- a/lib/foreman_ansible/version.rb
+++ b/lib/foreman_ansible/version.rb
@@ -4,5 +4,5 @@
 # This way other parts of Foreman can just call ForemanAnsible::VERSION
 # and detect what version the plugin is running.
 module ForemanAnsible
-  VERSION = '13.0.4'
+  VERSION = '13.0.5'
 end


### PR DESCRIPTION
- RPM is not installed for version 2.0.0
- Removed keep-rhsm flag

(cherry picked from commit https://github.com/theforeman/foreman_ansible/commit/8c6be4f1759732b474b753c2bceeb8f4da4645a6)