### PR TITLE
Fixes #36193 - Restrict Ansible inventory visibility

### DIFF
--- a/lib/foreman_ansible/register.rb
+++ b/lib/foreman_ansible/register.rb
@@ -143,8 +143,10 @@ Foreman::Plugin.register :foreman_ansible do
                },
                :resource_type => 'AnsibleVariable'
     permission :view_hosts,
-               { :'api/v2/hosts' => [:ansible_roles],
-                 :'api/v2/ansible_inventories' => [:hosts] },
+               { :'api/v2/hosts' => [:ansible_roles] },
+               :resource_type => 'Host'
+    permission :view_ansible_inventory,
+               { :'api/v2/ansible_inventories' => [:hosts] },
                :resource_type => 'Host'
     permission :view_hostgroups,
                { :'api/v2/hostgroups' => [:ansible_roles],

--- a/test/functional/api/v2/ansible_inventories_controller_test.rb
+++ b/test/functional/api/v2/ansible_inventories_controller_test.rb
@@ -22,6 +22,22 @@ module Api
         hosts_inventory_assertions(hosts)
       end
 
+      test 'user with inventory permission should show inventory for hosts' do
+        user = user_with_permissions(:view_ansible_inventory)
+
+        get :hosts, :params => { :host_ids => [@host1.id] }, :session => set_session_user(user)
+
+        assert_response :success
+      end
+
+      test 'user with only view hosts permission should not show inventory for hosts' do
+        user = user_with_permissions(:view_hosts)
+
+        get :hosts, :params => { :host_ids => [@host1.id] }, :session => set_session_user(user)
+
+        assert_response :forbidden
+      end
+
       test 'should show inventory for hostgroup by GET' do
         get :hostgroups, :params => { :hostgroup_ids => [@hostgroup.id] }, :session => set_session_user
         hosts_inventory_assertions(@hostgroup.hosts)
@@ -42,6 +58,14 @@ module Api
       end
 
       private
+
+      def user_with_permissions(*permissions)
+        role = FactoryBot.create(:role)
+        role.add_permissions!(permissions)
+        user = FactoryBot.create(:user)
+        user.roles << role
+        user
+      end
 
       def hosts_inventory_assertions(hosts)
         response = JSON.parse(@response.body)

--- a/webpack/components/AnsibleHostDetail/AnsibleHostDetail.js
+++ b/webpack/components/AnsibleHostDetail/AnsibleHostDetail.js
@@ -16,6 +16,11 @@ const AnsibleHostDetail = ({
   history,
 }) => {
   const hashHistory = useHistory();
+  const canViewInventory = response?.permissions?.['view_ansible_inventory'];
+  const tabs = canViewInventory
+    ? SECONDARY_TABS
+    : SECONDARY_TABS.filter(({ key }) => key !== 'inventory');
+
   return (
     <SkeletonLoader status={status} skeletonProps={{ count: 5 }}>
       {response?.id && (
@@ -27,7 +32,7 @@ const AnsibleHostDetail = ({
             activeKey={pathname?.split('/')[2]}
             isSecondary
           >
-            {SECONDARY_TABS.map(({ key, title }) => (
+            {tabs.map(({ key, title }) => (
               <Tab
                 ouiaId={`ansible-host-details-tabs-${title}`}
                 key={key}

--- a/webpack/components/AnsibleHostDetail/AnsibleHostDetail.test.js
+++ b/webpack/components/AnsibleHostDetail/AnsibleHostDetail.test.js
@@ -1,7 +1,9 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import AnsibleHostDetail from './';
+
+jest.mock('./components/SecondaryTabRoutes', () => () => null);
 
 describe('AnsibleHostDetail', () => {
   it('should show skeleton when loading', () => {
@@ -16,5 +18,31 @@ describe('AnsibleHostDetail', () => {
     expect(
       container.getElementsByClassName('react-loading-skeleton')
     ).toHaveLength(5);
+  });
+
+  it('should hide inventory without permission', () => {
+    render(
+      <AnsibleHostDetail
+        status="RESOLVED"
+        response={{ id: 5, permissions: { view_ansible_inventory: false } }}
+        router={{}}
+        history={{}}
+      />
+    );
+
+    expect(screen.queryByText('Inventory')).not.toBeInTheDocument();
+  });
+
+  it('should show inventory with permission', () => {
+    render(
+      <AnsibleHostDetail
+        status="RESOLVED"
+        response={{ id: 5, permissions: { view_ansible_inventory: true } }}
+        router={{}}
+        history={{}}
+      />
+    );
+
+    expect(screen.getByText('Inventory')).toBeInTheDocument();
   });
 });

--- a/webpack/components/AnsibleHostDetail/components/SecondaryTabRoutes.js
+++ b/webpack/components/AnsibleHostDetail/components/SecondaryTabRoutes.js
@@ -35,9 +35,13 @@ const SecondaryTabRoutes = ({ response, router, history }) => (
       </TabLayout>
     </Route>
     <Route path={route('inventory')}>
-      <TabLayout>
-        <WrappedAnsibleHostInventory hostId={response.id} />
-      </TabLayout>
+      {response.permissions.view_ansible_inventory ? (
+        <TabLayout>
+          <WrappedAnsibleHostInventory hostId={response.id} />
+        </TabLayout>
+      ) : (
+        <Redirect to={route('roles')} />
+      )}
     </Route>
     <Route path={route('jobs')}>
       <TabLayout>


### PR DESCRIPTION
## Summary

Fixes [#36193](https://projects.theforeman.org/issues/36193).

The Ansible Inventory sub-tab exposed the rendered host inventory to every user with `view_hosts`. That inventory can contain host parameters and connection data, so administrators had no way to grant access to host details without also granting access to the inventory.

Add a dedicated `view_ansible_inventory` host permission and require it for the host inventory API endpoint. Hide the Inventory sub-tab when the permission is missing and redirect direct navigation back to the Roles sub-tab. Existing default roles receive the new view permission through the plugin's standard permission seeding, while custom roles can leave it out.

Add controller tests for the new permission boundary and frontend tests for the tab visibility.

## Testing

- Targeted ESLint passes
- `AnsibleHostDetail.test.js`: 3 tests passed
- Added API authorization tests; CI runs them in the supported Foreman test environment

## AI usage disclosure

Per the [community discussion on AI policy](https://community.theforeman.org/t/could-foreman-benefit-from-an-ai-usage-policy/44638), the issue was investigated and the changes, tests, and PR wording were prepared with the assistance of Codex 5.6 Sol High. The resulting changes were reviewed before submitting. The commit also includes an `Assisted-By` trailer.
