### PR TITLE
Loosen dependency on REX to allow <17

### DIFF
--- a/foreman_ansible.gemspec
+++ b/foreman_ansible.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'acts_as_list', '~> 1.2'
   s.add_dependency 'deface', '< 2.0'
-  s.add_dependency 'foreman_remote_execution', '>= 14.0', '< 16'
+  s.add_dependency 'foreman_remote_execution', '>= 14.0', '< 17'
   s.add_dependency 'foreman-tasks', '>= 10.0', '< 11'
 
   s.add_development_dependency 'theforeman-rubocop', '~> 0.1.0'


### PR DESCRIPTION
#### Overview of Changes
Loosening the dependency on REX to allow next major version

#### Implementation Considerations
Next release of REX will require Foreman 3.15 (because of PF5) and therefore will be a major release. To avoid the traditional issues when rex gets major-bumped, I'm opening this in advance.