### PR TITLE
Fixes #39260 - Move theforeman-rubocop dependency to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@
 source 'http://rubygems.org'
 
 gemspec
+
+gem 'theforeman-rubocop', '~> 0.1.2', require: false, groups: [:development, :rubocop]

--- a/foreman_ansible.gemspec
+++ b/foreman_ansible.gemspec
@@ -22,6 +22,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'deface', '< 2.0'
   s.add_dependency 'foreman_remote_execution', '>= 14.0', '< 17'
   s.add_dependency 'foreman-tasks', '>= 10.0', '< 13'
-
-  s.add_development_dependency 'theforeman-rubocop', '~> 0.1.0'
 end


### PR DESCRIPTION
#### Overview of Changes

Move theforeman-rubocop dependency to Gemfile instead of specifying it in gemspec.

#### Implementation Considerations

With newer bundler and the way we setup the Foreman with plugins, there are resolution failures due to duplicated dependencies. 

#### Testing Steps

Run `bundle install` with any other plugin that has the same dependency with a different version.

Before: fails to resolve (or there are warning on older bundler version)
After: passes without any issue, rubocop still works locally and in CI

#### Checklists

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman/blob/develop/CONTRIBUTING.md) guidelines.
* [ ] ~I have added relevant tests for my changes.~
* [ ] ~I have updated the documentation accordingly.~
