### PR TITLE
Fixes #35970 - feature to upgrade orcharhino Proxy

### DIFF
--- a/app/helpers/foreman_ansible/smart_proxies_helper.rb
+++ b/app/helpers/foreman_ansible/smart_proxies_helper.rb
@@ -29,6 +29,8 @@ module ForemanAnsible
     def proxy_update_button(proxy)
       name = if Foreman::Plugin.find('foreman_theme_satellite').present?
                :ansible_run_capsule_upgrade
+             elsif Foreman::Plugin.find('orcharhino_core').present?
+               :ansible_run_orcharhino_proxy_upgrade
              else
                :ansible_run_smart_proxy_upgrade
              end

--- a/app/views/foreman_ansible/job_templates/orcharhino_proxy_upgrade_-_ansible_default.erb
+++ b/app/views/foreman_ansible/job_templates/orcharhino_proxy_upgrade_-_ansible_default.erb
@@ -1,0 +1,129 @@
+<%#
+name: Upgrade orcharhino Proxy - Ansible Default
+snippet: false
+model: JobTemplate
+job_category: Maintenance Operations
+description_format: "%{template_name}"
+provider_type: Ansible
+kind: job_template
+feature: ansible_run_orcharhino_proxy_upgrade
+%>
+
+---
+- name: Upgrade orcharhino Proxy - Ansible Default
+  hosts: all
+  vars:
+    repository_regex: "<%= @host.organization %>_(Smart_Proxy_Atix|orcharhino_Proxy)_ATIX_orcharhino_Server_[a-zA-Z]{2}[0-9]_orcharhino_([0-9]+)_([0-9]+)(_EL[0-9]+)?"
+  tasks:
+<% if plugin_present?('orcharhino_core') -%>
+    - name: Gather RPM package facts
+      ansible.builtin.package_facts:
+        manager: auto
+
+    - name: Fail if target is orcharhino Server
+      ansible.builtin.fail:
+        msg: "This playbook cannot be executed on orcharhino Server. Use only on orcharhino Proxy."
+      when: "'orcharhino' in ansible_facts.packages"
+
+    - name: Check if orcharhino Proxy can be upgraded
+      block:
+
+        - name: Determine initial version of orcharhino-proxy
+          ansible.builtin.set_fact:
+            initial_proxy_version: "{{ ansible_facts.packages['orcharhino-proxy'][0]['version'] }}"
+
+        - name: Find repository to be enabled
+          ansible.builtin.shell:
+            cmd: >
+              set -o pipefail && /usr/bin/grep -oE
+              '{{ repository_regex }}'
+              /etc/yum.repos.d/redhat.repo
+              | sort
+              | tail -n1
+          changed_when: false
+          register: repository
+
+        - name: Set repository name
+          ansible.builtin.set_fact:
+            repository_name: "{{ repository.stdout_lines[0] }}"
+
+        - name: Extract repository version as major.minor
+          ansible.builtin.set_fact:
+            repository_version: >-
+              {{
+              repository_name
+              | regex_replace(repository_regex, '\2.\3')
+              }}
+
+        - name: Print repository version
+          ansible.builtin.debug:
+            msg: "orcharhino Proxy version available in the repository: {{ repository_version }}"
+
+        - name: Warn if repository is not newer than current orcharhino Proxy version
+          ansible.builtin.debug:
+            msg: >
+              WARNING: No upgrade seems necessary, currently installed version is {{ initial_proxy_version }}
+              (did you forget to sync and publish the orcharhino Proxy content?)
+          when: initial_proxy_version is version(repository_version, '>=')
+
+    - name: Perform orcharhino Proxy upgrade
+      block:
+
+        - name: Enable the orcharhino Proxy Repository
+          ansible.builtin.command:
+            cmd: "subscription-manager repos --enable {{ repository_name }}"
+          changed_when: true
+
+        - name: Update all packages on orcharhino Proxy
+          ansible.builtin.dnf:
+            name: "*"
+            state: latest
+          register: result
+
+        - name: Update package orcharhino-proxy
+          ansible.builtin.dnf:
+            name: "orcharhino-proxy"
+            state: latest
+          register: result
+
+        - name: Run orcharhino-installer
+          ansible.builtin.command: orcharhino-installer
+          changed_when: true
+          register: result
+
+        - name: Re-Gather RPM package facts after the upgrade
+          ansible.builtin.package_facts:
+            manager: auto
+
+        - name: Determine new version of orcharhino Proxy
+          ansible.builtin.set_fact:
+            final_proxy_version: "{{ ansible_facts.packages['orcharhino-proxy'][0]['version'] }}"
+
+        - name: Report when orcharhino Proxy version is unchanged
+          ansible.builtin.debug:
+            msg: >
+              Success! orcharhino Proxy upgrade completed.
+              orcharhino Proxy version ({{ final_proxy_version  }}) is unchanged
+          when: final_proxy_version == initial_proxy_version
+
+
+        - name: Report when orcharhino Proxy version changed
+          ansible.builtin.debug:
+            msg: >
+              Success! orcharhino Proxy upgrade completed.
+              New version of orcharhino Proxy is {{ final_proxy_version }}
+          when: final_proxy_version != initial_proxy_version
+
+      rescue:
+        - name: Hint to orcharhino Proxy log in case of failure
+          ansible.builtin.fail:
+            msg: >
+             Failed! orcharhino Proxy upgrade failed.
+             For more information,
+             see /var/log/foreman-installer/foreman-proxy-content.log
+             on your orcharhino Proxy."
+<% else -%>
+    - name: Fail if orcharhino_core is missing
+      ansible.builtin.fail:
+        msg: "Failed! The plug-in orcharhino_core is not present. This playbook is only for use with orcharhino."
+<%- end -%>

