### PR TITLE
Fixes #37802 - remove unused attributes in pagination

### DIFF
--- a/webpack/components/AnsibleRolesSwitcher/components/AvailableRolesList.js
+++ b/webpack/components/AnsibleRolesSwitcher/components/AvailableRolesList.js
@@ -17,13 +17,11 @@ const AvailableRolesList = ({
   <ListView>
     <div className="sticky-pagination">
       <Pagination
-        viewType="list"
         itemCount={itemCount}
         updateParamsByUrl={false}
         page={pagination.page}
         perPage={pagination.perPage}
         onChange={onListingChange}
-        dropdownButtonId="available-ansible-roles-pagination-row-dropdown"
       />
     </div>
     <LoadingState loading={loading}>

--- a/webpack/components/AnsibleRolesSwitcher/components/__snapshots__/AvailableRolesList.test.js.snap
+++ b/webpack/components/AnsibleRolesSwitcher/components/__snapshots__/AvailableRolesList.test.js.snap
@@ -9,7 +9,6 @@ exports[`AvailableRolesList should render 1`] = `
   >
     <Pagination
       className={null}
-      dropdownButtonId="available-ansible-roles-pagination-row-dropdown"
       itemCount={2}
       noSidePadding={false}
       onChange={[Function]}
@@ -19,7 +18,6 @@ exports[`AvailableRolesList should render 1`] = `
       perPage={25}
       updateParamsByUrl={false}
       variant="bottom"
-      viewType="list"
     />
   </div>
   <LoadingState


### PR DESCRIPTION
Causing these errors
Warning: React does not recognize the `viewType` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `viewtype` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
in div (created by Pagination)
in Pagination (created by Pagination)
in Pagination (created by AvailableRolesList)

printWarning @ react-dom.development.js:88Understand this error
react-dom.development.js:88 Warning: React does not recognize the `dropdownButtonId` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `dropdownbuttonid` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
in div (created by Pagination)
in Pagination (created by Pagination)
in Pagination (created by AvailableRolesList)