### PR TITLE
Fixes #39669 - Use SeedHelper.format_errors in seeds

### DIFF
--- a/db/seeds.d/62_ansible_proxy_feature.rb
+++ b/db/seeds.d/62_ansible_proxy_feature.rb
@@ -2,5 +2,5 @@
 
 proxy_feature = Feature.where(:name => 'Ansible').first_or_create
 if proxy_feature.nil? || proxy_feature.errors.any?
-  raise "Unable to create proxy feature: #{format_errors proxy_feature}"
+  raise "Unable to create proxy feature: #{SeedHelper.format_errors(proxy_feature)}"
 end


### PR DESCRIPTION
Refs #39669

The top-level `format_errors` seed helper in Foreman core is deprecated (since 3.4) and is being removed as part of Foreman #39667 (theforeman/foreman#11193). This switches the plugin seed scripts to call `SeedHelper.format_errors` directly.

`SeedHelper.format_errors` has been available since the helper was deprecated, so this change is backward compatible with all supported Foreman versions and can be merged independently of the core removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)