### PR TITLE
Fixes #37537 - Allow inventory reader to view host parameters

### DIFF
--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -173,8 +173,8 @@ Foreman::Plugin.register :foreman_ansible do
         :edit_ansible_variables, :destroy_ansible_variables, :import_ansible_playbooks]
 
   role 'Ansible Tower Inventory Reader',
-       [:view_hosts, :view_hostgroups, :view_facts, :generate_report_templates, :generate_ansible_inventory,
-        :view_report_templates],
+       [:view_hosts, :view_hostgroups, :view_facts, :view_params, :generate_report_templates,
+        :generate_ansible_inventory, :view_report_templates],
        'Permissions required for the user which is used by Ansible Tower Dynamic Inventory Item'
 
   add_all_permissions_to_default_roles

--- a/test/functional/api/v2/ansible_inventories_controller_test.rb
+++ b/test/functional/api/v2/ansible_inventories_controller_test.rb
@@ -41,6 +41,18 @@ module Api
         assert_response :success
       end
 
+      test 'inventory reader can see host parameters' do
+        parameter = FactoryBot.create(:host_parameter, :host => @host1)
+        user = FactoryBot.create(:user)
+        user.roles << Role.find_by(:name => 'Ansible Tower Inventory Reader')
+
+        get :hosts, :params => { :host_ids => [@host1.id] }, :session => set_session_user(user)
+
+        assert_response :success
+        hostvars = JSON.parse(@response.body).dig('_meta', 'hostvars', @host1.name)
+        assert_equal parameter.value, hostvars[parameter.name]
+      end
+
       private
 
       def hosts_inventory_assertions(hosts)


### PR DESCRIPTION
## Summary

Fixes [#37537](https://projects.theforeman.org/issues/37537).

`InventoryCreator` obtains host variables through `host.host_params`. Foreman authorizes those parameters with `view_params`, but the locked `Ansible Tower Inventory Reader` role did not include that permission. As a result, the inventory endpoint succeeded while silently omitting host parameters.

Add `view_params` to the inventory reader role. Add a controller regression test that calls the hosts inventory endpoint as a user with only that role and verifies a host parameter is present in `hostvars`.

## Testing

- RuboCop passes for both changed Ruby files
- Ruby syntax checks pass

## AI usage disclosure

Per the [community discussion on AI policy](https://community.theforeman.org/t/could-foreman-benefit-from-an-ai-usage-policy/44638), the issue was investigated and the changes, tests, and PR wording were prepared with the assistance of Codex 5.6 Sol High. The resulting changes were reviewed before submitting. The commit also includes an `Assisted-By` trailer.