### PR TITLE
Fixes #38031 - Use the same routes constraints as Foreman

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -270,3 +270,6 @@ Style/TrailingCommaInArrayLiteral:
 # SupportedStylesForMultiline: comma, consistent_comma, no_comma
 Style/TrailingCommaInHashLiteral:
   Enabled: false
+
+Style/RegexpLiteral:
+  Enabled: false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,14 +7,14 @@ Rails.application.routes.draw do
           :defaults => { apiv: 'v2' },
           :apiv => /v2/,
           :constraints => ApiConstraints.new(version: 2, default: true) do
-      constraints(:id => %r{[^\/]+}) do
-        resources :hosts, :except => [:new, :edit] do
+      constraints(:id => /[^\/]+/) do
+        resources :hosts, :only => [] do
           member do
             post :play_roles
             get :ansible_roles
             post :assign_ansible_roles
-            put 'ansible_roles/:ansible_role_id', :to => 'hosts#add_ansible_role', :constraints => { id: %r{[^\/]+} }
-            delete 'ansible_roles/:ansible_role_id', :to => 'hosts#remove_ansible_role', :constraints => { id: %r{[^\/]+} }
+            put 'ansible_roles/:ansible_role_id', :to => 'hosts#add_ansible_role', :constraints => { id: /[^\/]+/ }
+            delete 'ansible_roles/:ansible_role_id', :to => 'hosts#remove_ansible_role', :constraints => { id: /[^\/]+/ }
           end
           collection do
             post :multiple_play_roles
@@ -25,8 +25,8 @@ Rails.application.routes.draw do
             post :play_roles
             get :ansible_roles
             post :assign_ansible_roles
-            put 'ansible_roles/:ansible_role_id', :to => 'hostgroups#add_ansible_role', :constraints => { id: %r{[^\/]+} }
-            delete 'ansible_roles/:ansible_role_id', :to => 'hostgroups#remove_ansible_role', :constraints => { id: %r{[^\/]+} }
+            put 'ansible_roles/:ansible_role_id', :to => 'hostgroups#add_ansible_role', :constraints => { id: /[^\/]+/ }
+            delete 'ansible_roles/:ansible_role_id', :to => 'hostgroups#remove_ansible_role', :constraints => { id: /[^\/]+/ }
           end
           collection do
             post :multiple_play_roles
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
     end
   end
   scope '/ansible' do
-    constraints(:id => %r{[^\/]+}) do
+    constraints(:id => /[^\/]+/) do
       resources :hosts, :only => [] do
         member do
           get :play_roles


### PR DESCRIPTION
#### Overview of Changes
- Somewhat reverts and updates https://github.com/theforeman/foreman_ansible/commit/73bb74a0d2f2c06048a5a0f86cfe9091c81a4a76.

#### Implementation Considerations
- Without this change `GET /api/v2/hosts/<fqdn_or_id>/power` is not recognized in API calls, even though it's listed internally (e.g. rails routes command) on Rails 7.0.

#### Testing Steps
- I've tried to write a test, but locally it didn't discover this issue (test passed), I've tested it by running the app with/out this patch checked on hosts index page the power state icons (they should not be grey for real machines) or just check in the logs for failed requests. 

#### Checklists

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman/blob/develop/CONTRIBUTING.md) guidelines.
* [?] I have added relevant tests for my changes.
* [?] I have updated the documentation accordingly.

#### Additional Notes
- Doesn't depend on any other PR, but to observe the issue, check with https://github.com/theforeman/foreman/pull/10299.
