### PR TITLE
Fixes #37942 - Adding Ansible Check Mode to Ansible Job Templates

### DIFF
--- a/app/controllers/concerns/foreman/controller/parameters/job_template_extensions.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/job_template_extensions.rb
@@ -7,7 +7,7 @@ module Foreman
         class_methods do
           def job_template_params_filter
             super.tap do |filter|
-              filter.permit :ansible_callback_enabled
+              filter.permit :ansible_callback_enabled, :ansible_check_mode
             end
           end
         end

--- a/app/controllers/foreman_ansible/api/v2/job_templates_controller_extensions.rb
+++ b/app/controllers/foreman_ansible/api/v2/job_templates_controller_extensions.rb
@@ -10,6 +10,7 @@ module ForemanAnsible
         update_api(:create, :update) do
           param :job_template, Hash do
             param :ansible_callback_enabled, :bool, :desc => N_('Enable the callback plugin for this template')
+            param :ansible_check_mode, :bool, :desc => N_('Enable Ansible Check Mode for this template')
           end
         end
       end

--- a/app/models/foreman_ansible/ansible_provider.rb
+++ b/app/models/foreman_ansible/ansible_provider.rb
@@ -33,6 +33,7 @@ if defined? ForemanRemoteExecution
             ),
             :name => host.name,
             :check_mode => host.host_param('ansible_roles_check_mode'),
+            :job_check_mode => template_invocation.template.ansible_check_mode,
             :cleanup_working_dirs => cleanup_working_dirs?(host)
           )
         end

--- a/app/views/api/v2/job_templates/job_templates.json.rabl
+++ b/app/views/api/v2/job_templates/job_templates.json.rabl
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-attributes :ansible_callback_enabled
+attributes :ansible_callback_enabled, :ansible_check_mode

--- a/app/views/job_templates/_job_template_callback_tab_content.html.erb
+++ b/app/views/job_templates/_job_template_callback_tab_content.html.erb
@@ -1,3 +1,4 @@
 <div class="tab-pane" id="ansible_callback_enabled">
   <%= checkbox_f f, :ansible_callback_enabled, :label => _('Enable Ansible Callback'), :disabled => @template.locked? %>
+  <%= checkbox_f f, :ansible_check_mode, :label => _('Enable Ansible Check Mode'), :disabled => @template.locked? %>
 </div>

--- a/db/migrate/20241022000000_add_ansible_check_mode_to_templates.rb
+++ b/db/migrate/20241022000000_add_ansible_check_mode_to_templates.rb
@@ -1,10 +1,5 @@
-# frozen_string_literal: true
-
-class AddAnsibleCheckModeToTemplates < ActiveRecord::Migration[6.0]
+class AddAnsibleCheckModeToTemplates < ActiveRecord::Migration[7.0]
   def change
     add_column :templates, :ansible_check_mode, :boolean, default: false
-    RemoteExecutionFeature.where(label: 'ansible_run_host').each do |rex_feature|
-      Template.where(id: rex_feature.job_template_id).update_all(ansible_check_mode: false)
-    end
   end
 end

--- a/db/migrate/20241022000000_add_ansible_check_mode_to_templates.rb
+++ b/db/migrate/20241022000000_add_ansible_check_mode_to_templates.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddAnsibleCheckModeToTemplates < ActiveRecord::Migration[6.0]
+  def change
+    add_column :templates, :ansible_check_mode, :boolean, default: false
+    RemoteExecutionFeature.where(label: 'ansible_run_host').each do |rex_feature|
+      Template.where(id: rex_feature.job_template_id).update_all(ansible_check_mode: false)
+    end
+  end
+end


### PR DESCRIPTION
#### Overview of Changes
This PR intends to add the Ansible Check Mode (identified with the `--check` argument to ansible-runner) to Ansible Job Templates via a checkbox option.  The follow-up after all the subsequent PRs are submitted/approved (hammer cli support for instance) is to add Ansible Diff Mode support in a similar manner.  See below screenshot:

![screenshot](https://github.com/user-attachments/assets/6129ed6a-a9cf-4251-8b76-b6e8bc86aa40)

#### Implementation Considerations
Foreman already offers the ability for users to run Ansible Config Commands (Running Ansible Roles on a host) with check mode enabled by setting the host's host parameter ansible_roles_check_mode to True.  This is left in-place as-is.  However, that implementation does not allow users to run Ansible Playbook jobs or any other custom remote execution jobs in Ansible Check Mode.  Nor is setting a host parameter as flexible as setting an entire Job Template to use Ansible Check Mode.

I have a few questions/concerns:
1. It's sort of kludgy, but I've added a separate "job_check_mode" variable passed to the smart_proxy_ansible plugin instead of using the existing "check_mode" variable.  My reason for doing this is that the latter is used when setting the ansible_roles_check_mode host parameter which is only intended for use when running an Ansible Roles job.  Meanwhile, this PR is intended for use on any host that is the target of any job whose template uses the new Ansible Check Mode (identified by the "job_check_mode" variable).  Another reason I split the functions in two is that I do not want to break the existing functionality.  Because of [this change](https://github.com/theforeman/smart_proxy_ansible/pull/48/commits/c5df4e07bb9c03b1e725a96b84d72a53f1656ec9#diff-65b556454b9717ae33c08487e6ace03409dadb3c66b54f921b1dee1caccfb142R189), "check_mode" with the ansible_roles_check_mode parameter will not work for rex (remote execution) jobs.  This obviously runs completely counter to what I'm trying to accomplish in this PR.
2. For the [db/migrate/20241022000000_add_ansible_check_mode_to_templates.rb](https://github.com/theforeman/foreman_ansible/compare/master...bnerickson:foreman_ansible:check-mode-flag?expand=1#diff-0478c1f4badadd851533896cbc75394aab608daff65c13b1c0259444b8c938dc) file, I arbitrarily set the date string in the filename to 20241022000000, but is that supposed to be automatically generated somehow?

#### Testing Steps
1. Add the changes in https://github.com/theforeman/smart_proxy_ansible/pull/94 to your test environment.
2. Add the changes in _this_ PR to your test environment.
3. Clone the "Ansible Roles - Ansible Default" Job Template.
4. In the clone's "Ansible" tab, select the "Ansible Check Mode Enabled" checkbox and save the Job Template.
5. On a host, schedule a Job and select the cloned Job Category and Job Template.  Execute the job.

#### Checklists

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman/blob/develop/CONTRIBUTING.md) guidelines.
* [x] I have added relevant tests for my changes.
* [x] I have updated the documentation accordingly.

#### Additional Notes
This PR is not dependent on any other changes.  The follow PRs are dependent on this change:
* [x] hammer-cli PR: https://github.com/theforeman/hammer-cli-foreman-ansible/pull/31
* [x] smart_proxy_ansible PR: https://github.com/theforeman/smart_proxy_ansible/pull/94
* [x] Documentation update PR: https://github.com/theforeman/foreman-documentation/pull/3391
