### PR TITLE
Fixes #37612 - Fix deletion of Ansible variables from Host page

### DIFF
--- a/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/AnsibleVariableOverridesTableHelper.js
+++ b/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/AnsibleVariableOverridesTableHelper.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { isEqual } from 'lodash';
 import { TimesIcon, CheckIcon } from '@patternfly/react-icons';
 import { sprintf, translate as __ } from 'foremanReact/common/I18n';
 
@@ -48,7 +49,7 @@ export const onCompleted = onSubmitSuccess => response => {
       message: formatError(joinErrors(errors)),
     });
   } else {
-    onSubmitSuccess(overridenAnsibleVariable.currentValue.value);
+    onSubmitSuccess(overridenAnsibleVariable.defaultValue);
     showToast({
       type: 'success',
       message: __('Ansible variable override was successfully deleted.'),
@@ -59,7 +60,7 @@ export const onCompleted = onSubmitSuccess => response => {
 export const findOverride = (variable, hostname) =>
   variable.lookupValues.nodes.find(
     item =>
-      item.value === variable.currentValue.value &&
+      isEqual(item.value, variable.currentValue.value) &&
       item.match === `fqdn=${hostname}`
   );
 

--- a/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/__test__/AnsibleVariableOverrides.fixtures.js
+++ b/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/__test__/AnsibleVariableOverrides.fixtures.js
@@ -309,6 +309,7 @@ export const deleteMocks = [
           overridenAnsibleVariable: {
             __typename: 'OverridenAnsibleVariable',
             id: ansibleVariableId,
+            defaultValue: 101,
             currentValue: {
               __typename: 'AnsibleVariableOverride',
               element: 'os',

--- a/webpack/graphql/mutations/deleteAnsibleVariableOverride.gql
+++ b/webpack/graphql/mutations/deleteAnsibleVariableOverride.gql
@@ -3,6 +3,7 @@ mutation DeleteAnsibleVariableOverride($id: ID!, $hostId: Int!, $variableId: Int
     id
     overridenAnsibleVariable {
       id
+      defaultValue
       currentValue {
         value
         element


### PR DESCRIPTION
- Use `isEqual` for deep comparison when matching variable values,
  ensuring correct behavior during variable deletion.
- Add `defaultValue` field to GraphQL mutation, for proper value display
  after Ansible variable deletion.