### PR TITLE
Fixes #37404 - Drop webpacked_plugins_css_for from code

### DIFF
--- a/app/views/ansible_roles/import.html.erb
+++ b/app/views/ansible_roles/import.html.erb
@@ -1,6 +1,5 @@
 <% title _("Changed Ansible roles") %>
 <%= webpacked_plugins_js_for :foreman_ansible %>
-<%= webpacked_plugins_css_for :foreman_ansible %>
 
 
 <%= react_component(

--- a/app/views/foreman_ansible/ansible_roles/_select_tab_content.html.erb
+++ b/app/views/foreman_ansible/ansible_roles/_select_tab_content.html.erb
@@ -1,5 +1,4 @@
 <%= webpacked_plugins_js_for :foreman_ansible %>
-<%= webpacked_plugins_css_for :foreman_ansible %>
 
 <div class='tab-pane' id='ansible_roles'>
   <% class_name = f.object.is_a?(Hostgroup) ? 'Hostgroup' : 'Host' %>


### PR DESCRIPTION
`webpacked_plugins_css_for` was deprecated in Foreman 3.10 and will be removed in 3.12:
https://github.com/theforeman/foreman/commit/89c610451c9ea22eb426826e405518e04d68972f

This PR removes occurrences of `webpacked_plugins_css_for`.