--- a/db/seeds.d/75_job_templates.rb
+++ b/db/seeds.d/75_job_templates.rb
@@ -5,12 +5,20 @@ locations = Location.unscoped.all
 
 template_files = Dir[File.join("#{ForemanAnsible::Engine.root}/app/views/foreman_ansible/job_templates/**/*.erb")]
 
-unsupported_templates =
-  if Foreman::Plugin.find('foreman_theme_satellite').present?
-    { 'Smart Proxy Upgrade Playbook': 'smart_proxy_upgrade_-_ansible_default.erb' }
-  else
-    { 'Capsule Upgrade Playbook': 'capsule_upgrade_-_ansible_default.erb' }
-  end
+unsupported_templates = {
+  'Smart Proxy Upgrade Playbook': 'smart_proxy_upgrade_-_ansible_default.erb',
+  'Capsule Upgrade Playbook': 'capsule_upgrade_-_ansible_default.erb',
+  'Upgrade orcharhino Proxy - Ansible Default': 'orcharhino_proxy_upgrade_-_ansible_default.erb',
+}
+
+if Foreman::Plugin.find('foreman_theme_satellite').present?
+  unsupported_templates.delete(:'Capsule Upgrade Playbook')
+elsif Foreman::Plugin.find('orcharhino_core').present?
+  unsupported_templates.delete(:'orcharhino Proxy Upgrade Playbook')
+else
+  unsupported_templates.delete(:'Smart Proxy Upgrade Playbook')
+end
+
 
 User.as_anonymous_admin do
   RemoteExecutionFeature.without_auditing do

--- a/lib/foreman_ansible/remote_execution.rb
+++ b/lib/foreman_ansible/remote_execution.rb
@@ -34,18 +34,27 @@ module ForemanAnsible
         :description => N_('Run an Ansible playbook to enable web console on given hosts'),
         :host_action_button => true
       )
-      RemoteExecutionFeature.register(
-        :ansible_run_capsule_upgrade,
-        N_('Upgrade Capsules on given hosts'),
-        :description => N_('Upgrade Capsules on given Capsule server hosts'),
-        :proxy_selector_override => ::RemoteExecutionProxySelector::INTERNAL_PROXY
-      )
-      RemoteExecutionFeature.register(
-        :ansible_run_capsule_update,
-        N_('Update Capsules on given hosts'),
-        :description => N_('Update Capsules on given Capsule server hosts'),
-        :proxy_selector_override => ::RemoteExecutionProxySelector::INTERNAL_PROXY
-      )
+      if Foreman::Plugin.find('foreman_theme_satellite').present?
+        RemoteExecutionFeature.register(
+          :ansible_run_capsule_upgrade,
+          N_('Upgrade Capsules on given hosts'),
+          :description => N_('Upgrade Capsules on given Capsule server hosts'),
+          :proxy_selector_override => ::RemoteExecutionProxySelector::INTERNAL_PROXY
+        )
+        RemoteExecutionFeature.register(
+          :ansible_run_capsule_update,
+          N_('Update Capsules on given hosts'),
+          :description => N_('Update Capsules on given Capsule server hosts'),
+          :proxy_selector_override => ::RemoteExecutionProxySelector::INTERNAL_PROXY
+        )
+      elsif Foreman::Plugin.find('orcharhino_core').present?
+        RemoteExecutionFeature.register(
+          :ansible_run_orcharhino_proxy_upgrade,
+          N_('Upgrade orcharhino Proxy on given hosts'),
+          :description => N_('Update orcharhino Proxy on given orcharhino Proxy server hosts'),
+          :proxy_selector_override => ::RemoteExecutionProxySelector::INTERNAL_PROXY
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
This adds a playbook/remote execution feature to upgrade an orcharhino Proxy. It also ensures that the distinction between Foreman, Satellite, and orcharhino is properly made everywhere where the proxy upgrade feature is used.

#### Overview of Changes
- add a playbook/job template/remote execution feature for updating orcharhino Proxies

#### Implementation Considerations
- Will not affect Smart Proxy or Capsule installations
- Unify behavior to work nicely for all 3 proxy brandings

#### Testing Steps
- Test setup: a orcharhino/Foreman/Satellite with foreman_ansible from this PR with a proxy (smart proxy/orcharhino Proxy/Capsule) that is on an outdated foreman version
- with the changes in this PR, the following will also work for orcharhino:
- If the foreman version of the proxy is outdated, the upgrade button appears in the proxy overview page (/smart_proxies) and on the proxy detail page as action(/smart_proxies/<smart-proxy-name>) on the webpage and triggers the upgrade playbook; the upgrade playbook can also be executed manually as remote execution

#### Checklists

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman/blob/develop/CONTRIBUTING.md) guidelines.
* [x] I have added relevant tests for my changes.
  * => current upgrade functionality has no tests, so I assume it is fine if I do not touch testing files (I would need help with how this should be tested)
* [x] I have updated the documentation accordingly.
  * => this will only affect orcharhino documentation

#### Additional Notes
- this is a second take on fixing [#35970](https://projects.theforeman.org/issues/35970) (first attempt was https://github.com/theforeman/foreman_ansible/pull/586, which was never finished and eventually closed) and takes it a bit further by ensuring the upgrade mechanism for smart proxy/Capsule is handled analogously for orcharhino Proxy everywhere in the UI.
