### PR TITLE
Fixes #37338 - Authorize Ansible variable overrides

### DIFF
--- a/app/graphql/mutations/ansible_variable_overrides/authorization.rb
+++ b/app/graphql/mutations/ansible_variable_overrides/authorization.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Mutations
+  module AnsibleVariableOverrides
+    module Authorization
+      private
+
+      def authorize!(resource, action)
+        return super unless resource.is_a?(LookupValue)
+
+        variable = resource.lookup_key
+        unless variable.is_a?(AnsibleVariable)
+          raise GraphQL::ExecutionError.new(
+            _('Ansible variable overrides can only be changed for Ansible variables.')
+          )
+        end
+
+        super(variable, :edit)
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/ansible_variable_overrides/create.rb
+++ b/app/graphql/mutations/ansible_variable_overrides/create.rb
@@ -1,6 +1,8 @@
 module Mutations
   module AnsibleVariableOverrides
     class Create < ::Mutations::CreateMutation
+      include Authorization
+
       graphql_name 'CreateAnsibleVariableOverrideMutation'
       description 'Creates Ansible Variable Override'
 

--- a/app/graphql/mutations/ansible_variable_overrides/delete.rb
+++ b/app/graphql/mutations/ansible_variable_overrides/delete.rb
@@ -1,6 +1,8 @@
 module Mutations
   module AnsibleVariableOverrides
     class Delete < ::Mutations::DeleteMutation
+      include Authorization
+
       graphql_name 'DeleteAnsibleVariableOverride'
       description 'Deletes Ansible Variable Override'
 

--- a/app/graphql/mutations/ansible_variable_overrides/update.rb
+++ b/app/graphql/mutations/ansible_variable_overrides/update.rb
@@ -1,6 +1,8 @@
 module Mutations
   module AnsibleVariableOverrides
     class Update < ::Mutations::UpdateMutation
+      include Authorization
+
       graphql_name 'UpdateAnsibleVariableOverrideMutation'
       description 'Updates Ansible Variable Override'
 

--- a/test/graphql/mutations/ansible_variable_overrides/authorization_test.rb
+++ b/test/graphql/mutations/ansible_variable_overrides/authorization_test.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'test_plugin_helper'
+
+module Mutations
+  module AnsibleVariableOverrides
+    class AuthorizationTest < GraphQLQueryTestCase
+      let(:host) { as_admin { FactoryBot.create(:host, :ansible_roles => [variable.ansible_role]) } }
+      let(:variable) { as_admin { FactoryBot.create(:ansible_variable, :override => true) } }
+      let(:lookup_value) do
+        as_admin do
+          FactoryBot.create(
+            :lookup_value,
+            :lookup_key => variable,
+            :match => "fqdn=#{host.name}",
+            :value => 'old value'
+          )
+        end
+      end
+      let(:context_user) { user_with_permissions(:edit_ansible_variables, :view_hosts) }
+
+      def user_with_permissions(*permissions)
+        as_admin do
+          role = FactoryBot.create(:role)
+          role.add_permissions!(permissions)
+          user = FactoryBot.create(:user)
+          user.roles << role
+          user
+        end
+      end
+
+      context 'when creating an override' do
+        let(:query) do
+          <<-GRAPHQL
+            mutation CreateOverride($hostId: Int!, $lookupKeyId: Int!, $match: String!, $value: RawJson!) {
+              createAnsibleVariableOverride(input: {
+                hostId: $hostId,
+                lookupKeyId: $lookupKeyId,
+                match: $match,
+                value: $value
+              }) {
+                errors { path message }
+              }
+            }
+          GRAPHQL
+        end
+        let(:variables) do
+          {
+            :hostId => host.id,
+            :lookupKeyId => variable.id,
+            :match => "fqdn=#{host.name}",
+            :value => 'new value'
+          }
+        end
+
+        test 'requires only edit ansible variables permission' do
+          assert_empty result['errors']
+          assert_empty result['data']['createAnsibleVariableOverride']['errors']
+          assert_equal 'new value', variable.reload.lookup_values.find_by(:match => "fqdn=#{host.name}").value
+        end
+      end
+
+      context 'when updating an override' do
+        let(:query) do
+          <<-GRAPHQL
+            mutation UpdateOverride($id: ID!, $hostId: Int!, $ansibleVariableId: Int!, $value: RawJson!) {
+              updateAnsibleVariableOverride(input: {
+                id: $id,
+                hostId: $hostId,
+                ansibleVariableId: $ansibleVariableId,
+                value: $value
+              }) {
+                errors { path message }
+              }
+            }
+          GRAPHQL
+        end
+        let(:variables) do
+          {
+            :id => Foreman::GlobalId.for(lookup_value),
+            :hostId => host.id,
+            :ansibleVariableId => variable.id,
+            :value => 'new value'
+          }
+        end
+
+        test 'requires only edit ansible variables permission' do
+          assert_empty result['errors']
+          assert_empty result['data']['updateAnsibleVariableOverride']['errors']
+          assert_equal 'new value', lookup_value.reload.value
+        end
+
+        test 'rejects lookup values belonging to another lookup key type' do
+          other_value = as_admin { FactoryBot.create(:lookup_value, :match => "fqdn=#{host.name}") }
+          variables[:id] = Foreman::GlobalId.for(other_value)
+
+          assert_includes result['errors'].map { |error| error['message'] },
+            'Ansible variable overrides can only be changed for Ansible variables.'
+        end
+      end
+
+      context 'when deleting an override' do
+        let(:query) do
+          <<-GRAPHQL
+            mutation DeleteOverride($id: ID!, $hostId: Int!, $variableId: Int!) {
+              deleteAnsibleVariableOverride(input: {
+                id: $id,
+                hostId: $hostId,
+                variableId: $variableId
+              }) {
+                errors { path message }
+              }
+            }
+          GRAPHQL
+        end
+        let(:variables) do
+          {
+            :id => Foreman::GlobalId.for(lookup_value),
+            :hostId => host.id,
+            :variableId => variable.id
+          }
+        end
+
+        test 'requires only edit ansible variables permission' do
+          assert_empty result['errors']
+          assert_empty result['data']['deleteAnsibleVariableOverride']['errors']
+          refute LookupValue.exists?(lookup_value.id)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes [#37338](https://projects.theforeman.org/issues/37338).

The host details UI checks `edit_ansible_variables`, but its GraphQL mutations inherited authorization from `LookupValue`. Creating, updating, or deleting an override therefore also required the unrelated generic lookup value permissions.

Authorize these mutations through the associated `AnsibleVariable`, matching the existing REST API and UI permission model. The authorization helper verifies that the lookup value actually belongs to an Ansible variable before applying the plugin permission, so the mutations cannot be used to modify other lookup key types.

Add GraphQL regression coverage for create, update, and delete with only `edit_ansible_variables`, plus a negative test for a non-Ansible lookup value.

## Testing

- Ruby syntax checks pass for the new authorization helper and test
- Added GraphQL mutation tests; CI runs them in the supported Foreman test environment

## AI usage disclosure

Per the [community discussion on AI policy](https://community.theforeman.org/t/could-foreman-benefit-from-an-ai-usage-policy/44638), the issue was investigated and the changes, tests, and PR wording were prepared with the assistance of Codex 5.6 Sol High. The resulting changes were reviewed before submitting. The commit also includes an `Assisted-By` trailer.
