### PR TITLE
fixes #37524 - feat: enable ansible events for webhooks

### DIFF
--- a/app/models/ansible_role.rb
+++ b/app/models/ansible_role.rb
@@ -4,6 +4,7 @@
 class AnsibleRole < ApplicationRecord
   audited
   include Authorizable
+  include Foreman::ObservableModel
 
   self.include_root_in_json = false
   validates :name, :presence => true, :uniqueness => true
@@ -27,6 +28,8 @@ class AnsibleRole < ApplicationRecord
                 :on => :id, :rename => :hostgroup_id, :only_explicit => true
   scoped_search :relation => :hostgroups,
                 :on => :name, :rename => :hostgroup, :only_explicit => true
+
+  set_crud_hooks :ansible_role
 
   apipie :class, "A class representing #{model_name.human} object" do
     name 'Ansible role'

--- a/app/models/ansible_variable.rb
+++ b/app/models/ansible_variable.rb
@@ -2,6 +2,8 @@
 
 # Represents the variables used in Ansible to parameterize playbooks
 class AnsibleVariable < LookupKey
+  include Foreman::ObservableModel
+
   belongs_to :ansible_role, :inverse_of => :ansible_variables
   validates :ansible_role_id, :presence => true
   before_validation :cast_default_value, :if => :override?
@@ -10,6 +12,8 @@ class AnsibleVariable < LookupKey
   scoped_search :on => :imported, :complete_value => { :true => true, :false => false }
   scoped_search :relation => :ansible_role, :on => :name,
                 :complete_value => true, :rename => :ansible_role
+
+  set_crud_hooks :ansible_variable
 
   def ansible?
     true


### PR DESCRIPTION
Enables the following events:
- `ansible_variable_created.event.foreman`
- `ansible_variable_updated.event.foreman`
- `ansible_variable_destroyed.event.foreman`
- `ansible_role_created.event.foreman`
- `ansible_role_updated.event.foreman`
- `ansible_role_destroyed.event.foreman`

Which can then be used with [`foreman_webhooks`](https://github.com/theforeman/foreman_webhooks)

![image](https://github.com/theforeman/foreman_ansible/assets/455556/9e5476a7-fc64-4bde-997d-4d483243e1d7)

https://projects.theforeman.org/issues/37524