### PR TITLE
Use trusted publishers to release the gem

### DIFF
--- a/.github/workflows/release_gem.yml
+++ b/.github/workflows/release_gem.yml
@@ -1,6 +1,6 @@
 name: Release
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     # Pattern matched against refs/tags
     tags:
@@ -9,8 +9,12 @@ on:
 jobs:
   release:
     name: Release gem
-    uses: theforeman/actions/.github/workflows/release-gem.yml@v0
-    with:
-      allowed_owner: theforeman
-    secrets:
-      api_key: ${{ secrets.RUBYGEM_API_KEY }}
+    runs-on: ubuntu-latest
+    environment: release
+    if: github.repository_owner == 'theforeman'
+
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: voxpupuli/ruby-release@v0


### PR DESCRIPTION
#### Overview of Changes

To convert from the legacy API-key based publishing to using Trusted Publishers. See https://community.theforeman.org/t/use-trusted-publishers-to-release-gems/42009 for the details.

#### Implementation Considerations

See the RFC. Some admin (likely me) will also need to set up GitHub and Rubygems.

#### Testing Steps

Push a tag and see that it gets published.

#### Checklists

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman/blob/develop/CONTRIBUTING.md) guidelines.
* [ ] I have added relevant tests for my changes.
* [x] I have updated the documentation accordingly.

#### Additional Notes