### PR TITLE
Fixes #38079 - Refresh inherited roles after host update

### DIFF
--- a/webpack/components/AnsibleHostDetail/components/RolesTab/__test__/RolesTab.fixtures.js
+++ b/webpack/components/AnsibleHostDetail/components/RolesTab/__test__/RolesTab.fixtures.js
@@ -171,6 +171,16 @@ export const mocks = ansibleRolesMockFactory(
   { currentUser: admin }
 );
 
+export const emptyRolesMocks = ansibleRolesMockFactory(
+  { id: hostGlobalId, first: 20, last: 20 },
+  {
+    __typename: 'Host',
+    id: hostGlobalId,
+    ownAnsibleRoles: { totalCount: 0, nodes: [] },
+  },
+  { currentUser: admin }
+);
+
 export const unauthorizedMocks = ansibleRolesMockFactory(
   { id: hostGlobalId, first: 20, last: 20 },
   { __typename: 'Host', id: hostGlobalId, ownAnsibleRoles: ansibleRolesMock },

--- a/webpack/components/AnsibleHostDetail/components/RolesTab/__test__/RolesTab.test.js
+++ b/webpack/components/AnsibleHostDetail/components/RolesTab/__test__/RolesTab.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
+import APIHelper from 'foremanReact/redux/API/API';
 import {
   tick,
   withMockedProvider,
@@ -13,6 +14,7 @@ import {
   mocks,
   hostId,
   allRolesMocks,
+  emptyRolesMocks,
   unauthorizedMocks,
   authorizedMocks,
 } from './RolesTab.fixtures';
@@ -20,9 +22,18 @@ import {
 import RolesTab from '../';
 
 jest.mock('axios');
+jest.mock('foremanReact/redux/API/API');
 const TestComponent = withRedux(withReactRouter(withMockedProvider(RolesTab)));
 
 describe('RolesTab', () => {
+  beforeEach(() => {
+    APIHelper.get.mockResolvedValue({ data: [] });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should load Ansible Roles as admin', async () => {
     render(<TestComponent hostId={hostId} mocks={mocks} canEditHost />);
     await waitFor(tick);
@@ -77,5 +88,35 @@ describe('RolesTab', () => {
         'You are not authorized to view the page. Request the following permissions from administrator: view_ansible_roles.'
       )
     ).toBeInTheDocument();
+  });
+
+  it('reloads inherited roles after the host is updated', async () => {
+    APIHelper.get
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({ data: [{ id: 1, name: 'inherited.role' }] });
+
+    const { rerender } = render(
+      <TestComponent
+        hostId={hostId}
+        hostUpdatedAt="2026-08-19T10:00:00Z"
+        mocks={emptyRolesMocks}
+        canEditHost
+      />
+    );
+
+    await waitFor(() => expect(APIHelper.get).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText('View inherited roles')).not.toBeInTheDocument();
+
+    rerender(
+      <TestComponent
+        hostId={hostId}
+        hostUpdatedAt="2026-08-19T10:01:00Z"
+        mocks={emptyRolesMocks}
+        canEditHost
+      />
+    );
+
+    await waitFor(() => expect(APIHelper.get).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('View inherited roles')).toBeInTheDocument();
   });
 });

--- a/webpack/components/AnsibleHostDetail/components/RolesTab/index.js
+++ b/webpack/components/AnsibleHostDetail/components/RolesTab/index.js
@@ -17,7 +17,7 @@ import {
 import EditRolesModal from './EditRolesModal';
 import AllRolesModal from './AllRolesModal';
 
-const RolesTab = ({ hostId, history, canEditHost }) => {
+const RolesTab = ({ hostId, hostUpdatedAt, history, canEditHost }) => {
   const hostGlobalId = encodeId('Host', hostId);
   const pagination = useCurrentPagination(history);
   const [assignModal, setAssignModal] = useState(false);
@@ -44,7 +44,7 @@ const RolesTab = ({ hostId, history, canEditHost }) => {
 
   const url = hostId && foremanUrl(`/api/v2/hosts/${hostId}/ansible_roles`);
   const { response: allAnsibleRoles } = useAPI('get', url, {
-    key: 'ANSIBLE_ROLES',
+    key: `ANSIBLE_ROLES_${hostId}_${hostUpdatedAt}`,
   });
   const emptyStateDescription = allAnsibleRoles.length > 0 && (
     <>
@@ -93,8 +93,13 @@ const RolesTab = ({ hostId, history, canEditHost }) => {
 
 RolesTab.propTypes = {
   hostId: PropTypes.number.isRequired,
+  hostUpdatedAt: PropTypes.string,
   history: PropTypes.object.isRequired,
   canEditHost: PropTypes.bool.isRequired,
+};
+
+RolesTab.defaultProps = {
+  hostUpdatedAt: '',
 };
 
 export default RolesTab;

--- a/webpack/components/AnsibleHostDetail/components/SecondaryTabRoutes.js
+++ b/webpack/components/AnsibleHostDetail/components/SecondaryTabRoutes.js
@@ -20,6 +20,7 @@ const SecondaryTabRoutes = ({ response, router, history }) => (
       <TabLayout>
         <RolesTab
           hostId={response.id}
+          hostUpdatedAt={response.updated_at}
           history={history}
           canEditHost={response.permissions.edit_hosts}
         />


### PR DESCRIPTION
## Summary

Fixes [#38079](https://projects.theforeman.org/issues/38079).

The host details response is refreshed after editing a host, but the REST request used to decide whether inherited Ansible roles exist kept a fixed cache key. Re-selecting or changing the host group therefore left the Roles tab with stale data until the page was reloaded or the tab was remounted.

Include the host ID and updated_at value in the request key. A saved host update now triggers a fresh roles request even when the final host group ID remains unchanged.

Add a regression test that updates the host timestamp and verifies that inherited roles are fetched and the link becomes visible.

## Testing

- Targeted ESLint passes for all four changed files
- Added a Jest regression test for the host update refresh; CI runs it in the supported plugin test environment

## AI usage disclosure

Per the [community discussion on AI policy](https://community.theforeman.org/t/could-foreman-benefit-from-an-ai-usage-policy/44638), the issue was investigated and the changes, tests, and PR wording were prepared with the assistance of Codex 5.6 Sol High. The resulting changes were reviewed before submitting. The commit also includes an Assisted-By trailer.