### PR TITLE
Fixes #36596 - Update existing array variable overrides

### DIFF
--- a/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/AnsibleVariableOverridesTable.js
+++ b/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/AnsibleVariableOverridesTable.js
@@ -131,7 +131,7 @@ const AnsibleVariableOverridesTable = ({
 
   const actionsResolver = (variable, idx) => {
     const actions = [];
-    if (variable.currentValue?.element === 'fqdn' && variable.meta.canEdit) {
+    if (findOverride(variable, hostAttrs.name) && variable.meta.canEdit) {
       actions.push(deleteAction(variable, idx));
     }
     return actions;

--- a/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/AnsibleVariableOverridesTableHelper.js
+++ b/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/AnsibleVariableOverridesTableHelper.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { isEqual } from 'lodash';
 import { TimesIcon, CheckIcon } from '@patternfly/react-icons';
 import { sprintf, translate as __ } from 'foremanReact/common/I18n';
 
@@ -58,11 +57,7 @@ export const onCompleted = onSubmitSuccess => response => {
 };
 
 export const findOverride = (variable, hostname) =>
-  variable.lookupValues.nodes.find(
-    item =>
-      isEqual(item.value, variable.currentValue.value) &&
-      item.match === `fqdn=${hostname}`
-  );
+  variable.lookupValues.nodes.find(item => item.match === `fqdn=${hostname}`);
 
 const formatError = error =>
   sprintf(

--- a/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/EditableAction.js
+++ b/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/EditableAction.js
@@ -17,6 +17,7 @@ import {
   hasError,
   createMatcher,
 } from './EditableActionHelper';
+import { findOverride } from './AnsibleVariableOverridesTableHelper';
 
 const EditableAction = ({
   onValidationError,
@@ -56,18 +57,16 @@ const EditableAction = ({
     }
   );
 
-  const onSubmit = event => {
-    if (!variable.currentValue || variable.currentValue.element !== 'fqdn') {
-      return createOverride();
+  const onSubmit = () => {
+    const match = createMatcher(hostName);
+    const lookupValue = findOverride(variable, hostName);
+    if (lookupValue) {
+      return updateOverride(lookupValue, match);
     }
-    return updateOverride();
+    return createOverride(match);
   };
 
-  const updateOverride = () => {
-    const match = createMatcher(variable.currentValue.elementName);
-    const lookupValue = variable.lookupValues.nodes.find(
-      item => item.match === match
-    );
+  const updateOverride = (lookupValue, match) => {
     toggleWorking(true);
     callUpdateMutation({
       variables: {
@@ -80,8 +79,7 @@ const EditableAction = ({
     });
   };
 
-  const createOverride = () => {
-    const match = createMatcher(hostName);
+  const createOverride = match => {
     toggleWorking(true);
     callCreateMutation({
       variables: {

--- a/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/__test__/AnsibleVariableOverrides.fixtures.js
+++ b/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/__test__/AnsibleVariableOverrides.fixtures.js
@@ -20,6 +20,9 @@ const variableId = 66;
 
 const barVariableGlobalId = 'MDE6QW5zaWJsZVZhcmlhYmxlLTU3Mw==';
 const barVariableId = 573;
+const mergedArrayVariableGlobalId = 'MDE6QW5zaWJsZVZhcmlhYmxlLTY4MA==';
+const mergedArrayVariableId = 680;
+const mergedArrayLookupValueId = 'MDE6TG9va3VwVmFsdWUtOTc=';
 
 const withFqdnOverride = canEdit => ({
   __typename: 'OverridenAnsibleVariable',
@@ -124,7 +127,7 @@ export const mocks = [
         host: {
           id: hostGlobalId,
           ansibleVariablesWithOverrides: {
-            totalCount: 8,
+            totalCount: 9,
             nodes: [
               withFqdnOverride(true),
               {
@@ -143,15 +146,7 @@ export const mocks = [
                 validatorRule: 'a,b,c',
                 required: true,
                 lookupValues: {
-                  nodes: [
-                    {
-                      __typename: 'LookupValue',
-                      id: 'MDE6TG9va3VwVmFsdWUtODE=',
-                      match,
-                      value: 'b',
-                      omit: false,
-                    },
-                  ],
+                  nodes: [],
                 },
                 currentValue: null,
               },
@@ -287,6 +282,39 @@ export const mocks = [
                 },
                 currentValue: null,
               },
+              {
+                __typename: 'OverridenAnsibleVariable',
+                meta: {
+                  __typename: 'Meta',
+                  canEdit: true,
+                },
+                id: mergedArrayVariableGlobalId,
+                key: 'stars',
+                path: '/ansible/ansible_variables/18/edit',
+                defaultValue: [],
+                parameterType: 'array',
+                ansibleRoleName: 'test.role',
+                validatorType: '',
+                validatorRule: null,
+                required: false,
+                lookupValues: {
+                  nodes: [
+                    {
+                      __typename: 'LookupValue',
+                      id: mergedArrayLookupValueId,
+                      match,
+                      value: ['host value'],
+                      omit: false,
+                    },
+                  ],
+                },
+                currentValue: {
+                  __typename: 'AnsibleVariableOverride',
+                  value: ['hostgroup value', 'host value'],
+                  element: 'hostgroup',
+                  elementName: 'parent hostgroup',
+                },
+              },
             ],
           },
         },
@@ -323,15 +351,24 @@ export const deleteMocks = [
   },
 ];
 
-const updateMockFactory = (variableValue, returnValue, errors = []) => {
+const updateMockFactory = (
+  variableValue,
+  returnValue,
+  errors = [],
+  {
+    lookupValueId = overrideUpdateDeleteId,
+    variableGlobalId = ansibleVariableId,
+    variableId: updatedVariableId = variableId,
+  } = {}
+) => {
   const mockArray = [
     {
       request: {
         query: updateAnsibleVariableOverride,
         variables: {
-          id: overrideUpdateDeleteId,
+          id: lookupValueId,
           hostId,
-          ansibleVariableId: variableId,
+          ansibleVariableId: updatedVariableId,
           value: variableValue,
           match: `fqdn=${hostAttrs.name}`,
         },
@@ -342,7 +379,7 @@ const updateMockFactory = (variableValue, returnValue, errors = []) => {
             __typename: 'UpdateAnsibleVariableOverrideMutationPayload',
             overridenAnsibleVariable: {
               __typename: 'OverridenAnsibleVariable',
-              id: ansibleVariableId,
+              id: variableGlobalId,
               lookupValues: {
                 __typename: 'LookupValueConnection',
                 nodes: [
@@ -421,6 +458,16 @@ const createMockFactory = (variableValue, returnValue, errors = []) => {
 };
 
 export const updateMocks = updateMockFactory('2177', 2177);
+export const mergedArrayUpdateMocks = updateMockFactory(
+  '["updated"]',
+  ['updated'],
+  [],
+  {
+    lookupValueId: mergedArrayLookupValueId,
+    variableGlobalId: mergedArrayVariableGlobalId,
+    variableId: mergedArrayVariableId,
+  }
+);
 export const createMocks = createMockFactory('b', 'b');
 export const updateErrorMocks = updateMockFactory('2177', 21, [
   {

--- a/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/__test__/AnsibleVariableOverridesUpdate.test.js
+++ b/webpack/components/AnsibleHostDetail/components/AnsibleVariableOverrides/__test__/AnsibleVariableOverridesUpdate.test.js
@@ -1,5 +1,11 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 
@@ -12,6 +18,7 @@ import {
 import {
   mocks,
   updateMocks,
+  mergedArrayUpdateMocks,
   createMocks,
   updateErrorMocks,
   updateValidationMocks,
@@ -180,6 +187,41 @@ describe('AnsibleVariableOverrides', () => {
       })[1]
     );
     await waitFor(tick);
+    expect(showToast).toHaveBeenCalledWith({
+      type: 'success',
+      message: 'Ansible variable override successfully changed.',
+    });
+  });
+  it('should update an existing merged array override', async () => {
+    const showToast = jest.fn();
+    jest.spyOn(toasts, 'showToast').mockImplementation(showToast);
+
+    render(
+      <TestComponent
+        mocks={mocks.concat(mergedArrayUpdateMocks)}
+        hostId={hostId}
+        hostAttrs={hostAttrs}
+        history={historyMock}
+      />
+    );
+    await waitFor(tick);
+
+    const row = screen.getByText('stars').closest('tr');
+    userEvent.click(
+      within(row).getByRole('button', { name: 'Edit override button' })
+    );
+    const input = within(row).getByRole('textbox', {
+      name: 'Edit override field',
+    });
+    userEvent.clear(input);
+    fireEvent.change(input, { target: { value: '["updated"]' } });
+    userEvent.click(
+      within(row).getByRole('button', {
+        name: 'Submit editing override button',
+      })
+    );
+    await waitFor(tick);
+
     expect(showToast).toHaveBeenCalledWith({
       type: 'success',
       message: 'Ansible variable override successfully changed.',


### PR DESCRIPTION
## Summary

Fixes [#36596](https://projects.theforeman.org/issues/36596).

The host details editor decided whether to create or update an override from the effective value's source. For merged array variables, that source can remain a host group even when a host-specific lookup value already exists. Editing the variable again then attempted to create the same matcher and failed with `has already been taken`.

Choose the operation from the actual lookup value for the host matcher. Reuse the same lookup-by-matcher rule for deleting overrides, without comparing a stored array to its merged effective value.

Add a regression fixture and test for editing an existing host override whose effective array also contains inherited values.

## Testing

- Targeted ESLint passes
- Ansible variable override update and delete suites: 8 tests passed

## AI usage disclosure

Per the [community discussion on AI policy](https://community.theforeman.org/t/could-foreman-benefit-from-an-ai-usage-policy/44638), the issue was investigated and the changes, tests, and PR wording were prepared with the assistance of Codex 5.6 Sol High. The resulting changes were reviewed before submitting. The commit also includes an `Assisted-By` trailer.
