### PR TITLE
Fixes #38250 - keep newlines and trailing spaces in Ansible variables

### DIFF
--- a/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/EditableValue.js
+++ b/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/EditableValue.js
@@ -4,11 +4,7 @@ import { translate as __ } from 'foremanReact/common/I18n';
 
 import { formatValue } from './AnsibleVariableOverridesTableHelper';
 
-import {
-  TextAreaField,
-  TextInputField,
-  SelectField,
-} from './EditableValueHelper';
+import { TextAreaField, SelectField } from './EditableValueHelper';
 
 const EditableValue = props => {
   if (!props.editing) {
@@ -50,7 +46,7 @@ const EditableValue = props => {
   }
 
   return (
-    <TextInputField
+    <TextAreaField
       onChange={props.onChange}
       value={props.value}
       validation={props.validation}


### PR DESCRIPTION
#### Overview of Changes
Preserves newlines and trailing spaces for Ansible variable overrides in the new host UI.

#### Testing Steps
1. Create a new Ansible variable of type **String** with a multi-line override value and assign it to a host.  
2. Navigate to the **Host Details** page → **Ansible** tab → **Variables** tab.  
3. Edit the variable:  
   - It should display the string in multiple lines.  
   - You should be able to add or remove lines.  
4. Save the changes and verify that the updated value is preserved correctly.

#### Checklists

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman/blob/develop/CONTRIBUTING.md) guidelines.
* [ ] I have added relevant tests for my changes.
* [ ] I have updated the documentation accordingly.