### PR TITLE
Fixes #38250 - keep newlines and trailing spaces in Ansible variables

### DIFF
--- a/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/EditableValue.js
+++ b/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/EditableValue.js
@@ -4,11 +4,7 @@ import { translate as __ } from 'foremanReact/common/I18n';
 
 import { formatValue } from './AnsibleVariableOverridesTableHelper';
 
-import {
-  TextAreaField,
-  TextInputField,
-  SelectField,
-} from './EditableValueHelper';
+import { TextAreaField, SelectField } from './EditableValueHelper';
 
 const EditableValue = props => {
   if (!props.editing) {
@@ -50,7 +46,7 @@ const EditableValue = props => {
   }
 
   return (
-    <TextInputField
+    <TextAreaField
       onChange={props.onChange}
       value={props.value}
       validation={props.validation}


### PR DESCRIPTION
(cherry picked from commit 8b03e3d26bdbbf4462ad34f8cfd91a20a78aedf4)
