### PR TITLE
Fixes #29583 - Hide taxonomy options from Ansible API docs

### DIFF
--- a/app/controllers/api/v2/ansible_roles_controller.rb
+++ b/app/controllers/api/v2/ansible_roles_controller.rb
@@ -6,6 +6,7 @@ module Api
     class AnsibleRolesController < ::Api::V2::BaseController
       include ::Api::Version2
       include ::ForemanAnsible::AnsibleRolesDataPreparations
+      hide_taxonomy_options
 
       resource_description do
         api_version 'v2'

--- a/app/controllers/api/v2/ansible_variables_controller.rb
+++ b/app/controllers/api/v2/ansible_variables_controller.rb
@@ -6,6 +6,7 @@ module Api
     class AnsibleVariablesController < ::Api::V2::BaseController
       include ::Api::Version2
       include Foreman::Controller::Parameters::AnsibleVariable
+      hide_taxonomy_options
 
       resource_description do
         api_version 'v2'


### PR DESCRIPTION
AnsibleRole and AnsibleVariable models do not support taxonomies,
but the API documentation inherited organization_id and location_id
parameters from BaseController. Passing these parameters resulted
in a 500 error (Association not found for organization).

Add `hide_taxonomy_options` to both `AnsibleRolesController` and
`AnsibleVariablesController` to remove these parameters from the
API documentation and silently drop them from requests.