### PR TITLE
Fixes #38507 - always use transient flag with bootc hosts

### DIFF
--- a/app/views/foreman_ansible/job_templates/package_action_-_ansible_default.erb
+++ b/app/views/foreman_ansible/job_templates/package_action_-_ansible_default.erb
@@ -36,6 +36,7 @@ model: JobTemplate
 - hosts: all
   vars:
     pkg_name: "<%= input('name') %>"
+    pkg_names_for_dnf: "<%= input('name').respond_to?(:join) ? input('name').join(' ') : input('name') %>"
   <%- if input('pre_script').present? -%>
   pre_tasks:
     - shell: "<%= input('pre_script') %>"
@@ -51,19 +52,19 @@ model: JobTemplate
 <%= indent(4) { snippet('check_bootc_status') } %>
   <%- if input('state') == 'present' -%>
     - name: Ensure package is present transiently for image mode machines
-      shell: "dnf --transient install -y <%= input('name') %>"
+      shell: "dnf --transient install -y {{ pkg_names_for_dnf }}"
       when: is_bootc_host
   <%- end -%>
   <%- if input('state') == 'latest' -%>
     - name: Ensure package is at the latest version transiently for image mode machines
       shell: |
-        dnf --transient install -y <%= input('name') %>
-        dnf --transient update -y <%= input('name') %>
+        dnf --transient install -y {{ pkg_names_for_dnf }}
+        dnf --transient update -y {{ pkg_names_for_dnf }}
       when: is_bootc_host
   <%- end -%>
   <%- if input('state') == 'absent' -%>
     - name: Remove packages transiently for image mode machines
-      shell: "dnf --transient remove -y <%= input('name') %>"
+      shell: "dnf --transient remove -y {{ pkg_names_for_dnf }}"
       when: is_bootc_host
   <%- end -%>
     - name: Install or remove packages normally

--- a/app/views/foreman_ansible/job_templates/package_action_-_ansible_default.erb
+++ b/app/views/foreman_ansible/job_templates/package_action_-_ansible_default.erb
@@ -34,26 +34,39 @@ model: JobTemplate
 # For Windows targets use the win_package module instead.
 ---
 - hosts: all
+  vars:
+    pkg_name: "<%= input('name') %>"
   <%- if input('pre_script').present? -%>
   pre_tasks:
     - shell: "<%= input('pre_script') %>"
   <%- end -%>
   tasks:
+    - name: Validate input
+      ansible.builtin.assert:
+        that:
+          - pkg_name is defined
+          - pkg_name | length > 0
+        fail_msg: "The 'name' input cannot be empty. A package name must be provided."
+        success_msg: "Valid 'name' input: '{{ pkg_name }}'"
 <%= indent(4) { snippet('check_bootc_status') } %>
-    - name: Enable bootc overlay
-      shell:
-        cmd: 'bootc usr-overlay'
-      register: out
-      ignore_errors: true
+  <%- if input('state') == 'present' -%>
+    - name: Ensure package is present transiently for image mode machines
+      shell: "dnf --transient install -y <%= input('name') %>"
       when: is_bootc_host
-    - debug: var=out
-    - name: Install packages via dnf for image mode machines
-      package:
-        use: 'dnf'
-<%= indent(8) { to_yaml({"name" => input('name')}).gsub(/---\n/, '') } -%>
-        state: <%= input('state') %>
+  <%- end -%>
+  <%- if input('state') == 'latest' -%>
+    - name: Ensure package is at the latest version transiently for image mode machines
+      shell: |
+        dnf --transient install -y <%= input('name') %>
+        dnf --transient update -y <%= input('name') %>
       when: is_bootc_host
-    - name: Install packages normally
+  <%- end -%>
+  <%- if input('state') == 'absent' -%>
+    - name: Remove packages transiently for image mode machines
+      shell: "dnf --transient remove -y <%= input('name') %>"
+      when: is_bootc_host
+  <%- end -%>
+    - name: Install or remove packages normally
       package:
 <%= indent(8) { to_yaml({"name" => input('name')}).gsub(/---\n/, '') } -%>
         state: <%= input('state') %>


### PR DESCRIPTION
#### Overview of Changes
bootc usr-overlay doesn't do anything if a user first installs a package with dnf --transient. To work around this, bootc machines should always use --transient.

Keeps the logic the same for non-bootc machines.


#### Implementation Considerations
I wanted the experience to be nearly the same for non bootc machines, but I could've switched everything over to using shell commands.

I've added a new failure in case the package name is empty to safeguard against updating all packages accidentally. In some templates we use an empty package list to update all, but I don't believe this particular template is used as such.

#### Testing Steps
Try package actions on bootc and non-bootc hosts.

