### PR TITLE
Drop foreman-tasks dependency upper bound

### DIFF
--- a/foreman_ansible.gemspec
+++ b/foreman_ansible.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'acts_as_list', '~> 1.2'
   s.add_dependency 'deface', '< 2.0'
   s.add_dependency 'foreman_remote_execution', '>= 14.0', '< 17'
-  s.add_dependency 'foreman-tasks', '>= 10.0', '< 13'
+  s.add_dependency 'foreman-tasks', '>= 10.0'
 end


### PR DESCRIPTION
The upper bound on foreman-tasks (currently `< 13`) causes repoclosure failures whenever foreman-tasks releases a new major version, requiring cascading unpins across plugins.

Since the Endeavour team controls both foreman_ansible and foreman-tasks, drop the upper bound entirely — other plugins (`foreman_remote_execution`, `katello`, `foreman_rh_cloud`) already use only a lower bound.

See: https://github.com/theforeman/foreman-packaging/pull/13661