### PR TITLE
Fixes #39129 - Reload host's roles after role assignment

### DIFF
--- a/webpack/components/AnsibleHostDetail/components/RolesTab/EditRolesModal/EditRolesForm.js
+++ b/webpack/components/AnsibleHostDetail/components/RolesTab/EditRolesModal/EditRolesForm.js
@@ -34,6 +34,7 @@ const EditRolesForm = props => {
   const [callMutation, { loading }] = useMutation(assignAnsibleRoles, {
     onCompleted: onCompleted(closeModal),
     onError,
+    refetchQueries: ['HostAnsibleRoles'],
   });
 
   const allRoles = (availableRoles || []).concat(assignedRoles || []);

--- a/webpack/graphql/queries/hostAnsibleRoles.gql
+++ b/webpack/graphql/queries/hostAnsibleRoles.gql
@@ -1,6 +1,6 @@
 #import "./currentUserAttributes.gql"
 
-query($id: String!, $first: Int, $last: Int) {
+query HostAnsibleRoles($id: String!, $first: Int, $last: Int) {
   host(id: $id) {
     id
     ownAnsibleRoles(first: $first, last: $last) {


### PR DESCRIPTION
This was previously done implicitly by apollo (as of 3.3.7), it seems to be no longer happening with apollo 3.14.0.