### PR TITLE
Fixes #37733 - Add audits of ansible role changes on hosts

### DIFF
--- a/app/models/host_ansible_role.rb
+++ b/app/models/host_ansible_role.rb
@@ -2,10 +2,16 @@
 
 # Join model that hosts the connection between hosts and ansible_roles
 class HostAnsibleRole < ApplicationRecord
+  audited associated_with: :host
+
   belongs_to_host
   belongs_to :ansible_role
   acts_as_list scope: :host
 
   validates :ansible_role_id, :presence => true,
                               :uniqueness => { :scope => :host_id }
+
+  def to_label
+    ansible_role.name
+  end
 end

--- a/test/unit/host_ansible_role_test.rb
+++ b/test/unit/host_ansible_role_test.rb
@@ -17,4 +17,34 @@ class HostAnsibleRoleTest < ActiveSupport::TestCase
     end
     should validate_uniqueness_of(:ansible_role_id).scoped_to(:host_id)
   end
+
+  describe 'auditing' do
+    setup do
+      @host = FactoryBot.create(:host)
+      @ansible_role = FactoryBot.create(:ansible_role)
+      @host_ansible_role = FactoryBot.create(:host_ansible_role, :with_auditing, host_id: @host.id, ansible_role_id: @ansible_role.id)
+      @audits = @host_ansible_role.audits
+    end
+
+    test 'should audit creation of a host ansible role' do
+      assert_equal 1, @audits.size
+      assert_associated_ids
+      assert_equal 'create', @audits.last.action
+    end
+
+    test 'should audit deletion of a host ansible role' do
+      @audits.clear
+      @host_ansible_role.destroy
+
+      assert_equal 1, @audits.size
+      assert_associated_ids
+      assert_equal 'destroy', @audits.last.action
+    end
+
+    def assert_associated_ids
+      audit = @audits.last
+      assert_equal @ansible_role.id, audit.audited_changes['ansible_role_id']
+      assert_equal @host.id, audit.audited_changes['host_id']
+    end
+  end
 end


### PR DESCRIPTION
This records audits when ansible role is added to a host or removed from a host.

Defining the `to_label` method is necessary so the name of host ansible
role is shown in the format `role / host` rather than `id / host`.
