### PR TITLE
Fixes #39427 - Drop warn: false from Module Action - Ansible Default template

### DIFF
--- a/app/views/foreman_ansible/job_templates/module_action_-_ansible_default.erb
+++ b/app/views/foreman_ansible/job_templates/module_action_-_ansible_default.erb
@@ -43,8 +43,6 @@ template_inputs:
     - shell: |
 <%=     indent(8) { command } %>
       register: out
-      args:
-        warn: false
     - debug: var=out
   <%- if input('post_script').present? -%>
   post_tasks:


### PR DESCRIPTION
## Problem

The "Module Action - Ansible Default" job template passes `warn: false` to Ansible's `shell` module. The `warn` parameter was deprecated in ansible-core 2.12 and **fully removed in ansible-core 2.14**, where its presence causes a fatal error:

> `"Unsupported parameters for (ansible.legacy.command) module: warn."`

This breaks all Ansible module actions for users on Ansible 2.14+.

## Fix

Remove the `args: warn: false` block from the template. The `warn: false` was originally used to suppress Ansible's suggestion to use the `dnf` module instead of invoking `dnf` via `shell`. Since the warning mechanism itself was removed in 2.14, the parameter can simply be dropped:

- **< 2.12**: `warn` was never a concern; the shell module worked fine without it.
- **2.12–2.13**: `warn` was deprecated but still accepted — omitting it means users may see the suggestion to use the `dnf` module directly, but it is harmless.
- **2.14+**: `warn` is fully removed; omitting it is the correct behavior.

## Related

Reported in https://community.theforeman.org/t/ansible-error-on-both-foreman-3-17-and-3-18/46806